### PR TITLE
Update the credit card table

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -73,7 +73,7 @@ extension AutofillUserScript {
                                   title: identity.title,
                                   firstName: identity.firstName,
                                   middleName: identity.middleName,
-                                  lastName: identity.middleName,
+                                  lastName: identity.lastName,
                                   birthdayDay: identity.birthdayDay,
                                   birthdayMonth: identity.birthdayMonth,
                                   birthdayYear: identity.birthdayYear,

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -78,7 +78,7 @@ extension AutofillUserScript {
                                   birthdayMonth: identity.birthdayMonth,
                                   birthdayYear: identity.birthdayYear,
                                   addressStreet: identity.addressStreet,
-                                  addressStreet2: nil,
+                                  addressStreet2: identity.addressStreet2,
                                   addressCity: identity.addressCity,
                                   addressProvince: identity.addressProvince,
                                   addressPostalCode: identity.addressPostalCode,

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
@@ -812,6 +812,7 @@ extension SecureVaultModels.Identity: PersistableRecord, FetchableRecord {
         container[Columns.birthdayYear] = birthdayYear
 
         container[Columns.addressStreet] = addressStreet
+        container[Columns.addressStreet2] = addressStreet2
         container[Columns.addressCity] = addressCity
         container[Columns.addressProvince] = addressProvince
         container[Columns.addressPostalCode] = addressPostalCode

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
@@ -756,6 +756,9 @@ extension SecureVaultModels.Note: PersistableRecord, FetchableRecord {
         lastUpdated = row[Columns.lastUpdated]
         associatedDomain = row[Columns.associatedDomain]
         text = row[Columns.text]
+        
+        displayTitle = generateDisplayTitle()
+        displaySubtitle = generateDisplaySubtitle()
     }
 
     public func encode(to container: inout PersistenceContainer) {

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultError.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultError.swift
@@ -23,6 +23,7 @@ public enum SecureVaultError: Error {
     case initFailed(cause: Error)
     case authRequired
     case invalidPassword
+    case noL1Key
     case noL2Key
     case authError(cause: Error)
     case failedToOpenDatabase(cause: Error)

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultFactory.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultFactory.swift
@@ -74,17 +74,7 @@ public class SecureVaultFactory {
             if let existingL1Key = try keystoreProvider.l1Key() {
                 databaseProvider = try DefaultDatabaseProvider(key: existingL1Key)
             } else {
-                let l1Key = try cryptoProvider.generateSecretKey()
-                let l2Key = try cryptoProvider.generateSecretKey()
-                let password = try cryptoProvider.generatePassword()
-                let passwordKey = try cryptoProvider.deriveKeyFromPassword(password)
-                let encryptedL2Key = try cryptoProvider.encrypt(l2Key, withKey: passwordKey)
-
-                try keystoreProvider.storeEncryptedL2Key(encryptedL2Key)
-                try keystoreProvider.storeGeneratedPassword(password)
-                try keystoreProvider.storeL1Key(l1Key)
-
-                databaseProvider = try DefaultDatabaseProvider(key: l1Key)
+                throw SecureVaultError.noL1Key
             }
             
             return SecureVaultProviders(crypto: cryptoProvider, database: databaseProvider, keystore: keystoreProvider)

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultFactory.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultFactory.swift
@@ -40,7 +40,7 @@ public class SecureVaultFactory {
     /// * Generates a secret key for L1 encryption and stores in Keychain
     /// * Generates a secret key for L2 encryption
     /// * Generates a user password to encrypt the L2 key with
-    /// * Stores encyprted L2 key in Keychain
+    /// * Stores encrypted L2 key in Keychain
     public func makeVault(authExpiration: TimeInterval = 60 * 60 * 24 * 72) throws -> SecureVault {
 
         if let vault = self.vault, authExpiration == vault.authExpiry {
@@ -51,31 +51,12 @@ public class SecureVaultFactory {
                 lock.unlock()
             }
 
-            let cryptoProvider = makeCryptoProvider()
-            let keystoreProvider = makeKeyStoreProvider()
-            let databaseProvider: SecureVaultDatabaseProvider
-
             do {
-                if let existingL1Key = try keystoreProvider.l1Key() {
-                    databaseProvider = try DefaultDatabaseProvider(key: existingL1Key)
-                } else {
-                    let l1Key = try cryptoProvider.generateSecretKey()
-                    let l2Key = try cryptoProvider.generateSecretKey()
-                    let password = try cryptoProvider.generatePassword()
-                    let passwordKey = try cryptoProvider.deriveKeyFromPassword(password)
-                    let encryptedL2Key = try cryptoProvider.encrypt(l2Key, withKey: passwordKey)
-
-                    try keystoreProvider.storeEncryptedL2Key(encryptedL2Key)
-                    try keystoreProvider.storeGeneratedPassword(password)
-                    try keystoreProvider.storeL1Key(l1Key)
-
-                    databaseProvider = try DefaultDatabaseProvider(key: l1Key)
-                }
-
-                let providers = SecureVaultProviders(crypto: cryptoProvider, database: databaseProvider, keystore: keystoreProvider)
-
+                let providers = try makeSecureVaultProviders()
                 let vault = DefaultSecureVault(authExpiry: authExpiration, providers: providers)
+
                 self.vault = vault
+
                 return vault
 
             } catch {
@@ -83,6 +64,34 @@ public class SecureVaultFactory {
             }
         }
 
+    }
+    
+    internal func makeSecureVaultProviders() throws -> SecureVaultProviders {
+        let cryptoProvider = makeCryptoProvider()
+        let keystoreProvider = makeKeyStoreProvider()
+        let databaseProvider: SecureVaultDatabaseProvider
+        
+        do {
+            if let existingL1Key = try keystoreProvider.l1Key() {
+                databaseProvider = try DefaultDatabaseProvider(key: existingL1Key)
+            } else {
+                let l1Key = try cryptoProvider.generateSecretKey()
+                let l2Key = try cryptoProvider.generateSecretKey()
+                let password = try cryptoProvider.generatePassword()
+                let passwordKey = try cryptoProvider.deriveKeyFromPassword(password)
+                let encryptedL2Key = try cryptoProvider.encrypt(l2Key, withKey: passwordKey)
+
+                try keystoreProvider.storeEncryptedL2Key(encryptedL2Key)
+                try keystoreProvider.storeGeneratedPassword(password)
+                try keystoreProvider.storeL1Key(l1Key)
+
+                databaseProvider = try DefaultDatabaseProvider(key: l1Key)
+            }
+        } catch {
+            throw SecureVaultError.initFailed(cause: error)
+        }
+        
+        return SecureVaultProviders(crypto: cryptoProvider, database: databaseProvider, keystore: keystoreProvider)
     }
 
     internal func makeCryptoProvider() -> SecureVaultCryptoProvider {

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -76,17 +76,25 @@ public struct SecureVaultModels {
         public let created: Date
         public let lastUpdated: Date
 
-        public var cardNumber: String
+        public var cardNumberData: Data
+        public var cardSuffix: String // Stored as L1 data, used when presenting a list of cards in the Autofill UI
         public var cardholderName: String?
         public var cardSecurityCode: String?
         public var expirationMonth: Int?
         public var expirationYear: Int?
+        
+        public var cardNumber: String {
+            return String(data: cardNumberData, encoding: .utf8)!
+        }
 
         public var displayName: String {
             let type = CreditCardValidation.type(for: cardNumber)
-            let suffix = String(cardNumber.suffix(4))
-
-            return "\(type.displayName) (\(suffix))"
+            return "\(type.displayName) (\(cardSuffix))"
+        }
+        
+        static func suffix(from cardNumber: String) -> String {
+            let trimmedCardNumber = cardNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+            return String(trimmedCardNumber.suffix(4))
         }
 
         public init(id: Int64? = nil,
@@ -101,7 +109,8 @@ public struct SecureVaultModels {
             self.created = Date()
             self.lastUpdated = self.created
 
-            self.cardNumber = cardNumber
+            self.cardNumberData = cardNumber.data(using: .utf8)!
+            self.cardSuffix = Self.suffix(from: cardNumber)
             self.cardholderName = cardholderName
             self.cardSecurityCode = cardSecurityCode
             self.expirationMonth = expirationMonth
@@ -148,6 +157,7 @@ public struct SecureVaultModels {
         public var birthdayYear: Int?
 
         public var addressStreet: String?
+        public var addressStreet2: String?
         public var addressCity: String?
         public var addressProvince: String?
         public var addressPostalCode: String?
@@ -174,6 +184,7 @@ public struct SecureVaultModels {
                     birthdayMonth: Int? = nil,
                     birthdayYear: Int? = nil,
                     addressStreet: String? = nil,
+                    addressStreet2: String? = nil,
                     addressCity: String? = nil,
                     addressProvince: String? = nil,
                     addressPostalCode: String? = nil,
@@ -192,6 +203,7 @@ public struct SecureVaultModels {
             self.birthdayMonth = birthdayMonth
             self.birthdayYear = birthdayYear
             self.addressStreet = addressStreet
+            self.addressStreet2 = addressStreet2
             self.addressCity = addressCity
             self.addressProvince = addressProvince
             self.addressPostalCode = addressPostalCode

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -127,7 +127,12 @@ public struct SecureVaultModels {
         public let lastUpdated: Date
 
         public var associatedDomain: String?
-        public var text: String
+        public var text: String {
+            didSet {
+                self.displayTitle = generateDisplayTitle()
+                self.displaySubtitle = generateDisplaySubtitle()
+            }
+        }
 
         public init(title: String? = nil, associatedDomain: String? = nil, text: String) {
             self.id = nil
@@ -137,6 +142,55 @@ public struct SecureVaultModels {
 
             self.associatedDomain = associatedDomain
             self.text = text
+            
+            self.displayTitle = generateDisplayTitle()
+            self.displaySubtitle = generateDisplaySubtitle()
+        }
+        
+        // Display Properties:
+        
+        public internal(set) var displayTitle: String?
+        public internal(set) var displaySubtitle: String = ""
+        
+        /// If a note has a title, it will be used when displaying the note in the UI. If it doesn't have a title and it has body text, the first non-empty line of the body text
+        /// will be used. If it doesn't have a title or body text, a placeholder string is used.
+        internal func generateDisplayTitle() -> String? {
+            guard title.isEmpty else {
+                return title
+            }
+
+            // If a note doesn't have a title, the first non-empty line will be used instead.
+            let noteLines = text.components(separatedBy: .newlines)
+            return noteLines.first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
+        }
+        
+        /// If a note has a title, the first non-empty line of the note is used as the subtitle. If it doesn't have a title, the first non-empty line will be used as a title, so the
+        /// second non-empty line will then be used as the subtitle. If there is no title or body text, an empty string is returned.
+        internal func generateDisplaySubtitle() -> String {
+            guard title.isEmpty else {
+                return firstNonEmptyLine ?? ""
+            }
+
+            // The title's empty, so assume that the first non-empty line is used as the title, and find the second non-
+            // empty line instead.
+            
+            let noteLines = text.components(separatedBy: .newlines)
+            var alreadyFoundFirstNonEmptyLine = false
+            
+            for line in noteLines where !line.isEmpty {
+                if !alreadyFoundFirstNonEmptyLine {
+                    alreadyFoundFirstNonEmptyLine = true
+                } else if alreadyFoundFirstNonEmptyLine {
+                    return line
+                }
+            }
+            
+            return ""
+        }
+        
+        private var firstNonEmptyLine: String? {
+            let noteLines = text.components(separatedBy: .newlines)
+            return noteLines.first(where: { !$0.isEmpty })
         }
 
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1201406179271672/f
Tech Design URL:
CC: @brindy 

**Description**:

This PR updates the credit card table to store the number as L2 data.

There are a couple other small database tweaks included here too, such as storing an additional address column.

**Steps to test this PR**:

⚠️ Back up your existing Vault.db file, in case something in this migration is broken.
Go to `~/Library/Containers/com.duckduckgo.macos.browser.debug/Data/Library/Application Support/Vault` to find the Vault file, and copy/paste it somewhere else for the time being.

**This PR requires checking out the corresponding desktop branch.**

1. Run this branch with existing Vault data, and check that the migration completes successfully. Ideally, run this on existing Vault data that already has some credit cards
1. Create a credit card and check that it shows up correctly when Autofilling; you can easily test this somewhere like Amazon.com
1. Edit an existing card and check that it has updated correctly

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
