### PR TITLE
Call onload handler once surrogate is called

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/SurrogatesUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/SurrogatesUserScript.swift
@@ -141,6 +141,9 @@ open class SurrogatesUserScript: NSObject, UserScript {
         // Construct a JavaScript object for function lookup
         let surrogatesOut = surrogateScripts.map { (surrogate) -> String in
             var codeLines = surrogate.split(separator: "\n")
+            if (codeLines.isEmpty) {
+                return ""
+            }
             let instructionsRow = codeLines.removeFirst()
             let pattern = instructionsRow.split(separator: " ")[0].split(separator: "/")[1]
             let stringifiedFunction = codeLines.joined(separator: "\n")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:  https://app.asana.com/0/1200277586140538/1200918044697295/f
Tech Design URL:
CC:

**Description**:

Moved from: https://github.com/more-duckduckgo-org/macos-browser/pull/316
Depends on: https://github.com/duckduckgo/BrowserServicesKit/pull/36

Steps to test this PR:

- Open dwell.com

Page should render without full page DOM blank screen.

- Open https://privacy-test-pages.glitch.me/privacy-protections/surrogates/

Notice that main and iframe load tests now work.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
