### PR TITLE
Simplify and fix percent encoding in URL.addParameter

### DIFF
--- a/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
@@ -32,12 +32,6 @@ extension String {
         self.dropping(prefix: "www.")
     }
 
-    // Encodes plus symbols in a string so they are not treated as spaces on the web
-    // Plus sign UTF-8 encoding is 0x2B
-    func encodingPluses() -> String {
-        replacingOccurrences(of: "+", with: "%2B")
-    }
-
     // Replaces plus symbols in a string with the space character encoding
     // Space UTF-8 encoding is 0x20
     func encodingPlusesAsSpaces() -> String {

--- a/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
@@ -53,12 +53,26 @@ final class URLExtensionTests: XCTestCase {
         )
     }
 
-    func testWhenAddParameterIsCalled_ThenItEncodesPlusesInTheParameter() {
-        let url = URL(string: "https://duckduckgo.com/?q=Battlestar+Galactica")!
+    func testWhenAddParameterIsCalled_ThenItEncodesRFC3986QueryReservedCharactersInTheParameter() {
+        let url = URL(string: "https://duck.com/")!
 
-        XCTAssertEqual(
-            try url.addParameter(name: "ia", value: "web+ios and android"),
-            URL(string: "https://duckduckgo.com/?q=Battlestar+Galactica&ia=web%2Bios%20and%20android")!
-        )
+        XCTAssertEqual(try url.addParameter(name: ":", value: ":"), URL(string: "https://duck.com/?%3A=%3A")!)
+        XCTAssertEqual(try url.addParameter(name: "/", value: "/"), URL(string: "https://duck.com/?%2F=%2F")!)
+        XCTAssertEqual(try url.addParameter(name: "?", value: "?"), URL(string: "https://duck.com/?%3F=%3F")!)
+        XCTAssertEqual(try url.addParameter(name: "#", value: "#"), URL(string: "https://duck.com/?%23=%23")!)
+        XCTAssertEqual(try url.addParameter(name: "[", value: "["), URL(string: "https://duck.com/?%5B=%5B")!)
+        XCTAssertEqual(try url.addParameter(name: "]", value: "]"), URL(string: "https://duck.com/?%5D=%5D")!)
+        XCTAssertEqual(try url.addParameter(name: "@", value: "@"), URL(string: "https://duck.com/?%40=%40")!)
+        XCTAssertEqual(try url.addParameter(name: "!", value: "!"), URL(string: "https://duck.com/?%21=%21")!)
+        XCTAssertEqual(try url.addParameter(name: "$", value: "$"), URL(string: "https://duck.com/?%24=%24")!)
+        XCTAssertEqual(try url.addParameter(name: "&", value: "&"), URL(string: "https://duck.com/?%26=%26")!)
+        XCTAssertEqual(try url.addParameter(name: "'", value: "'"), URL(string: "https://duck.com/?%27=%27")!)
+        XCTAssertEqual(try url.addParameter(name: "(", value: "("), URL(string: "https://duck.com/?%28=%28")!)
+        XCTAssertEqual(try url.addParameter(name: ")", value: ")"), URL(string: "https://duck.com/?%29=%29")!)
+        XCTAssertEqual(try url.addParameter(name: "*", value: "*"), URL(string: "https://duck.com/?%2A=%2A")!)
+        XCTAssertEqual(try url.addParameter(name: "+", value: "+"), URL(string: "https://duck.com/?%2B=%2B")!)
+        XCTAssertEqual(try url.addParameter(name: ",", value: ","), URL(string: "https://duck.com/?%2C=%2C")!)
+        XCTAssertEqual(try url.addParameter(name: ";", value: ";"), URL(string: "https://duck.com/?%3B=%3B")!)
+        XCTAssertEqual(try url.addParameter(name: "=", value: "="), URL(string: "https://duck.com/?%3D=%3D")!)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201985700849146/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1091
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/475

**Optional**:

Tech Design URL:
CC: @tomasstrba 

**Description**:
When adding a new query parameter to an existing URL, manually percent encode the name and value and add them to
percentEncodedQueryItems. When percent-encoding the parameter, use a modified allowed characters set that does not include "URI query reserved characters" as they need to be percent encoded (when part of the parameter name or value).

**Steps to test this PR**:
This fix is only for macOS, since iOS does not use `URL.addParameter` (yet) when constructing a search URL.
1. Search for `star;trek`
1. Verify that the search is done for `star;trek` not just `star`.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
