### PR TITLE
Fix unprotected sites flag in JS layer

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/contentblockerrules.js
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/contentblockerrules.js
@@ -36,7 +36,7 @@
         domainParts.shift()
     }
 
-    if (!unprotectedDomain && topLevelUrl.host != null) {
+    if (!unprotectedDomain && topLevelUrl.host != null && topLevelUrl.host.length > 0) {
         unprotectedDomain = `
         $USER_UNPROTECTED_DOMAINS$
         `.split('\n').filter(domain => domain.trim() === topLevelUrl.host).length > 0

--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/surrogates.js
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/surrogates.js
@@ -487,7 +487,7 @@
         domainParts.shift()
     }
 
-    if (!unprotectedDomain && topLevelUrl.host != null) {
+    if (!unprotectedDomain && topLevelUrl.host != null && topLevelUrl.host.length > 0) {
         unprotectedDomain = `
           $USER_UNPROTECTED_DOMAINS$
           `.split('\n').filter(domain => domain.trim() === topLevelUrl.host).length > 0


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1201666147268877
Tech Design URL:
CC:

**Description**:
Fix JS, so when we cannot determine top level url, we won't assume it is unprotected.

**Steps to test this PR**:

1. Visit https://wsj.com
2. Validate list of blocked trackers: googlesyndication should be blocked.

In addition re-test disabling protection.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] macOS

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
