### PR TITLE
Fix lastName in identity

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -73,7 +73,7 @@ extension AutofillUserScript {
                                   title: identity.title,
                                   firstName: identity.firstName,
                                   middleName: identity.middleName,
-                                  lastName: identity.middleName,
+                                  lastName: identity.lastName,
                                   birthdayDay: identity.birthdayDay,
                                   birthdayMonth: identity.birthdayMonth,
                                   birthdayYear: identity.birthdayYear,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1201393138029482/f
CC: @samsymons 

**Description**:
Just a copy/paste mishap. The identities object was returning `middleName` for `lastName`. This fixes it.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
