### PR TITLE
don't inject autofill into frames on pre-ios 14

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -62,7 +62,13 @@ public class AutofillUserScript: NSObject, UserScript {
     }()
 
     public var injectionTime: WKUserScriptInjectionTime { .atDocumentStart }
-    public var forMainFrameOnly: Bool { false }
+    public var forMainFrameOnly: Bool {
+        if #available(iOS 14, macOS 11, *) {
+            return false
+        }
+        // We can't do reply based messaging to frames on versions before the ones mentioned above, so main frame only
+        return true
+    }
     public var messageNames: [String] { MessageName.allCases.map(\.rawValue) }
 
     private func messageHandlerFor(_ message: MessageName) -> MessageHandler {
@@ -191,11 +197,11 @@ extension AutofillUserScript {
 
             let script = """
             (() => {
-                window.\(methodName)({
+                window.\(methodName) && window.\(methodName)({
                     ciphertext: [\(ciphertext)],
                     tag: [\(tag)]
                 });
-            })()
+            })();
             """
 
             assert(message.webView != nil)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/1200465696711800/1200466433503758
Tech Design URL:
CC: @GioSensation 

**Description**:

Messaging into frames isn't supported before iOS 11, macOS 14 and causes unexpected side effects when trying to inject autofill there.

**Steps to test this PR**:
1. On iOS 13 - using 4.0.1 of BSK visit the SERP with a simulator and debug console active.  You'll see a console error and jext pixel.
1. Update to using this version of BSK, the console and jext pixel will be gone.
1. Ensure autofill still works as expected on both iOS 13 and 14

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
