### PR TITLE
Support content scope as a user script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Sources/BrowserServicesKit/Resources/duckduckgo-autofill"]
 	path = Sources/BrowserServicesKit/Resources/duckduckgo-autofill
 	url = https://github.com/duckduckgo/duckduckgo-autofill
+[submodule "Sources/BrowserServicesKit/Resources/content-scope-scripts"]
+	path = Sources/BrowserServicesKit/Resources/content-scope-scripts
+	url = https://github.com/duckduckgo/content-scope-scripts

--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,7 @@ let package = Package(
                 .process("Resources/duckduckgo-autofill/dist/autofill.js"),
                 .process("ContentBlocking/UserScripts/contentblockerrules.js"),
                 .process("ContentBlocking/UserScripts/surrogates.js"),
+                .process("Resources/content-scope-scripts/build/apple/contentScope.js"),
                 .copy("Resources/trackerData.json")
             ]),
         .testTarget(

--- a/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
@@ -1,0 +1,68 @@
+//
+//  ContentScopeUserScript.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+import Combine
+
+public final class ContentScopeProperties: Encodable {
+    public let globalPrivacyControlValue: Bool
+    public let debug: Bool = false
+    public let sessionKey: String
+
+    public init(gpcEnabled: Bool, sessionKey: String) {
+        self.globalPrivacyControlValue = gpcEnabled
+        self.sessionKey = sessionKey
+    }
+}
+
+public final class ContentScopeUserScript: NSObject, UserScript {
+    public let messageNames: [String] = []
+
+    public init(_ privacyConfigManager: PrivacyConfigurationManager, properties: ContentScopeProperties) {
+        source = ContentScopeUserScript.generateSource(privacyConfigManager, properties: properties)
+    }
+
+    public static func generateSource(_ privacyConfigurationManager: PrivacyConfigurationManager, properties: ContentScopeProperties) -> String {
+
+        guard let privacyConfigJson = String(data: privacyConfigurationManager.currentConfig, encoding: .utf8),
+              let userUnprotectedDomains = try? JSONEncoder().encode(privacyConfigurationManager.privacyConfig.userUnprotectedDomains),
+              let userUnprotectedDomainsString = String(data: userUnprotectedDomains, encoding: .utf8),
+              let jsonProperties = try? JSONEncoder().encode(properties),
+              let jsonPropertiesString = String(data: jsonProperties, encoding: .utf8)
+              else {
+            return ""
+        }
+        
+        return loadJS("contentScope", from: Bundle.module, withReplacements: [
+            "$CONTENT_SCOPE$": privacyConfigJson,
+            "$USER_UNPROTECTED_DOMAINS$": userUnprotectedDomainsString,
+            "$USER_PREFERENCES$": jsonPropertiesString,
+        ])
+    }
+
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    }
+
+    public let source: String
+
+    public let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
+    public let forMainFrameOnly: Bool = false
+    public let requiresRunInPageContentWorld: Bool = true
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1163321984198618/1201071474741984/f
Tech Design URL:
CC:

**Description**:

- Loads the code that is currently in the extension as a user script that's bundled and accounts for the privacy config.
- https://github.com/duckduckgo/content-scope-scripts is the bundled code.
- This change doesn't implement anything in isolation so would be safe to merge, the scripts are controlled by remote config and require integration into iOS etc.

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
