### PR TITLE
Walk up the domains when querying accounts

### DIFF
--- a/Sources/BrowserServicesKit/SecureVault/SecureVault.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVault.swift
@@ -150,7 +150,15 @@ class DefaultSecureVault: SecureVault {
         }
 
         do {
-            return try self.providers.database.websiteAccountsForDomain(domain)
+            var parts = domain.components(separatedBy: ".")
+            while !parts.isEmpty {
+                let accounts = try self.providers.database.websiteAccountsForDomain(parts.joined(separator: "."))
+                if !accounts.isEmpty {
+                    return accounts
+                }
+                parts.removeFirst()
+            }
+            return []
         } catch {
             throw SecureVaultError.databaseError(cause: error)
         }

--- a/Tests/BrowserServicesKitTests/SecureVault/MockVaultProviders.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/MockVaultProviders.swift
@@ -23,7 +23,7 @@ internal class MockDatabaseProvider: SecureVaultDatabaseProvider {
 
     // swiftlint:disable identifier_name
     var _accounts =  [SecureVaultModels.WebsiteAccount]()
-    var _forDomain: String?
+    var _forDomain = [String]()
     var _credentials: SecureVaultModels.WebsiteCredentials?
     var _lastCredentials: SecureVaultModels.WebsiteCredentials?
     // swiftlint:enable identifier_name
@@ -38,7 +38,7 @@ internal class MockDatabaseProvider: SecureVaultDatabaseProvider {
     }
 
     func websiteAccountsForDomain(_ domain: String) throws -> [SecureVaultModels.WebsiteAccount] {
-        self._forDomain = domain
+        self._forDomain.append(domain)
         return _accounts
     }
 

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultTests.swift
@@ -61,8 +61,15 @@ class SecureVaultTests: XCTestCase {
         XCTAssertEqual("domain", accounts[0].domain)
         XCTAssertEqual("username", accounts[0].username)
 
-        XCTAssertEqual("example.com", mockDatabaseProvider._forDomain)
+        XCTAssertEqual(["example.com"], mockDatabaseProvider._forDomain)
+    }
 
+    func testWhenRetrievingAccountsForDomain_ThenWalkUpDomainToFindAccounts() throws {
+
+        mockDatabaseProvider._accounts = []
+
+        _ = try testVault.accountsFor(domain: "www.example.com")
+        XCTAssertEqual(["www.example.com", "example.com", "com"], mockDatabaseProvider._forDomain)
     }
 
     func testWhenDeletingCredentialsForAccount_ThenDatabaseCalled() throws {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1200661107896190
Tech Design URL:
CC:

**Description**:

When requesting accounts walk up the domains.

**Steps to test this PR**:
1. Test domain detection on a subdomain that has a domain saved in password manager

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
