### PR TITLE
Brad/multiple rule lists

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -288,8 +288,9 @@ public class ContentBlockerRulesManager {
                                               completionTokens: completionTokens)
             
             
-                WKContentRuleListStore.default()?.removeContentRuleList(forIdentifier: oldIdentifier) { _ in }
-            })
+            if let oldIdentifier = oldIdentifier {
+                WKContentRuleListStore.default()?.removeContentRuleList(forIdentifier: oldIdentifier.stringValue) { _ in }
+            }
         }
     }
 

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -61,13 +61,15 @@ public class ContentBlockerRulesManager {
     private let logger: OSLog
     public let sourceManager: ContentBlockerRulesSourceManager
 
-    private let workQueue = DispatchQueue(label: "ContentBlockerManagerQueue", qos: .userInitiated)
+    private let workQueue: DispatchQueue
 
     public init(source: ContentBlockerRulesSource,
                 updateListener: ContentBlockerRulesUpdating,
                 errorReporting: EventMapping<ContentBlockerDebugEvents>? = nil,
                 logger: OSLog = .disabled) {
         dataSource = source
+        self.workQueue = DispatchQueue(label: "ContentBlockerManagerQueue\(UUID().uuidString)",
+                                       qos: .userInitiated)
         self.updateListener = updateListener
         self.errorReporting = errorReporting
         self.logger = logger

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -26,6 +26,7 @@ public protocol ContentBlockerRulesUpdating {
 
     func rulesManager(_ manager: ContentBlockerRulesManager,
                       didUpdateRules: ContentBlockerRulesManager.CurrentRules,
+                      oldRules: WKContentRuleList?,
                       changes: ContentBlockerRulesIdentifier.Difference,
                       completionTokens: [ContentBlockerRulesManager.CompletionToken])
 }
@@ -259,6 +260,7 @@ public class ContentBlockerRulesManager {
                                      encodedTrackerData: encodedTrackerData,
                                      etag: input.tdsIdentifier,
                                      identifier: input.rulesIdentifier)
+        let oldRules = _currentRules?.rulesList
         _currentRules = newRules
 
         var completionTokens = [CompletionToken]()
@@ -280,6 +282,7 @@ public class ContentBlockerRulesManager {
         DispatchQueue.main.async {
             self.updateListener?.rulesManager(self,
                                               didUpdateRules: newRules,
+                                              oldRules: oldRules,
                                               changes: diff,
                                               completionTokens: completionTokens)
             

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -261,6 +261,7 @@ public class ContentBlockerRulesManager {
                                      etag: input.tdsIdentifier,
                                      identifier: input.rulesIdentifier)
         let oldRules = _currentRules?.rulesList
+        let oldIdentifier = _currentRules?.identifier
         _currentRules = newRules
 
         var completionTokens = [CompletionToken]()
@@ -286,15 +287,8 @@ public class ContentBlockerRulesManager {
                                               changes: diff,
                                               completionTokens: completionTokens)
             
-            WKContentRuleListStore.default()?.getAvailableContentRuleListIdentifiers({ ids in
-                guard let ids = ids else { return }
-
-                var idsSet = Set(ids)
-                idsSet.remove(ruleList.identifier)
-
-                for id in idsSet {
-                    WKContentRuleListStore.default()?.removeContentRuleList(forIdentifier: id) { _ in }
-                }
+            
+                WKContentRuleListStore.default()?.removeContentRuleList(forIdentifier: oldIdentifier) { _ in }
             })
         }
     }

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
@@ -20,6 +20,7 @@
 import XCTest
 import TrackerRadarKit
 import BrowserServicesKit
+import WebKit
 
 // swiftlint:disable file_length
 
@@ -175,6 +176,7 @@ final private class RulesUpdateListener: ContentBlockerRulesUpdating {
 
     func rulesManager(_ manager: ContentBlockerRulesManager,
                       didUpdateRules: ContentBlockerRulesManager.CurrentRules,
+                      oldRules: WKContentRuleList?,
                       changes: ContentBlockerRulesIdentifier.Difference,
                       completionTokens: [ContentBlockerRulesManager.CompletionToken]) {
         onRulesUpdated()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1201470200663180/1201476979675567/f
Tech Design URL:
CC: @ladamski, @bwaresiak 

**Description**:
This PR adds base support for multiple content blocking lists. Specifically it prevents removing all content blocking lists when one is compiled and passes a reference to the old list on compilation success so the webview may remove the specific old list.

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
