### PR TITLE
Migrate the GRDB dependency to HTTPS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These people are listed as being the code owners for this project. As such, they will be automatically added as a reviewer when a PR is created.
+# For more details on how this is configured, see https://help.github.com/articles/about-code-owners/
+
+* @brindy @bwaresiak @mallexxx @THISISDINOSAUR @tomasstrba @samsymons

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
+-->
+
+Task/Issue URL:
+Tech Design URL:
+CC:
+
+**Description**:
+
+
+**Steps to test this PR**:
+1.
+1.
+
+<!--
+Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.
+
+Using a simulator where a physical device is unavailable is acceptable.
+-->
+
+**OS Testing**:
+
+* [ ] iOS 13
+* [ ] iOS 14
+
+---
+###### Internal references:
+[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
+[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,9 @@ Using a simulator where a physical device is unavailable is acceptable.
 * [ ] iOS 13
 * [ ] iOS 14
 
+* [ ] macOS 10.15
+* [ ] macOS 11
+
 ---
 ###### Internal references:
 [Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "GRDB",
-        "repositoryURL": "git@github.com:duckduckgo/GRDB.swift.git",
+        "repositoryURL": "https://github.com/duckduckgo/GRDB.swift.git",
         "state": {
           "branch": "SQLCipher",
           "revision": "e5714d4b6ee1651d2271b04ae85aaf5a327fe70a",

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "SecureVault", targets: ["SecureVault"]),
     ],
     dependencies: [
-        .package(name: "GRDB", url: "git@github.com:duckduckgo/GRDB.swift.git", .branch("SQLCipher")),
+        .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .branch("SQLCipher")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
cc @brindy 

This PR includes three changes:

1. The GRDB dependency has moved to HTTPS, to circumvent Bitrise SSH authentication issues
2. A `CODEOWNERS` file has been added
3. A pull request template has been added

**Steps to test this PR:**

1. Check out the branch locally and make sure that `swift build` clones GRDB successfully and is able to build