### PR TITLE
Ensure that URL.addParameter only encodes the parameter being added

### DIFF
--- a/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
@@ -74,12 +74,17 @@ extension URL {
 
     public func addParameter(name: String, value: String) throws -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { throw ParameterError.parsingFailed }
-        var queryItems = components.queryItems ?? [URLQueryItem]()
+        var encodedQueryItems = components.percentEncodedQueryItems ?? [URLQueryItem]()
+
         let newQueryItem = URLQueryItem(name: name, value: value)
-        queryItems.append(newQueryItem)
-        components.queryItems = queryItems
+        components.queryItems = [newQueryItem]
         guard let encodedQuery = components.percentEncodedQuery else { throw ParameterError.encodingFailed }
         components.percentEncodedQuery = encodedQuery.encodingPluses()
+
+        guard let encodedNewQueryItem = components.percentEncodedQueryItems?.first else { throw ParameterError.encodingFailed }
+        encodedQueryItems.append(encodedNewQueryItem)
+        components.percentEncodedQueryItems = encodedQueryItems
+
         guard let newUrl = components.url else { throw ParameterError.creatingFailed }
         return newUrl
     }

--- a/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
@@ -44,4 +44,21 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertFalse(url.isRoot)
     }
 
+    func testWhenAddParameterIsCalled_ThenItDoesNotChangeExistingURL() {
+        let url = URL(string: "https://duckduckgo.com/?q=Battlestar+Galactica")!
+
+        XCTAssertEqual(
+            try url.addParameter(name: "ia", value: "web"),
+            URL(string: "https://duckduckgo.com/?q=Battlestar+Galactica&ia=web")!
+        )
+    }
+
+    func testWhenAddParameterIsCalled_ThenItEncodesPlusesInTheParameter() {
+        let url = URL(string: "https://duckduckgo.com/?q=Battlestar+Galactica")!
+
+        XCTAssertEqual(
+            try url.addParameter(name: "ia", value: "web+ios and android"),
+            URL(string: "https://duckduckgo.com/?q=Battlestar+Galactica&ia=web%2Bios%20and%20android")!
+        )
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201865561825271/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1082
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/456

**Description**:
`URL.addParameter` used to call `encodingPluses` on the whole URL query, which had a side effect of potentially changing existing query parameters. I updated the function so that it:
* temporarily replaces existing query with only the parameter being added,
* encodes that parameter alone,
* merges existing encoded query with the newly added encoded parameter.

**Steps to test this PR**:
Note that the bug is only present on MacOS.
1. Search for `Battlestar Galactica`
1. Click in the address field
1. Hit enter
1. The search should be resubmitted, instead of changing to `Battlestar+Galactica`

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
