### PR TITLE
Prompt to store cards and identities

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -252,7 +252,7 @@ extension AutofillUserScript {
         }
 
     }
-    
+     
     func pmStoreData(_ message: AutofillMessage, _ replyHandler: @escaping MessageReplyHandler) {
         defer {
             replyHandler(nil)

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -84,7 +84,7 @@ extension AutofillUserScript {
                                   addressPostalCode: identity.addressPostalCode,
                                   addressCountryCode: identity.addressCountryCode,
                                   phone: identity.homePhone, // Replace with single "phone number" column
-                                  emailAddress: identity.emailAddress)
+                                  emailAddress: identity.emailAddress ?? "")
         }
     }
 

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -135,7 +135,7 @@ extension AutofillUserScript {
     // MARK: - Requests
     
     public struct IncomingCredentials {
-        let username: String
+        let username: String?
         let password: String
     }
     
@@ -159,9 +159,8 @@ extension AutofillUserScript {
             }
             
             if let credentialsDictionary = dictionary["credentials"] as? [String: String],
-               let username = credentialsDictionary["username"],
                let password = credentialsDictionary["password"] {
-                self.credentials = IncomingCredentials(username: username, password: password)
+                self.credentials = IncomingCredentials(username: credentialsDictionary["username"], password: password)
             } else {
                 self.credentials = nil
             }

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -135,6 +135,13 @@ extension AutofillUserScript {
     // MARK: - Requests
     
     public struct IncomingCredentials {
+        
+        private enum Constants {
+            static let credentialsKey = "credentials"
+            static let usernameKey = "credentials"
+            static let passwordKey = "password"
+        }
+        
         let username: String?
         let password: String
         
@@ -144,13 +151,15 @@ extension AutofillUserScript {
         }
         
         init?(autofillDictionary: [String: Any]) {
-            guard let credentialsDictionary = autofillDictionary["credentials"] as? [String: String],
-                  let password = credentialsDictionary["password"] else {
+            guard let credentialsDictionary = autofillDictionary[Constants.credentialsKey] as? [String: String],
+                  let password = credentialsDictionary[Constants.passwordKey] else {
                       return nil
                   }
             
-            self.init(username: credentialsDictionary["username"], password: password)
+            // Usernames are optional, as the Autofill script can pass a generated password through without a corresponding username.
+            self.init(username: credentialsDictionary[Constants.usernameKey], password: password)
         }
+
     }
     
     /// Represents the incoming Autofill data provided by the user script.

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -259,18 +259,18 @@ extension AutofillUserScript {
             replyHandler(nil)
         }
         
-        guard var body = message.messageBody as? [String: Any] else {
+        guard let body = message.messageBody as? [String: Any] else {
             return
         }
         
-        // TODO: Remove this, temporary to make testing easier
-        body["creditCards"] = [
-            "cardNumber": "5555555555555555",
-            "cardholderName": "Test User",
-            "cardSecurityCode": "123",
-            "expirationMonth": 1,
-            "expirationYear": 2025
-        ]
+        // TODO: Remove this, it's temporary to make testing easier
+//        body["creditCards"] = [
+//            "cardNumber": "5555555555555555",
+//            "cardholderName": "Test User",
+//            "cardSecurityCode": "123",
+//            "expirationMonth": 1,
+//            "expirationYear": 2025
+//        ]
         
         let incomingData = DetectedAutofillData(dictionary: body)
         let domain = hostProvider.hostForMessage(message)

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -138,7 +138,7 @@ extension AutofillUserScript {
         
         private enum Constants {
             static let credentialsKey = "credentials"
-            static let usernameKey = "credentials"
+            static let usernameKey = "username"
             static let passwordKey = "password"
         }
         

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -263,15 +263,6 @@ extension AutofillUserScript {
             return
         }
         
-        // TODO: Remove this, it's temporary to make testing easier
-//        body["creditCards"] = [
-//            "cardNumber": "5555555555555555",
-//            "cardholderName": "Test User",
-//            "cardSecurityCode": "123",
-//            "expirationMonth": 1,
-//            "expirationYear": 2025
-//        ]
-        
         let incomingData = DetectedAutofillData(dictionary: body)
         let domain = hostProvider.hostForMessage(message)
         

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -18,6 +18,7 @@
 //
 
 import WebKit
+import os.log
 
 public class AutofillUserScript: NSObject, UserScript {
 
@@ -80,8 +81,11 @@ public class AutofillUserScript: NSObject, UserScript {
 
     internal func messageHandlerFor(_ messageName: String) -> MessageHandler? {
         guard let message = MessageName(rawValue: messageName) else {
+            os_log("Failed to parse Autofill User Script message: '%{public}s'", log: .userScripts, type: .debug, messageName)
             return nil
         }
+        
+        os_log("AutofillUserScript: received '%{public}s'", log: .userScripts, type: .debug, messageName)
 
         switch message {
             case .emailHandlerStoreToken: return emailStoreToken

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -34,7 +34,7 @@ public class AutofillUserScript: NSObject, UserScript {
 
         case pmHandlerGetAutofillInitData
 
-        case pmHandlerStoreCredentials
+        case pmHandlerStoreData
         case pmHandlerGetAccounts
         case pmHandlerGetAutofillCredentials
         case pmHandlerGetIdentity
@@ -75,7 +75,7 @@ public class AutofillUserScript: NSObject, UserScript {
 
         case .pmHandlerGetAutofillInitData: return pmGetAutoFillInitData
 
-        case .pmHandlerStoreCredentials: return pmStoreCredentials
+        case .pmHandlerStoreData: return pmStoreData
         case .pmHandlerGetAccounts: return pmGetAccounts
         case .pmHandlerGetAutofillCredentials: return pmGetAutofillCredentials
 

--- a/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
@@ -44,8 +44,21 @@ extension String {
         return replacingOccurrences(of: "+", with: "%20")
     }
     
-    func normalizingDiacritics() -> String {
-        return self.folding(options: .diacriticInsensitive, locale: .current)
+    func removingCharacters(in set: CharacterSet) -> String {
+      let filtered = unicodeScalars.filter { !set.contains($0) }
+      return String(String.UnicodeScalarView(filtered))
+    }
+    
+    func autofillNormalized() -> String {
+        let autofillCharacterSet = CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters).union(.symbols)
+        
+        var normalizedString = self
+
+        normalizedString = normalizedString.removingCharacters(in: autofillCharacterSet)
+        normalizedString = normalizedString.folding(options: .diacriticInsensitive, locale: .current)
+        normalizedString = normalizedString.localizedLowercase
+        
+        return normalizedString
     }
 
 }

--- a/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
@@ -32,4 +32,9 @@ extension String {
         self.dropping(prefix: "www.")
     }
 
+    func normalizingDiacritics() -> String {
+        return self.folding(options: .diacriticInsensitive, locale: .current)
+    }
+    
 }
+

--- a/Sources/BrowserServicesKit/Common/Logging.swift
+++ b/Sources/BrowserServicesKit/Common/Logging.swift
@@ -34,10 +34,10 @@ extension OSLog {
 
 struct Logging {
 
-    fileprivate static let userScriptsEnabled = true
+    fileprivate static let userScriptsEnabled = false
     fileprivate static let userScriptsLog: OSLog = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo", category: "User Scripts")
     
-    fileprivate static let passwordManagerEnabled = true
+    fileprivate static let passwordManagerEnabled = false
     fileprivate static let passwordManagerLog: OSLog = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo", category: "Password Manager")
 
 }

--- a/Sources/BrowserServicesKit/Common/Logging.swift
+++ b/Sources/BrowserServicesKit/Common/Logging.swift
@@ -1,0 +1,43 @@
+//
+//  Logging.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os
+
+extension OSLog {
+
+    static var userScripts: OSLog {
+        Logging.userScriptsEnabled ? Logging.userScriptsLog : .disabled
+    }
+    
+    static var passwordManager: OSLog {
+        Logging.passwordManagerEnabled ? Logging.passwordManagerLog : .disabled
+    }
+
+}
+
+struct Logging {
+
+    fileprivate static let userScriptsEnabled = true
+    fileprivate static let userScriptsLog: OSLog = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo", category: "User Scripts")
+    
+    fileprivate static let passwordManagerEnabled = true
+    fileprivate static let passwordManagerLog: OSLog = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo", category: "Password Manager")
+
+}

--- a/Sources/BrowserServicesKit/SecureVault/CreditCardValidation.swift
+++ b/Sources/BrowserServicesKit/SecureVault/CreditCardValidation.swift
@@ -31,7 +31,7 @@ public struct CreditCardValidation {
 
         case unknown
 
-        var displayName: String {
+        public var displayName: String {
             switch self {
             case .amex:
                 return "American Express"

--- a/Sources/BrowserServicesKit/SecureVault/SecureVault.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVault.swift
@@ -46,12 +46,14 @@ public protocol SecureVault {
 
     func identities() throws -> [SecureVaultModels.Identity]
     func identityFor(id: Int64) throws -> SecureVaultModels.Identity?
+    func existingIdentityForAutofill(matching proposedIdentity: SecureVaultModels.Identity) throws -> SecureVaultModels.Identity?
     @discardableResult
     func storeIdentity(_ identity: SecureVaultModels.Identity) throws -> Int64
     func deleteIdentityFor(identityId: Int64) throws
 
     func creditCards() throws -> [SecureVaultModels.CreditCard]
     func creditCardFor(id: Int64) throws -> SecureVaultModels.CreditCard?
+    func existingCardForAutofill(matching proposedCard: SecureVaultModels.CreditCard) throws -> SecureVaultModels.CreditCard?
     @discardableResult
     func storeCreditCard(_ card: SecureVaultModels.CreditCard) throws -> Int64
     func deleteCreditCardFor(cardId: Int64) throws
@@ -275,6 +277,14 @@ class DefaultSecureVault: SecureVault {
             try self.providers.database.deleteIdentityForIdentityId(identityId)
         }
     }
+    
+    func existingIdentityForAutofill(matching proposedIdentity: SecureVaultModels.Identity) throws -> SecureVaultModels.Identity? {
+        let identities = try self.identities()
+        
+        return identities.first { existingIdentity in
+            existingIdentity.hasAutofillEquality(comparedTo: proposedIdentity)
+        }
+    }
 
     // MARK: - Credit Cards
 
@@ -302,6 +312,14 @@ class DefaultSecureVault: SecureVault {
             card.cardNumberData = try self.l2Decrypt(data: card.cardNumberData)
 
             return card
+        }
+    }
+    
+    func existingCardForAutofill(matching proposedCard: SecureVaultModels.CreditCard) throws -> SecureVaultModels.CreditCard? {
+        let cards = try self.creditCards()
+        
+        return cards.first { existingCard in
+            existingCard.hasAutofillEquality(comparedTo: proposedCard)
         }
     }
 

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
@@ -878,6 +878,9 @@ extension SecureVaultModels.Identity: PersistableRecord, FetchableRecord {
         homePhone = row[Columns.homePhone]
         mobilePhone = row[Columns.mobilePhone]
         emailAddress = row[Columns.emailAddress]
+        
+        autofillEqualityName = normalizedAutofillName()
+        autofillEqualityAddressStreet = addressStreet?.autofillNormalized()
     }
 
     public func encode(to container: inout PersistenceContainer) {

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -101,7 +101,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                     .first(where: { $0.username == credentials.username }) {
                     proposedCredentials = SecureVaultModels.WebsiteCredentials(account: account, password: passwordData)
                 } else {
-                    let account = SecureVaultModels.WebsiteAccount(username: credentials.username, domain: domain)
+                    let account = SecureVaultModels.WebsiteAccount(username: credentials.username ?? "", domain: domain)
                     proposedCredentials = SecureVaultModels.WebsiteCredentials(account: account, password: passwordData)
                 }
             }

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -160,7 +160,10 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
         var proposedIdentity: SecureVaultModels.Identity?
         
         if let identity = autofillData.identity, try vault.existingIdentityForAutofill(matching: identity) == nil {
+            os_log("Got new identity/address to save", log: .passwordManager, type: .info)
             proposedIdentity = identity
+        } else {
+            os_log("No identity/address, avoid prompting user", log: .passwordManager, type: .info)
         }
         
         // Determine if the credentials should be sent to the client app:
@@ -175,12 +178,15 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                 if let existingAccountID = account.id,
                    let existingCredentials = try vault.websiteCredentialsFor(accountId: existingAccountID),
                    existingCredentials.password == passwordData {
+                    os_log("Found duplicate credentials, avoid prompting user", log: .passwordManager, type: .info)
                     proposedCredentials = nil
                 } else {
+                    os_log("Found existing credentials to update", log: .passwordManager, type: .info)
                     proposedCredentials = SecureVaultModels.WebsiteCredentials(account: account, password: passwordData)
                 }
 
             } else {
+                os_log("Received new credentials to save", log: .passwordManager, type: .info)
                 let account = SecureVaultModels.WebsiteAccount(username: credentials.username ?? "", domain: domain)
                 proposedCredentials = SecureVaultModels.WebsiteCredentials(account: account, password: passwordData)
             }
@@ -191,7 +197,10 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
         var proposedCard: SecureVaultModels.CreditCard?
         
         if let card = autofillData.creditCard, try vault.existingCardForAutofill(matching: card) == nil {
+            os_log("Got new payment method to save", log: .passwordManager, type: .info)
             proposedCard = card
+        } else {
+            os_log("No payment method, avoid prompting user", log: .passwordManager, type: .info)
         }
         
         // Assemble data and send to the delegate:

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -160,10 +160,10 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
         var proposedIdentity: SecureVaultModels.Identity?
         
         if let identity = autofillData.identity, try vault.existingIdentityForAutofill(matching: identity) == nil {
-            os_log("Got new identity/address to save", log: .passwordManager, type: .info)
+            os_log("Got new identity/address to save", log: .passwordManager)
             proposedIdentity = identity
         } else {
-            os_log("No new identity/address found, avoid prompting user", log: .passwordManager, type: .info)
+            os_log("No new identity/address found, avoid prompting user", log: .passwordManager)
         }
         
         // Determine if the credentials should be sent to the client app:
@@ -178,20 +178,20 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                 if let existingAccountID = account.id,
                    let existingCredentials = try vault.websiteCredentialsFor(accountId: existingAccountID),
                    existingCredentials.password == passwordData {
-                    os_log("Found duplicate credentials, avoid prompting user", log: .passwordManager, type: .info)
+                    os_log("Found duplicate credentials, avoid prompting user", log: .passwordManager)
                     proposedCredentials = nil
                 } else {
-                    os_log("Found existing credentials to update", log: .passwordManager, type: .info)
+                    os_log("Found existing credentials to update", log: .passwordManager)
                     proposedCredentials = SecureVaultModels.WebsiteCredentials(account: account, password: passwordData)
                 }
 
             } else {
-                os_log("Received new credentials to save", log: .passwordManager, type: .info)
+                os_log("Received new credentials to save", log: .passwordManager)
                 let account = SecureVaultModels.WebsiteAccount(username: credentials.username ?? "", domain: domain)
                 proposedCredentials = SecureVaultModels.WebsiteCredentials(account: account, password: passwordData)
             }
         } else {
-            os_log("No new credentials found, avoid prompting user", log: .passwordManager, type: .info)
+            os_log("No new credentials found, avoid prompting user", log: .passwordManager)
         }
         
         // Determine if the payment method should be sent to the client app:
@@ -199,10 +199,10 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
         var proposedCard: SecureVaultModels.CreditCard?
         
         if let card = autofillData.creditCard, try vault.existingCardForAutofill(matching: card) == nil {
-            os_log("Got new payment method to save", log: .passwordManager, type: .info)
+            os_log("Got new payment method to save", log: .passwordManager)
             proposedCard = card
         } else {
-            os_log("No new payment method found, avoid prompting user", log: .passwordManager, type: .info)
+            os_log("No new payment method found, avoid prompting user", log: .passwordManager)
         }
         
         // Assemble data and send to the delegate:

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -163,7 +163,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
             os_log("Got new identity/address to save", log: .passwordManager, type: .info)
             proposedIdentity = identity
         } else {
-            os_log("No identity/address, avoid prompting user", log: .passwordManager, type: .info)
+            os_log("No new identity/address found, avoid prompting user", log: .passwordManager, type: .info)
         }
         
         // Determine if the credentials should be sent to the client app:
@@ -190,6 +190,8 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                 let account = SecureVaultModels.WebsiteAccount(username: credentials.username ?? "", domain: domain)
                 proposedCredentials = SecureVaultModels.WebsiteCredentials(account: account, password: passwordData)
             }
+        } else {
+            os_log("No new credentials found, avoid prompting user", log: .passwordManager, type: .info)
         }
         
         // Determine if the payment method should be sent to the client app:
@@ -200,7 +202,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
             os_log("Got new payment method to save", log: .passwordManager, type: .info)
             proposedCard = card
         } else {
-            os_log("No payment method, avoid prompting user", log: .passwordManager, type: .info)
+            os_log("No new payment method found, avoid prompting user", log: .passwordManager, type: .info)
         }
         
         // Assemble data and send to the delegate:

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -218,14 +218,14 @@ public struct SecureVaultModels {
             return nameFormatter
         }()
         
-        public lazy var formattedName: String = {
+        public var formattedName: String {
             var nameComponents = PersonNameComponents()
             nameComponents.givenName = firstName
             nameComponents.middleName = middleName
             nameComponents.familyName = lastName
 
             return Self.personNameComponentsFormatter.string(from: nameComponents)
-        }()
+        }
         
         private(set) var autofillEqualityName: String?
         private(set) var autofillEqualityAddressStreet: String?

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -211,20 +211,34 @@ public struct SecureVaultModels {
 
     public struct Identity {
 
-        private static let personNameComponentsFormatter: PersonNameComponentsFormatter = {
+        private static let mediumPersonNameComponentsFormatter: PersonNameComponentsFormatter = {
             let nameFormatter = PersonNameComponentsFormatter()
             nameFormatter.style = .medium
-
             return nameFormatter
         }()
         
-        public var formattedName: String {
+        private static let longPersonNameComponentsFormatter: PersonNameComponentsFormatter = {
+            let nameFormatter = PersonNameComponentsFormatter()
+            nameFormatter.style = .long
+            return nameFormatter
+        }()
+        
+        private var nameComponents: PersonNameComponents {
             var nameComponents = PersonNameComponents()
+
             nameComponents.givenName = firstName
             nameComponents.middleName = middleName
             nameComponents.familyName = lastName
 
-            return Self.personNameComponentsFormatter.string(from: nameComponents)
+            return nameComponents
+        }
+        
+        public var formattedName: String {
+            return Self.mediumPersonNameComponentsFormatter.string(from: nameComponents)
+        }
+        
+        public var longFormattedName: String {
+            return Self.longPersonNameComponentsFormatter.string(from: nameComponents)
         }
         
         var autofillEqualityName: String?

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -125,7 +125,7 @@ public struct SecureVaultModels {
             self.init(id: nil,
                       title: nil,
                       cardNumber: cardNumber,
-                      cardholderName: dictionary["cardholderName"] as? String,
+                      cardholderName: dictionary["cardName"] as? String,
                       cardSecurityCode: dictionary["cardSecurityCode"] as? String,
                       expirationMonth: Int(dictionary["expirationMonth"] as? String ?? ""),
                       expirationYear: Int(dictionary["expirationYear"] as? String ?? ""))

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -75,9 +75,9 @@ public struct SecureVaultModels {
             static let creditCardsKey = "creditCards"
             static let cardNumberKey = "cardNumber"
             static let cardNameKey = "cardName"
-            static let cardSecurityCodeKey = "cardSecurityCodeKey"
-            static let expirationMonthKey = "expirationMonthKey"
-            static let expirationYearKey = "expirationYearKey"
+            static let cardSecurityCodeKey = "cardSecurityCode"
+            static let expirationMonthKey = "expirationMonth"
+            static let expirationYearKey = "expirationYear"
         }
         
         public var id: Int64?

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -127,8 +127,8 @@ public struct SecureVaultModels {
                       cardNumber: cardNumber,
                       cardholderName: dictionary["cardholderName"] as? String,
                       cardSecurityCode: dictionary["cardSecurityCode"] as? String,
-                      expirationMonth: dictionary["expirationMonth"] as? Int,
-                      expirationYear: dictionary["expirationYear"] as? Int)
+                      expirationMonth: Int(dictionary["expirationMonth"] as? String ?? ""),
+                      expirationYear: Int(dictionary["expirationYear"] as? String ?? ""))
         }
 
     }

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -71,6 +71,15 @@ public struct SecureVaultModels {
 
     public struct CreditCard {
 
+        private enum Constants {
+            static let creditCardsKey = "creditCards"
+            static let cardNumberKey = "cardNumber"
+            static let cardNameKey = "cardName"
+            static let cardSecurityCodeKey = "cardSecurityCodeKey"
+            static let expirationMonthKey = "expirationMonthKey"
+            static let expirationYearKey = "expirationYearKey"
+        }
+        
         public var id: Int64?
         public var title: String
         public let created: Date
@@ -118,7 +127,7 @@ public struct SecureVaultModels {
         }
         
         public init?(autofillDictionary: [String: Any]) {
-            guard let creditCardsDictionary = autofillDictionary["creditCards"] as? [String: Any] else {
+            guard let creditCardsDictionary = autofillDictionary[Constants.creditCardsKey] as? [String: Any] else {
                 return nil
             }
             
@@ -126,17 +135,17 @@ public struct SecureVaultModels {
         }
         
         public init?(creditCardsDictionary: [String: Any]) {
-            guard let cardNumber = creditCardsDictionary["cardNumber"] as? String else {
+            guard let cardNumber = creditCardsDictionary[Constants.cardNumberKey] as? String else {
                 return nil
             }
 
             self.init(id: nil,
                       title: nil,
                       cardNumber: cardNumber,
-                      cardholderName: creditCardsDictionary["cardName"] as? String,
-                      cardSecurityCode: creditCardsDictionary["cardSecurityCode"] as? String,
-                      expirationMonth: Int(creditCardsDictionary["expirationMonth"] as? String ?? ""),
-                      expirationYear: Int(creditCardsDictionary["expirationYear"] as? String ?? ""))
+                      cardholderName: creditCardsDictionary[Constants.cardNameKey] as? String,
+                      cardSecurityCode: creditCardsDictionary[Constants.cardSecurityCodeKey] as? String,
+                      expirationMonth: Int(creditCardsDictionary[Constants.expirationMonthKey] as? String ?? ""),
+                      expirationYear: Int(creditCardsDictionary[Constants.expirationYearKey] as? String ?? ""))
         }
 
     }

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -389,7 +389,7 @@ extension SecureVaultModels.Identity: SecureVaultAutofillEquatable {
 extension SecureVaultModels.CreditCard: SecureVaultAutofillEquatable {
     
     func hasAutofillEquality(comparedTo object: Self) -> Bool {
-        if self.cardNumber == object.cardNumber {
+        if self.cardNumber.autofillNormalized() == object.cardNumber.autofillNormalized() {
             return true
         }
         

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -117,18 +117,26 @@ public struct SecureVaultModels {
             self.expirationYear = expirationYear
         }
         
-        public init?(dictionary: [String: Any]) {
-            guard let cardNumber = dictionary["cardNumber"] as? String else {
+        public init?(autofillDictionary: [String: Any]) {
+            guard let creditCardsDictionary = autofillDictionary["creditCards"] as? [String: Any] else {
+                return nil
+            }
+            
+            self.init(creditCardsDictionary: creditCardsDictionary)
+        }
+        
+        public init?(creditCardsDictionary: [String: Any]) {
+            guard let cardNumber = creditCardsDictionary["cardNumber"] as? String else {
                 return nil
             }
 
             self.init(id: nil,
                       title: nil,
                       cardNumber: cardNumber,
-                      cardholderName: dictionary["cardName"] as? String,
-                      cardSecurityCode: dictionary["cardSecurityCode"] as? String,
-                      expirationMonth: Int(dictionary["expirationMonth"] as? String ?? ""),
-                      expirationYear: Int(dictionary["expirationYear"] as? String ?? ""))
+                      cardholderName: creditCardsDictionary["cardName"] as? String,
+                      cardSecurityCode: creditCardsDictionary["cardSecurityCode"] as? String,
+                      expirationMonth: Int(creditCardsDictionary["expirationMonth"] as? String ?? ""),
+                      expirationYear: Int(creditCardsDictionary["expirationYear"] as? String ?? ""))
         }
 
     }
@@ -185,9 +193,7 @@ public struct SecureVaultModels {
                 return firstNonEmptyLine ?? ""
             }
 
-            // The title's empty, so assume that the first non-empty line is used as the title, and find the second non-
-            // empty line instead.
-            
+            // The title is empty, so assume that the first non-empty line is used as the title, and find the second non-empty line instead.
             let noteLines = text.components(separatedBy: .newlines)
             var alreadyFoundFirstNonEmptyLine = false
             
@@ -336,26 +342,34 @@ public struct SecureVaultModels {
             self.autofillEqualityAddressStreet = addressStreet?.autofillNormalized()
         }
         
-        public init(dictionary: [String: Any]) {
+        public init?(autofillDictionary: [String: Any]) {
+            guard let dictionary = autofillDictionary["identities"] as? [String: Any] else {
+                return nil
+            }
+            
+            self.init(identityDictionary: dictionary)
+        }
+
+        public init(identityDictionary: [String: Any]) {
             self.init(id: nil,
                       title: nil,
                       created: Date(),
                       lastUpdated: Date(),
-                      firstName: dictionary["firstName"] as? String,
-                      middleName: dictionary["middleName"] as? String,
-                      lastName: dictionary["lastName"] as? String,
-                      birthdayDay: dictionary["birthdayDay"] as? Int,
-                      birthdayMonth: dictionary["birthdayMonth"] as? Int,
-                      birthdayYear: dictionary["birthdayYear"] as? Int,
-                      addressStreet: dictionary["addressStreet"] as? String,
-                      addressStreet2: dictionary["addressStreet2"] as? String,
-                      addressCity: dictionary["addressCity"] as? String,
-                      addressProvince: dictionary["addressProvince"] as? String,
-                      addressPostalCode: dictionary["addressPostalCode"] as? String,
-                      addressCountryCode: dictionary["addressCountryCode"] as? String,
-                      homePhone: dictionary["phone"] as? String,
+                      firstName: identityDictionary["firstName"] as? String,
+                      middleName: identityDictionary["middleName"] as? String,
+                      lastName: identityDictionary["lastName"] as? String,
+                      birthdayDay: identityDictionary["birthdayDay"] as? Int,
+                      birthdayMonth: identityDictionary["birthdayMonth"] as? Int,
+                      birthdayYear: identityDictionary["birthdayYear"] as? Int,
+                      addressStreet: identityDictionary["addressStreet"] as? String,
+                      addressStreet2: identityDictionary["addressStreet2"] as? String,
+                      addressCity: identityDictionary["addressCity"] as? String,
+                      addressProvince: identityDictionary["addressProvince"] as? String,
+                      addressPostalCode: identityDictionary["addressPostalCode"] as? String,
+                      addressCountryCode: identityDictionary["addressCountryCode"] as? String,
+                      homePhone: identityDictionary["phone"] as? String,
                       mobilePhone: nil,
-                      emailAddress: dictionary["emailAddress"] as? String)
+                      emailAddress: identityDictionary["emailAddress"] as? String)
         }
 
         func normalizedAutofillName() -> String {

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -218,13 +218,18 @@ public struct SecureVaultModels {
             return nameFormatter
         }()
         
-        public var formattedName: String {
+        public lazy var formattedName: String = {
             var nameComponents = PersonNameComponents()
             nameComponents.givenName = firstName
             nameComponents.middleName = middleName
             nameComponents.familyName = lastName
 
             return Self.personNameComponentsFormatter.string(from: nameComponents)
+        }()
+        
+        var autofillEqualityName: String {
+            let nameString = (firstName ?? "") + (middleName ?? "") + (lastName ?? "")
+            return nameString.autofillNormalized()
         }
 
         public var id: Int64?
@@ -333,12 +338,13 @@ protocol SecureVaultAutofillEquatable {
 
 extension SecureVaultModels.Identity: SecureVaultAutofillEquatable {
 
-    func hasAutofillEquality(comparedTo object: SecureVaultModels.Identity) -> Bool {
-        if self.formattedName.normalizingDiacritics() != object.formattedName.normalizingDiacritics() {
+    func hasAutofillEquality(comparedTo otherIdentity: SecureVaultModels.Identity) -> Bool {
+        // TODO: Avoid doing the normalization work on the fly, it should be cached on each object.
+        if self.autofillEqualityName != otherIdentity.autofillEqualityName {
             return false
         }
         
-        if self.addressStreet?.normalizingDiacritics() != object.addressStreet?.normalizingDiacritics() {
+        if self.addressStreet?.autofillNormalized() != otherIdentity.addressStreet?.autofillNormalized() {
             return false
         }
         

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -340,15 +340,11 @@ extension SecureVaultModels.Identity: SecureVaultAutofillEquatable {
 
     func hasAutofillEquality(comparedTo otherIdentity: SecureVaultModels.Identity) -> Bool {
         // TODO: Avoid doing the normalization work on the fly, it should be cached on each object.
-        if self.autofillEqualityName != otherIdentity.autofillEqualityName {
-            return false
-        }
+
+        let hasNameEquality = self.autofillEqualityName == otherIdentity.autofillEqualityName
+        let hasAddressEquality = self.addressStreet?.autofillNormalized() == otherIdentity.addressStreet?.autofillNormalized()
         
-        if self.addressStreet?.autofillNormalized() != otherIdentity.addressStreet?.autofillNormalized() {
-            return false
-        }
-        
-        return true
+        return hasNameEquality && hasAddressEquality
     }
     
 }

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -227,8 +227,8 @@ public struct SecureVaultModels {
             return Self.personNameComponentsFormatter.string(from: nameComponents)
         }
         
-        private(set) var autofillEqualityName: String?
-        private(set) var autofillEqualityAddressStreet: String?
+        var autofillEqualityName: String?
+        var autofillEqualityAddressStreet: String?
 
         public var id: Int64?
         public var title: String
@@ -339,12 +339,12 @@ public struct SecureVaultModels {
                       addressProvince: dictionary["addressProvince"] as? String,
                       addressPostalCode: dictionary["addressPostalCode"] as? String,
                       addressCountryCode: dictionary["addressCountryCode"] as? String,
-                      homePhone: dictionary["homePhone"] as? String,
-                      mobilePhone: dictionary["mobilePhone"] as? String,
+                      homePhone: dictionary["phone"] as? String,
+                      mobilePhone: nil,
                       emailAddress: dictionary["emailAddress"] as? String)
         }
-        
-        private func normalizedAutofillName() -> String {
+
+        func normalizedAutofillName() -> String {
             let nameString = (firstName ?? "") + (middleName ?? "") + (lastName ?? "")
             return nameString.autofillNormalized()
         }

--- a/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
@@ -298,6 +298,45 @@ class AutofillVaultUserScriptTests: XCTestCase {
 
         XCTAssertEqual(delegate.lastDomain, "example.com")
     }
+    
+    func testWhenInitializingAutofillData_WhenCredentialsAreProvidedWithoutAUsername_ThenAutofillDataIsStillInitialized() {
+        let password = "password"
+        let detectedAutofillData = [
+            "credentials": [
+                "password": password
+            ]
+        ]
+        
+        let autofillData = AutofillUserScript.DetectedAutofillData(dictionary: detectedAutofillData)
+        
+        XCTAssertNil(autofillData.creditCard)
+        XCTAssertNil(autofillData.identity)
+        XCTAssertNotNil(autofillData.credentials)
+        
+        XCTAssertEqual(autofillData.credentials?.username, nil)
+        XCTAssertEqual(autofillData.credentials?.password, password)
+    }
+    
+    func testWhenInitializingAutofillData_WhenCredentialsAreProvidedWithAUsername_ThenAutofillDataIsStillInitialized() {
+        let username = "username"
+        let password = "password"
+        
+        let detectedAutofillData = [
+            "credentials": [
+                "username": username,
+                "password": password
+            ]
+        ]
+        
+        let autofillData = AutofillUserScript.DetectedAutofillData(dictionary: detectedAutofillData)
+        
+        XCTAssertNil(autofillData.creditCard)
+        XCTAssertNil(autofillData.identity)
+        XCTAssertNotNil(autofillData.credentials)
+        
+        XCTAssertEqual(autofillData.credentials?.username, username)
+        XCTAssertEqual(autofillData.credentials?.password, password)
+    }
 
 }
 

--- a/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
@@ -137,17 +137,16 @@ class AutofillVaultUserScriptTests: XCTestCase {
     }
 
     @available(macOS 11, iOS 14, *)
-    func testWhenStoreCredentialsCalled_ThenDelegateIsCalled() {
+    func testWhenStoreDataCalled_ThenDelegateIsCalled() {
 
         let delegate = MockSecureVaultDelegate()
         userScript.vaultDelegate = delegate
 
         var body = encryptedMessagingParams
-        body["username"] = "username@example.com"
-        body["password"] = "password"
+        body["credentials"] = ["username": "username@example.com", "password": "password"]
 
         let mockWebView = MockWebView()
-        let message = MockAutofillMessage(name: "pmHandlerStoreCredentials", body: body,
+        let message = MockAutofillMessage(name: "pmHandlerStoreData", body: body,
                                           host: "example.com", webView: mockWebView)
 
         userScript.processMessage(userContentController, didReceive: message)
@@ -312,12 +311,10 @@ class MockSecureVaultDelegate: AutofillSecureVaultDelegate {
         lastDomain = domain
     }
 
-    func autofillUserScript(_: AutofillUserScript, didRequestStoreCredentialsForDomain domain: String,
-                            username: String,
-                            password: String) {
+    func autofillUserScript(_: AutofillUserScript, didRequestStoreDataForDomain domain: String, data: AutofillUserScript.DetectedAutofillData) {
         lastDomain = domain
-        lastUsername = username
-        lastPassword = password
+        lastUsername = data.credentials?.username
+        lastPassword = data.credentials?.password
     }
 
     func autofillUserScript(_: AutofillUserScript,

--- a/Tests/BrowserServicesKitTests/Common/Extensions/StringExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/StringExtensionTests.swift
@@ -1,8 +1,19 @@
 //
 //  StringExtensionTests.swift
-//  
 //
-//  Created by Sam Symons on 2022-02-26.
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Tests/BrowserServicesKitTests/Common/Extensions/StringExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/StringExtensionTests.swift
@@ -12,11 +12,46 @@ import XCTest
 
 final class StringExtensionTests: XCTestCase {
 
-    func testWhenNormalizingDiacritics_ThenDiacriticsAreRemoved() {
-        let stringToNormalize = "àáâäãåāèéêëēėęîïíīįìôöòóōõûüùúū"
-        let normalizedString = stringToNormalize.normalizingDiacritics()
+    func testWhenNormalizingStringsForAutofill_ThenDiacriticsAreRemoved() {
+        let stringToNormalize = "Dáx Thê Dûck"
+        let normalizedString = stringToNormalize.autofillNormalized()
         
-        XCTAssertEqual(normalizedString, "aaaaaaaeeeeeeeiiiiiioooooouuuuu")
+        XCTAssertEqual(normalizedString, "daxtheduck")
+    }
+    
+    func testWhenNormalizingStringsForAutofill_ThenWhitespaceIsRemoved() {
+        let stringToNormalize = "Dax The Duck"
+        let normalizedString = stringToNormalize.autofillNormalized()
+        
+        XCTAssertEqual(normalizedString, "daxtheduck")
+    }
+    
+    func testWhenNormalizingStringsForAutofill_ThenPunctuationIsRemoved() {
+        let stringToNormalize = ",Dax+The_Duck."
+        let normalizedString = stringToNormalize.autofillNormalized()
+        
+        XCTAssertEqual(normalizedString, "daxtheduck")
+    }
+    
+    func testWhenNormalizingStringsForAutofill_ThenNumbersAreRetained() {
+        let stringToNormalize = "Dax123"
+        let normalizedString = stringToNormalize.autofillNormalized()
+        
+        XCTAssertEqual(normalizedString, "dax123")
+    }
+    
+    func testWhenNormalizingStringsForAutofill_ThenStringsThatDoNotNeedNormalizationAreUntouched() {
+        let stringToNormalize = "firstmiddlelast"
+        let normalizedString = stringToNormalize.autofillNormalized()
+        
+        XCTAssertEqual(normalizedString, "firstmiddlelast")
+    }
+    
+    func testWhenNormalizingStringsForAutofill_ThenEmojiAreRemoved() {
+        let stringToNormalize = "Dax 🤔"
+        let normalizedString = stringToNormalize.autofillNormalized()
+        
+        XCTAssertEqual(normalizedString, "dax")
     }
 
 }

--- a/Tests/BrowserServicesKitTests/Common/Extensions/StringExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/StringExtensionTests.swift
@@ -1,0 +1,22 @@
+//
+//  StringExtensionTests.swift
+//  
+//
+//  Created by Sam Symons on 2022-02-26.
+//
+
+import Foundation
+
+import XCTest
+@testable import BrowserServicesKit
+
+final class StringExtensionTests: XCTestCase {
+
+    func testWhenNormalizingDiacritics_ThenDiacriticsAreRemoved() {
+        let stringToNormalize = "àáâäãåāèéêëēėęîïíīįìôöòóōõûüùúū"
+        let normalizedString = stringToNormalize.normalizingDiacritics()
+        
+        XCTAssertEqual(normalizedString, "aaaaaaaeeeeeeeiiiiiioooooouuuuu")
+    }
+
+}

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
@@ -1,0 +1,59 @@
+//
+//  SecureVaultModelTests.swift
+//  
+//
+//  Created by Sam Symons on 2022-02-26.
+//
+
+import Foundation
+import XCTest
+@testable import BrowserServicesKit
+
+class SecureVaultModelTests: XCTestCase {
+
+    func testWhenIdentitiesHaveTheSameNames_ThenAutoFillEqualityIsTrue() {
+        let identity1 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+        let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+        
+        XCTAssertTrue(identity1.hasAutofillEquality(comparedTo: identity2))
+    }
+    
+    func testWhenIdentitiesHaveTheSameNames_AndSomeNamesHaveDiacritics_ThenAutoFillEqualityIsTrue() {
+        let identity1 = identity(named: ("Fírst", "Mïddlé", "Lâst"), addressStreet: "Address Street")
+        let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+        
+        XCTAssertTrue(identity1.hasAutofillEquality(comparedTo: identity2))
+    }
+    
+    func testWhenIdentitiesHaveDifferentNames_ButOtherValuesMatch_ThenAutofillEqualityIsFalse() {
+        let identity1 = identity(named: ("One", "Two", "Three"), addressStreet: "Address Street")
+        let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+        
+        XCTAssertFalse(identity1.hasAutofillEquality(comparedTo: identity2))
+    }
+    
+    // MARK: - Test Utilities
+    
+    private func identity(named name: (String, String, String), addressStreet: String) -> SecureVaultModels.Identity {
+        return SecureVaultModels.Identity(id: nil,
+                                          title: nil,
+                                          created: Date(),
+                                          lastUpdated: Date(),
+                                          firstName: name.0,
+                                          middleName: name.1,
+                                          lastName: name.2,
+                                          birthdayDay: nil,
+                                          birthdayMonth: nil,
+                                          birthdayYear: nil,
+                                          addressStreet: nil,
+                                          addressStreet2: nil,
+                                          addressCity: nil,
+                                          addressProvince: nil,
+                                          addressPostalCode: nil,
+                                          addressCountryCode: nil,
+                                          homePhone: nil,
+                                          mobilePhone: nil,
+                                          emailAddress: nil)
+    }
+
+}

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
@@ -18,8 +18,29 @@ class SecureVaultModelTests: XCTestCase {
         XCTAssertTrue(identity1.hasAutofillEquality(comparedTo: identity2))
     }
     
+    func testWhenIdentitiesHaveTheSameNames_AndHaveArbitraryWhitespace_ThenAutoFillEqualityIsTrue() {
+        let identity1 = identity(named: ("First ", " Middle", " Last"), addressStreet: " Address Street ")
+        let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+        
+        XCTAssertTrue(identity1.hasAutofillEquality(comparedTo: identity2))
+    }
+    
     func testWhenIdentitiesHaveTheSameNames_AndSomeNamesHaveDiacritics_ThenAutoFillEqualityIsTrue() {
         let identity1 = identity(named: ("Fírst", "Mïddlé", "Lâst"), addressStreet: "Address Street")
+        let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+        
+        XCTAssertTrue(identity1.hasAutofillEquality(comparedTo: identity2))
+    }
+    
+    func testWhenIdentitiesHaveTheSameNames_AndSomeNamesHaveEmoji_ThenAutoFillEqualityIsTrue() {
+        let identity1 = identity(named: ("First 😎", "Middle", "Last"), addressStreet: "Address Street")
+        let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+        
+        XCTAssertTrue(identity1.hasAutofillEquality(comparedTo: identity2))
+    }
+    
+    func testWhenIdentitiesHaveTheFullNameInOneField_ThenAutoFillEqualityIsTrue() {
+        let identity1 = identity(named: ("First Middle Last", "", ""), addressStreet: "Address Street")
         let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
         
         XCTAssertTrue(identity1.hasAutofillEquality(comparedTo: identity2))

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
@@ -18,6 +18,20 @@ class SecureVaultModelTests: XCTestCase {
         XCTAssertTrue(identity1.hasAutofillEquality(comparedTo: identity2))
     }
     
+    func testWhenIdentitiesHaveTheSameNames_AndNoAddress_ThenAutoFillEqualityIsTrue() {
+        let identity1 = identity(named: ("First", "Middle", "Last"), addressStreet: nil)
+        let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: nil)
+        
+        XCTAssertTrue(identity1.hasAutofillEquality(comparedTo: identity2))
+    }
+    
+    func testWhenIdentitiesHaveTheSameNames_AndDifferentAddresses_ThenAutoFillEqualityIsFalse() {
+        let identity1 = identity(named: ("First", "Middle", "Last"), addressStreet: "First Address")
+        let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Second Address")
+        
+        XCTAssertFalse(identity1.hasAutofillEquality(comparedTo: identity2))
+    }
+    
     func testWhenIdentitiesHaveTheSameNames_AndHaveArbitraryWhitespace_ThenAutoFillEqualityIsTrue() {
         let identity1 = identity(named: ("First ", " Middle", " Last"), addressStreet: " Address Street ")
         let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
@@ -55,7 +69,7 @@ class SecureVaultModelTests: XCTestCase {
     
     // MARK: - Test Utilities
     
-    private func identity(named name: (String, String, String), addressStreet: String) -> SecureVaultModels.Identity {
+    private func identity(named name: (String, String, String), addressStreet: String?) -> SecureVaultModels.Identity {
         return SecureVaultModels.Identity(id: nil,
                                           title: nil,
                                           created: Date(),
@@ -66,7 +80,7 @@ class SecureVaultModelTests: XCTestCase {
                                           birthdayDay: nil,
                                           birthdayMonth: nil,
                                           birthdayYear: nil,
-                                          addressStreet: nil,
+                                          addressStreet: addressStreet,
                                           addressStreet2: nil,
                                           addressCity: nil,
                                           addressProvince: nil,

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
@@ -1,8 +1,19 @@
 //
 //  SecureVaultModelTests.swift
-//  
 //
-//  Created by Sam Symons on 2022-02-26.
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation
@@ -10,6 +21,29 @@ import XCTest
 @testable import BrowserServicesKit
 
 class SecureVaultModelTests: XCTestCase {
+    
+    func testWhenCreatingIdentities_ThenTheyHaveCachedAutofillProperties() {
+        let identity = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+
+        XCTAssertEqual(identity.autofillEqualityName, "firstmiddlelast")
+        XCTAssertEqual(identity.autofillEqualityAddressStreet, "addressstreet")
+    }
+
+    
+    func testWhenCreatingIdentities_AndTheyHaveCachedAutofillProperties_ThenMutatingThePropertiesUpdatesTheCachedVersions() {
+        var identity = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+
+        XCTAssertEqual(identity.autofillEqualityName, "firstmiddlelast")
+        XCTAssertEqual(identity.autofillEqualityAddressStreet, "addressstreet")
+        
+        identity.firstName = "Dax"
+        identity.middleName = "The"
+        identity.lastName = "Duck"
+        identity.addressStreet = "New Street"
+        
+        XCTAssertEqual(identity.autofillEqualityName, "daxtheduck")
+        XCTAssertEqual(identity.autofillEqualityAddressStreet, "newstreet")
+    }
 
     func testWhenIdentitiesHaveTheSameNames_ThenAutoFillEqualityIsTrue() {
         let identity1 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
@@ -65,6 +99,20 @@ class SecureVaultModelTests: XCTestCase {
         let identity2 = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
         
         XCTAssertFalse(identity1.hasAutofillEquality(comparedTo: identity2))
+    }
+    
+    func testIdentityEqualityPerformance() {
+        let identity = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
+        
+        let identitiesToCheck = (1...10000).map {
+            return self.identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street \($0)")
+        }
+
+        measure {
+            for identityToCheck in identitiesToCheck {
+                _ = identity.hasAutofillEquality(comparedTo: identityToCheck)
+            }
+        }
     }
     
     // MARK: - Test Utilities

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
@@ -22,6 +22,8 @@ import XCTest
 
 class SecureVaultModelTests: XCTestCase {
     
+    // MARK: - Identities
+    
     func testWhenCreatingIdentities_ThenTheyHaveCachedAutofillProperties() {
         let identity = identity(named: ("First", "Middle", "Last"), addressStreet: "Address Street")
 
@@ -115,6 +117,43 @@ class SecureVaultModelTests: XCTestCase {
         }
     }
     
+    // MARK: - Payment Methods
+
+    func testWhenCardNumbersAreTheSame_ThenAutofillEqualityIsTrue() {
+        let card1 = paymentMethod(cardNumber: "5555555555555557", cardholderName: "Name", cvv: "123", month: 1, year: 3000)
+        let card2 = paymentMethod(cardNumber: "5555555555555557", cardholderName: "Name", cvv: "123", month: 1, year: 3000)
+        
+        XCTAssertTrue(card1.hasAutofillEquality(comparedTo: card2))
+    }
+    
+    func testWhenCardNumbersAreTheSame_ButTheyHaveDifferentSpacing_ThenAutofillEqualityIsTrue() {
+        let card1 = paymentMethod(cardNumber: "5555555555555557", cardholderName: "Name", cvv: "123", month: 1, year: 3000)
+        let card2 = paymentMethod(cardNumber: "5555 5555 5555 5557", cardholderName: "Name", cvv: "123", month: 1, year: 3000)
+        
+        XCTAssertTrue(card1.hasAutofillEquality(comparedTo: card2))
+    }
+    
+    func testWhenCardNumbersAreDifferent_ThenAutofillEqualityIsFalse() {
+        let card1 = paymentMethod(cardNumber: "1234 1234 1234 1234", cardholderName: "Name", cvv: "123", month: 1, year: 3000)
+        let card2 = paymentMethod(cardNumber: "5555 5555 5555 5557", cardholderName: "Name", cvv: "123", month: 1, year: 3000)
+        
+        XCTAssertFalse(card1.hasAutofillEquality(comparedTo: card2))
+    }
+    
+    func testPaymentMethodEqualityPerformance() {
+        let paymentMethod = paymentMethod(cardNumber: "5555555555555557", cardholderName: "Name", cvv: "123", month: 1, year: 3000)
+        
+        let cardsToCheck = (1...10000).map {
+            return self.paymentMethod(cardNumber: "5555555555555557", cardholderName: "Name \($0)", cvv: "123", month: 1, year: 3000)
+        }
+
+        measure {
+            for cardToCheck in cardsToCheck {
+                _ = paymentMethod.hasAutofillEquality(comparedTo: cardToCheck)
+            }
+        }
+    }
+    
     // MARK: - Test Utilities
     
     private func identity(named name: (String, String, String), addressStreet: String?) -> SecureVaultModels.Identity {
@@ -137,6 +176,20 @@ class SecureVaultModelTests: XCTestCase {
                                           homePhone: nil,
                                           mobilePhone: nil,
                                           emailAddress: nil)
+    }
+    
+    private func paymentMethod(cardNumber: String,
+                               cardholderName: String,
+                               cvv: String,
+                               month: Int,
+                               year: Int) -> SecureVaultModels.CreditCard {
+        return SecureVaultModels.CreditCard(id: nil,
+                                            title: nil,
+                                            cardNumber: cardNumber,
+                                            cardholderName: cardholderName,
+                                            cardSecurityCode: cvv,
+                                            expirationMonth: month,
+                                            expirationYear: year)
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1201938691568505/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1086
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/461

**Optional**:

CC: @brindy 

**Description**:

This PR updates BrowserServicesKit to handle the new `pmHandlerStoreData` call. As a part of this, it runs some logic to look up whether the provided payment method or address already exist in the database.

**Steps to test this PR**:
1. See macOS PR for more information

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
