### PR TITLE
Report 1p trackers

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/TrackerResolver.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/TrackerResolver.swift
@@ -71,7 +71,7 @@ public class TrackerResolver {
            let pageHost = pageUrl.host,
            let pageEntity = tds.findEntity(forHost: pageHost),
            pageEntity.displayName == entity.displayName {
-            return nil
+            return DetectedTracker(url: trackerUrlString, knownTracker: tracker, entity: entity, blocked: false, pageUrl: pageUrlString)
         }
 
         return DetectedTracker(url: trackerUrlString, knownTracker: tracker, entity: entity, blocked: blocked, pageUrl: pageUrlString)

--- a/Tests/BrowserServicesKitTests/ContentBlocker/TrackerResolverTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/TrackerResolverTests.swift
@@ -135,7 +135,7 @@ class TrackerResolverTests: XCTestCase {
         XCTAssertEqual(result?.knownTracker, tracker)
     }
     
-    func testWhenTrackerIsOnAssociatedPageThenItIsNotReported() {
+    func testWhenTrackerIsOnAssociatedPageThenItIsNotBlocked() {
         
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
@@ -158,7 +158,8 @@ class TrackerResolverTests: XCTestCase {
         
         let result = resolver.trackerFromUrl("https://tracker.com/img/1.png", pageUrlString: "https://example.com", resourceType: "image", potentiallyBlocked: true)
     
-        XCTAssertNil(result)
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result!.blocked)
     }
     
     func testWhenTrackerIsACnameThenItIsReportedAsSuch() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1200835453786799/1201631913848424/f
Tech Design URL:
CC:

**Description**:
This PR reports first party trackers to the dashboard.

**Steps to test this PR**:
1. Go to news.google.com
1. Google trackers should be reported in the dashboard but should not be blocked
2. Text should read "0 Trackers Blocked"

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
