### PR TITLE
Fix autofill script memory leak

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -63,9 +63,7 @@ public class AutofillUserScript: NSObject, UserScript {
 
     public var injectionTime: WKUserScriptInjectionTime { .atDocumentStart }
     public var forMainFrameOnly: Bool { false }
-    public var messageNames: [String] {
-        MessageName.allCases.map(\.rawValue)
-    }
+    public var messageNames: [String] { MessageName.allCases.map(\.rawValue) }
 
     private func messageHandlerFor(_ message: MessageName) -> MessageHandler {
         switch message {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200422979562531/f
Tech Design URL:
CC: @brindy 

**Description**:

This PR fixed a leak in the autofill user script.

The fix is to avoid holding strong references to functions, and instead look them up as needed via a new function.

**Steps to test this PR**:
1. Test the autofill functions as expected
1. Open and close a few tabs, then check the memory graph debugger for leaks

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
