### PR TITLE
Add platform.name to BrowserServices kit

### DIFF
--- a/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
@@ -35,8 +35,10 @@ public final class ContentScopeProperties: Encodable {
 public struct ContentScopePlatform: Encodable {
     #if os(macOS)
     let name = "macos"
-    #else
+    #elseif os(iOS)
     let name = "ios"
+    #else
+    let name = "unknown"
     #endif
 }
 

--- a/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
@@ -24,11 +24,20 @@ public final class ContentScopeProperties: Encodable {
     public let globalPrivacyControlValue: Bool
     public let debug: Bool = false
     public let sessionKey: String
+    public let platform = ContentScopePlatform()
 
     public init(gpcEnabled: Bool, sessionKey: String) {
         self.globalPrivacyControlValue = gpcEnabled
         self.sessionKey = sessionKey
     }
+}
+
+public struct ContentScopePlatform: Encodable {
+    #if os(macOS)
+    let name = "macos"
+    #else
+    let name = "ios"
+    #endif
 }
 
 public final class ContentScopeUserScript: NSObject, UserScript {

--- a/Tests/BrowserServicesKitTests/UserScript/ContentScopePropertiesTests.swift
+++ b/Tests/BrowserServicesKitTests/UserScript/ContentScopePropertiesTests.swift
@@ -1,0 +1,34 @@
+//
+//  ContentScopePropertiesTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import WebKit
+@testable import BrowserServicesKit
+
+class ContentScopePropertiesTests: XCTestCase {
+    func testContentScopePropertiesInitializeCorrectly() {
+        let properties = ContentScopeProperties(gpcEnabled: true, sessionKey: "123456");
+
+        // ensure the properties can be encoded to valid JSON
+        XCTAssertNotNil(try? JSONEncoder().encode(properties))
+
+        // ensure the platform.name key exists, as this will be expected in the output JSON
+        XCTAssertEqual(properties.platform.name, ContentScopePlatform().name)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1201638082386077/f
Tech Design URL: https://app.asana.com/0/481882893211075/1201508656742121/f
CC:

**Description**:

This PR adds `platform.name` as a string of either `ios` or `macos` into the user preferences JSON that ends up in the content scope scripts. 

This enables the Navigator Interface feature

**Steps to test this PR**:
1. Unit tested

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
