### PR TITLE
Recreate SecureVault database on corruption

### DIFF
--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
@@ -61,20 +61,17 @@ final class DefaultDatabaseProvider: SecureVaultDatabaseProvider {
 
     let db: DatabaseQueue
 
-    init(key: Data) throws {
+    init(file: URL = DefaultDatabaseProvider.dbFile(), key: Data) throws {
         var config = Configuration()
         config.prepareDatabase {
             try $0.usePassphrase(key)
         }
 
-        let file = try Self.dbFile()
-
         do {
             db = try DatabaseQueue(path: file.path, configuration: config)
         } catch (let error) {
-            os_log("database initialization failed with %{public}s, recreating", type: .error, error.localizedDescription)
-            try? FileManager.default.removeItem(at: file)
-            db = try DatabaseQueue(path: file.path, configuration: config)
+            os_log("database initialization failed with %{public}s", type: .error, error.localizedDescription)
+            throw error
         }
 
         var migrator = DatabaseMigrator()
@@ -88,9 +85,32 @@ final class DefaultDatabaseProvider: SecureVaultDatabaseProvider {
         do {
             try migrator.migrate(db)
         } catch {
-            print(error)
+            os_log("database migration error: %{public}s", type: .error, error.localizedDescription)
             throw error
         }
+    }
+
+    static func recreateDatabase(withKey key: Data) throws -> DefaultDatabaseProvider {
+        let dbFile = self.dbFile()
+
+        guard FileManager.default.fileExists(atPath: dbFile.path) else {
+            return try Self(file: dbFile, key: key)
+        }
+
+        // make sure we can create an empty db first and release it then
+        let newDbFile = self.nonExistingDBFile(withExtension: dbFile.pathExtension)
+        try autoreleasepool {
+            try _=Self(file: newDbFile, key: key)
+        }
+
+        // backup old db file
+        let backupFile = self.nonExistingDBFile(withExtension: dbFile.pathExtension + ".bak")
+        try FileManager.default.moveItem(at: dbFile, to: backupFile)
+
+        // place just created new db in place of dbFile
+        try FileManager.default.moveItem(at: newDbFile, to: dbFile)
+
+        return try Self(file: dbFile, key: key)
     }
 
     func accounts() throws -> [SecureVaultModels.WebsiteAccount] {
@@ -624,7 +644,7 @@ struct MigrationUtility {
 
 extension DefaultDatabaseProvider {
 
-    static internal func dbFile() throws -> URL {
+    static internal func dbFile() -> URL {
 
         let fm = FileManager.default
 
@@ -655,6 +675,24 @@ extension DefaultDatabaseProvider {
         }
 
         return subDir.appendingPathComponent("Vault.db")
+    }
+
+    static internal func nonExistingDBFile(withExtension ext: String) -> URL {
+        let originalPath = Self.dbFile().deletingPathExtension().path
+
+        for i in 0... {
+            var path = originalPath
+            if i > 0 {
+                path = path + "_\(i)"
+            }
+            path = path + "." + ext
+
+            if !FileManager.default.fileExists(atPath: path) {
+                return URL(fileURLWithPath: path)
+            }
+        }
+
+        fatalError()
     }
 
 }

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
@@ -683,9 +683,9 @@ extension DefaultDatabaseProvider {
         for i in 0... {
             var path = originalPath
             if i > 0 {
-                path = path + "_\(i)"
+                path += "_\(i)"
             }
-            path = path + "." + ext
+            path += "." + ext
 
             if !FileManager.default.fileExists(atPath: path) {
                 return URL(fileURLWithPath: path)

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultFactory.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultFactory.swift
@@ -72,7 +72,11 @@ public class SecureVaultFactory {
             let databaseProvider: SecureVaultDatabaseProvider
 
             if let existingL1Key = try keystoreProvider.l1Key() {
-                databaseProvider = try DefaultDatabaseProvider(key: existingL1Key)
+                do {
+                    databaseProvider = try DefaultDatabaseProvider(key: existingL1Key)
+                } catch {
+                    databaseProvider = try DefaultDatabaseProvider.recreateDatabase(withKey: existingL1Key)
+                }
             } else {
                 throw SecureVaultError.noL1Key
             }

--- a/Sources/BrowserServicesKit/Suggestions/SuggestionProcessing.swift
+++ b/Sources/BrowserServicesKit/Suggestions/SuggestionProcessing.swift
@@ -199,7 +199,7 @@ final class SuggestionProcessing {
             case .historyEntry:
                 // If there is a historyEntry and bookmark with the same URL, suggest the bookmark
                 newSuggestion = findBookmarkDuplicate(to: suggestion, nakedUrl: suggestionNakedUrl, from: suggestions)
-            case .bookmark(title: let title, url: let url, isFavorite: let isFavorite, allowedInTopHits: _):
+            case .bookmark(title: _, url: _, isFavorite: _, allowedInTopHits: _):
                 newSuggestion = findAndMergeHistoryDuplicate(with: suggestion, nakedUrl: suggestionNakedUrl, from: suggestions)
             case .phrase, .website, .unknown:
                 break

--- a/Tests/BrowserServicesKitTests/SecureVault/VaultFactoryTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/VaultFactoryTests.swift
@@ -44,7 +44,7 @@ class VaultFactoryTests: XCTestCase {
     func test() throws {
         let testHarness = VaultFactoryTestHarness()
         testHarness.mockKeystoreProvider._l1Key = "samplekey".data(using: .utf8)
-        _ = try testHarness.makeVault()
+        _ = try testHarness.makeVault(errorReporter: nil)
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201649423461236/f
Tech Design URL:
CC: @samsymons 

**Description**:
Tries to recreate database file on corruption

see https://github.com/more-duckduckgo-org/macos-browser/pull/417

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
