### PR TITLE
add clickToPlay to privacyConfig

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
@@ -92,4 +92,5 @@ public enum PrivacyFeature: String {
     case gpc
     case httpsUpgrade = "https"
     case autoconsent
+    case clickToPlay
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1201730253863268/f

**Description**:
Once https://github.com/duckduckgo/privacy-configuration/pull/113, CTL for MacOS will no longer be disabled in the privacy config.  However, turns out its not yet supported in BSK as a config settings.  This adds property, so we can in turn land 

**Steps to test this PR**:
1. You can test https://github.com/more-duckduckgo-org/macos-browser/pull/407, it is failing because its missing the `clickToPlay` mapping in the privacy config
2. If you aim that PR at this branch instead, it should succeed


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
