### PR TITLE
Fix Privcy Config API to correctly take into account feature type

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -66,7 +66,7 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         if let domain = domain,
            isTempUnprotected(domain: domain) ||
             isUserUnprotected(domain: domain) ||
-            isInExceptionList(domain: domain, forFeature: .contentBlocking) {
+            isInExceptionList(domain: domain, forFeature: feature) {
             return false
         }
         return true

--- a/Tests/BrowserServicesKitTests/ContentBlocker/WebViewTestHelper.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/WebViewTestHelper.swift
@@ -88,11 +88,11 @@ final class MockDomainsProtectionStore: DomainsProtectionStore {
     var unprotectedDomains = Set<String>()
 
     func disableProtection(forDomain domain: String) {
-        unprotectedDomains.remove(domain)
+        unprotectedDomains.insert(domain)
     }
 
     func enableProtection(forDomain domain: String) {
-        unprotectedDomains.insert(domain)
+        unprotectedDomains.remove(domain)
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1200194497630846/1201770172458099
Tech Design URL:
CC:

**Description**:

Feature type has been incorrectly passed to code that was supposed to check the breakage exception list.

**Steps to test this PR**:

1. Validate new tests.
2. Smoke tests against Mac OS code.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [x] macOS 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
