### PR TITLE
Pass urlFactory to SuggestionsLoading

### DIFF
--- a/Sources/BrowserServicesKit/Suggestions/Suggestion.swift
+++ b/Sources/BrowserServicesKit/Suggestions/Suggestion.swift
@@ -35,9 +35,9 @@ extension Suggestion {
 
     static let phraseKey = "phrase"
 
-    init(key: String, value: String, urlFactory: (String) -> URL?) {
+    init(key: String, value: String, urlFactory: ((String) -> URL?)? = nil) {
         if key == Self.phraseKey {
-            if let url = urlFactory(value) {
+            if let url = urlFactory?(value) {
                 self = .website(url: url)
             } else {
                 self = .phrase(phrase: value)

--- a/Sources/BrowserServicesKit/Suggestions/Suggestion.swift
+++ b/Sources/BrowserServicesKit/Suggestions/Suggestion.swift
@@ -35,8 +35,16 @@ extension Suggestion {
 
     static let phraseKey = "phrase"
 
-    init(key: String, value: String) {
-        self = key == Self.phraseKey ? .phrase(phrase: value) : .unknown(value: value)
+    init(key: String, value: String, urlFactory: (String) -> URL?) {
+        if key == Self.phraseKey {
+            if let url = urlFactory(value) {
+                self = .website(url: url)
+            } else {
+                self = .phrase(phrase: value)
+            }
+        } else {
+            self = .unknown(value: value)
+        }
     }
 
 }

--- a/Sources/BrowserServicesKit/Suggestions/SuggestionLoading.swift
+++ b/Sources/BrowserServicesKit/Suggestions/SuggestionLoading.swift
@@ -20,9 +20,20 @@ import Foundation
 
 public protocol SuggestionLoading: AnyObject {
 
-    func getSuggestions(query: Query, maximum: Int, completion: @escaping ([Suggestion]?, Error?) -> Void)
+    func getSuggestions(query: Query,
+                        maximum: Int,
+                        urlFactory: @escaping (String) -> URL?,
+                        completion: @escaping ([Suggestion]?, Error?) -> Void)
 
     var dataSource: SuggestionLoadingDataSource? { get set }
+
+}
+
+extension SuggestionLoading {
+
+    func getSuggestions(query: Query, maximum: Int, completion: @escaping ([Suggestion]?, Error?) -> Void) {
+        getSuggestions(query: query, maximum: maximum, urlFactory: { _ in nil }, completion: completion)
+    }
 
 }
 
@@ -45,6 +56,7 @@ public class SuggestionLoader: SuggestionLoading {
 
     public func getSuggestions(query: Query,
                                maximum: Int,
+                               urlFactory: @escaping (String) -> URL?,
                                completion: @escaping ([Suggestion]?, Error?) -> Void) {
         guard let dataSource = dataSource else {
             completion(nil, SuggestionLoaderError.noDataSource)
@@ -81,7 +93,7 @@ public class SuggestionLoader: SuggestionLoading {
             }
 
             do {
-                remoteSuggestions = try Self.remoteSuggestions(from: data)
+                remoteSuggestions = try Self.remoteSuggestions(from: data, urlFactory: urlFactory)
             } catch {
                 remoteSuggestionsError = error
             }
@@ -92,11 +104,13 @@ public class SuggestionLoader: SuggestionLoading {
                                      bookmarkSuggestions: bookmarkSuggestions,
                                      remoteSuggestions: remoteSuggestions ?? [])
 
-            guard !result.isEmpty || remoteSuggestionsError == nil else {
-                completion(nil, SuggestionLoaderError.failedToObtainData)
-                return
+            DispatchQueue.main.async {
+                guard !result.isEmpty || remoteSuggestionsError == nil else {
+                    completion(nil, SuggestionLoaderError.failedToObtainData)
+                    return
+                }
+                completion(result, nil)
             }
-            completion(result, nil)
         }
     }
 
@@ -127,13 +141,13 @@ public class SuggestionLoader: SuggestionLoading {
 
     // MARK: - Remote Suggestions
 
-    private static func remoteSuggestions(from data: Data) throws -> [Suggestion] {
+    private static func remoteSuggestions(from data: Data, urlFactory: (String) -> URL?) throws -> [Suggestion] {
         let decoder = JSONDecoder()
         let apiResult = try decoder.decode(APIResult.self, from: data)
 
         return apiResult.items
             .joined()
-            .map { Suggestion(key: $0.key, value: $0.value) }
+            .map { Suggestion(key: $0.key, value: $0.value, urlFactory: urlFactory) }
     }
 
     // MARK: - Merging

--- a/Sources/BrowserServicesKit/Suggestions/SuggestionLoading.swift
+++ b/Sources/BrowserServicesKit/Suggestions/SuggestionLoading.swift
@@ -77,15 +77,15 @@ public class SuggestionLoader: SuggestionLoading {
         group.enter()
         dataSource.suggestionLoading(self,
                                      suggestionDataFromUrl: Self.remoteSuggestionsUrl,
-                                     withParameters: [Self.searchParameter: query]) { [urlFactory] data, error in
+                                     withParameters: [Self.searchParameter: query]) { [weak self] data, error in
             defer { group.leave() }
-            guard let data = data else {
+            guard let self = self, let data = data else {
                 remoteSuggestionsError = error
                 return
             }
 
             do {
-                remoteSuggestions = try Self.remoteSuggestions(from: data, urlFactory: urlFactory)
+                remoteSuggestions = try self.remoteSuggestions(from: data)
             } catch {
                 remoteSuggestionsError = error
             }
@@ -133,7 +133,7 @@ public class SuggestionLoader: SuggestionLoading {
 
     // MARK: - Remote Suggestions
 
-    private static func remoteSuggestions(from data: Data, urlFactory: ((String) -> URL?)?) throws -> [Suggestion] {
+    private func remoteSuggestions(from data: Data) throws -> [Suggestion] {
         let decoder = JSONDecoder()
         let apiResult = try decoder.decode(APIResult.self, from: data)
 

--- a/Sources/BrowserServicesKit/Suggestions/SuggestionLoading.swift
+++ b/Sources/BrowserServicesKit/Suggestions/SuggestionLoading.swift
@@ -42,7 +42,7 @@ public class SuggestionLoader: SuggestionLoading {
     public weak var dataSource: SuggestionLoadingDataSource?
     private var urlFactory: ((String) -> URL?)?
 
-    public init(dataSource: SuggestionLoadingDataSource? = nil, urlFactory: ((String) -> URL?)? = nil) {
+    public init(dataSource: SuggestionLoadingDataSource? = nil, urlFactory: ((String) -> URL?)?) {
         self.dataSource = dataSource
         self.urlFactory = urlFactory
     }

--- a/Tests/BrowserServicesKitTests/Suggestions/SuggestionLoadingTests.swift
+++ b/Tests/BrowserServicesKitTests/Suggestions/SuggestionLoadingTests.swift
@@ -62,7 +62,7 @@ final class SuggestionLoadingTests: XCTestCase {
     struct E: Error {}
 
     func testWhenNoDataSource_ThenErrorMustBeReturned() {
-        let loader = SuggestionLoader()
+        let loader = SuggestionLoader(urlFactory: nil)
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (suggestions, error) in
             XCTAssertNil(suggestions)
@@ -74,7 +74,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenQueryIsEmpty_ThenSuggestionsAreEmpty() {
         let dataSource = SuggestionLoadingDataSourceMock()
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "", maximum: 10) { (suggestions, error) in
@@ -87,7 +87,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenQueryHasOneLetter_ThenSuggestionsLoadedWithoutBookmarks() {
         let dataSource = SuggestionLoadingDataSourceMock(data: Data.anAPIResultData, bookmarks: BookmarkMock.someBookmarks)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "a", maximum: 10) { (suggestions, error) in
@@ -100,7 +100,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenGetSuggestionsIsCalled_ThenDataSourceAsksForBookmarksAndDataOnce() {
         let dataSource = SuggestionLoadingDataSourceMock(data: Data.anAPIResultData, bookmarks: BookmarkMock.someBookmarks)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (_, _) in
@@ -113,7 +113,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testMaximumNumberOfSuggestions() {
         let dataSource = SuggestionLoadingDataSourceMock(data: Data.anAPIResultData, bookmarks: BookmarkMock.someBookmarks)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 2) { (suggestions, _) in
@@ -125,7 +125,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenQueryMatchesBookmarkTitle_thenBookmarkMustBeSuggested() {
         let dataSource = SuggestionLoadingDataSourceMock(data: Data.anAPIResultData, bookmarks: BookmarkMock.someBookmarks)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test 1", maximum: 10) { (suggestions, _) in
@@ -139,7 +139,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenMaximumNumberIsLargeEnough_ThenSuggestionsContainAllRemoteSuggestionsAndTwoBookmarkSuggestions() {
         let dataSource = SuggestionLoadingDataSourceMock(data: Data.anAPIResultData, bookmarks: BookmarkMock.someBookmarks)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (suggestions, _) in
@@ -151,7 +151,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenAPIReturnsError_ThenBookmarksSuggested() {
         let dataSource = SuggestionLoadingDataSourceMock(error: E(), bookmarks: BookmarkMock.someBookmarks, delay: 0)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (suggestions, error) in
@@ -166,7 +166,7 @@ final class SuggestionLoadingTests: XCTestCase {
         let dataSource = SuggestionLoadingDataSourceMock(data: "malformed data".data(using: .utf8),
                                                          bookmarks: BookmarkMock.someBookmarks,
                                                          delay: 0)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (suggestions, error) in
@@ -179,7 +179,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenAPIReturnsErrorAndNoBookmarks_ThenFailedToLoadErrorReturned() {
         let dataSource = SuggestionLoadingDataSourceMock(error: E(), bookmarks: [], delay: 0)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (suggestions, error) in
@@ -192,7 +192,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenAPIReturnsMalformedDataAndNoBookmarks_ThenFailedToLoadErrorReturned() {
         let dataSource = SuggestionLoadingDataSourceMock(data: "malformed data".data(using: .utf8), bookmarks: [], delay: 0)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (suggestions, error) in
@@ -208,7 +208,7 @@ final class SuggestionLoadingTests: XCTestCase {
                                                          error: E(),
                                                          bookmarks: BookmarkMock.someBookmarks,
                                                          delay: 0)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (suggestions, error) in
@@ -221,7 +221,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenAPIReturnsAfterDelay_ThenSuggestionsContainAllRemoteSuggestionsAndTwoBookmarkSuggestions() {
         let dataSource = SuggestionLoadingDataSourceMock(data: Data.anAPIResultData, bookmarks: BookmarkMock.someBookmarks, delay: 0.2)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (suggestions, error) in
@@ -233,7 +233,7 @@ final class SuggestionLoadingTests: XCTestCase {
 
     func testWhenAPIReturnsErrorAfterDelay_ThenSuggestionsContainTwoBookmarkSuggestions() {
         let dataSource = SuggestionLoadingDataSourceMock(error: E(), bookmarks: BookmarkMock.someBookmarks, delay: 0.2)
-        let loader = SuggestionLoader(dataSource: dataSource)
+        let loader = SuggestionLoader(dataSource: dataSource, urlFactory: nil)
 
         let e = expectation(description: "suggestions callback")
         loader.getSuggestions(query: "test", maximum: 10) { (suggestions, error) in

--- a/Tests/BrowserServicesKitTests/Suggestions/SuggestionTests.swift
+++ b/Tests/BrowserServicesKitTests/Suggestions/SuggestionTests.swift
@@ -34,7 +34,7 @@ final class SuggestionTests: XCTestCase {
     func testWhenSuggestionKeyIsPhrase_ThenSuggestionIsPhrase() {
         let key = Suggestion.phraseKey
         let phraseValue = "value"
-        let suggestion = Suggestion(key: key, value: phraseValue)
+        let suggestion = Suggestion(key: key, value: phraseValue, urlFactory: { _ in nil })
 
         XCTAssertEqual(suggestion, Suggestion.phrase(phrase: phraseValue))
     }
@@ -42,9 +42,17 @@ final class SuggestionTests: XCTestCase {
     func testWhenSuggestionKeyIsNotPhrase_ThenSuggestionIsUnknown() {
         let key = "Key"
         let value = "value"
-        let suggestion = Suggestion(key: key, value: value)
+        let suggestion = Suggestion(key: key, value: value, urlFactory: { _ in nil })
 
         XCTAssertEqual(suggestion, Suggestion.unknown(value: value))
+    }
+
+    func testWhenSuggestionKeyIsURL_ThenSuggestionIsURL() {
+        let key = Suggestion.phraseKey
+        let phraseValue = "duckduckgo.com"
+        let suggestion = Suggestion(key: key, value: phraseValue, urlFactory: URL.init(string:))
+
+        XCTAssertEqual(suggestion, Suggestion.website(url: URL(string: phraseValue)!))
     }
 
 }

--- a/Tests/BrowserServicesKitTests/Suggestions/SuggestionTests.swift
+++ b/Tests/BrowserServicesKitTests/Suggestions/SuggestionTests.swift
@@ -42,7 +42,7 @@ final class SuggestionTests: XCTestCase {
     func testWhenSuggestionKeyIsNotPhrase_ThenSuggestionIsUnknown() {
         let key = "Key"
         let value = "value"
-        let suggestion = Suggestion(key: key, value: value, urlFactory: { _ in nil })
+        let suggestion = Suggestion(key: key, value: value)
 
         XCTAssertEqual(suggestion, Suggestion.unknown(value: value))
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1199237043628108/1200180252402997/1200259155963726
Tech Design URL:
CC: @tomasstrba 

**Description**:
This PR adds ability to parse Suggestion Phrases into .website(url:) providing an extra urlFactory: (String) -> URL? callback

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

* [ ] macOS 10.15
* [x] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
