### PR TITLE
Remove GRDB from the BrowserServicesKit target

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,6 @@ Using a simulator where a physical device is unavailable is acceptable.
 
 * [ ] iOS 13
 * [ ] iOS 14
-
 * [ ] macOS 10.15
 * [ ] macOS 11
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,7 @@
         "package": "GRDB",
         "repositoryURL": "https://github.com/duckduckgo/GRDB.swift.git",
         "state": {
-          "branch": "SQLCipher",
+          "branch": null,
           "revision": "e5714d4b6ee1651d2271b04ae85aaf5a327fe70a",
           "version": null
         }

--- a/Package.swift
+++ b/Package.swift
@@ -19,9 +19,7 @@ let package = Package(
     targets: [
         .target(
             name: "BrowserServicesKit",
-            dependencies: [
-                "GRDB",
-            ],
+            dependencies: [],
             resources: [
                 .process("Email/email-autofill.css"),
                 .process("Email/email-autofill.js")

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "SecureVault", targets: ["SecureVault"]),
     ],
     dependencies: [
-        .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .branch("SQLCipher")),
+        .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .revision("e5714d4b6ee1651d2271b04ae85aaf5a327fe70a")),
     ],
     targets: [
         .target(

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-public protocol EmailManagerStorage: class {
+public protocol EmailManagerStorage: AnyObject {
     func getUsername() -> String?
     func getToken() -> String?
     func getAlias() -> String?
@@ -36,7 +36,7 @@ public enum EmailManagerPermittedAddressType {
 }
 
 // swiftlint:disable identifier_name
-public protocol EmailManagerAliasPermissionDelegate: class {
+public protocol EmailManagerAliasPermissionDelegate: AnyObject {
 
     func emailManager(_ emailManager: EmailManager,
                       didRequestPermissionToProvideAliasWithCompletion: @escaping (EmailManagerPermittedAddressType) -> Void)
@@ -45,7 +45,7 @@ public protocol EmailManagerAliasPermissionDelegate: class {
 // swiftlint:enable identifier_name
 
 // swiftlint:disable function_parameter_count
-public protocol EmailManagerRequestDelegate: class {
+public protocol EmailManagerRequestDelegate: AnyObject {
     func emailManager(_ emailManager: EmailManager,
                       didRequestAliasWithURL url: URL,
                       method: String,

--- a/Sources/BrowserServicesKit/Email/EmailUserScript.swift
+++ b/Sources/BrowserServicesKit/Email/EmailUserScript.swift
@@ -19,7 +19,7 @@
 
 import WebKit
 
-public protocol EmailUserScriptDelegate: class {
+public protocol EmailUserScriptDelegate: AnyObject {
     func emailUserScriptDidRequestSignedInStatus(emailUserScript: EmailUserScript) -> Bool
     func emailUserScript(_ emailUserScript: EmailUserScript,
                          didRequestAliasAndRequiresUserPermission requiresUserPermission: Bool,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200299247026390/f
Tech Design URL:
CC: @brindy 

**Description**:

This PR makes three changes:

1. The GRDB dependency now points to a specific commit, allowing us to use tagged BrowserServicesKit versions. Previously this was not possible as it was pointing to a branch, and Xcode doesn't allow you to point to a version that itself doesn't use stable dependency versioning.
2. `class` keyword warnings are fixed.
3. GRDB has been removed from the BrowserServicesKit target, as it isn't used there.

**Steps to test this PR**:
1. Build this branch locally, making sure that tests pass and compiler warnings are gone.
2. Check out the [counterpart iOS branch here](https://github.com/duckduckgo/iOS/tree/feature/sam/update-browserserviceskit-to-remove-grdb) and verify that it builds, and check the build log for any traces of `GRDB` or `SQLCipher`. There shouldn't be any.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
