### PR TITLE
Run in page content world

### DIFF
--- a/Sources/BrowserServicesKit/UserScript/StaticUserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/StaticUserScript.swift
@@ -24,6 +24,7 @@ public protocol StaticUserScript: UserScript {
     static var source: String { get }
     static var injectionTime: WKUserScriptInjectionTime { get }
     static var forMainFrameOnly: Bool { get }
+    static var requiresRunInPageContentWorld: Bool { get }
 
     static var script: WKUserScript { get }
 
@@ -41,6 +42,10 @@ public extension StaticUserScript {
 
     var forMainFrameOnly: Bool {
         Self.forMainFrameOnly
+    }
+
+    var requiresRunInPageContentWorld: Bool {
+        Self.requiresRunInPageContentWorld
     }
 
     func makeWKUserScript() -> WKUserScript {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1163321984198618/1201316585073693/f
Tech Design URL:
CC:

**Description**:

For https://app.asana.com/0/1163321984198618/1201316585073693/f and https://app.asana.com/0/1199230911884351/1200442572797700/f

**Steps to test this PR**:

1. Open up pages using the browser change PR and check the relevant webkit.messageHandlers aren't erroring onto the page as undefined, check that the content blocker api is visible and working.

I'm all ears if there's obvious unit / integration tests here to help make sure this doesn't behave badly.

~~Annoyingly we have to specify `requiresRunInPageContentWorld` everywhere now, I can't find a solution to this.~~

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [x] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
