### PR TITLE
AMP protection

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -143,6 +143,10 @@ public class ContentBlockerRulesManager {
             lock.unlock()
         }
     }
+    
+    public var currentTDSRules: Rules? {
+        currentRules.first(where: { $0.name == DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName })
+    }
 
     @discardableResult
     public func scheduleCompilation() -> CompletionToken {

--- a/Sources/BrowserServicesKit/LinkProtection/AMPCanonicalExtractor.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/AMPCanonicalExtractor.swift
@@ -1,0 +1,242 @@
+//
+//  AMPCanonicalExtractor.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+
+public class AMPCanonicalExtractor: NSObject {
+
+    class CompletionHandler {
+
+        private var completion: ((URL?) -> Void)?
+
+        func setCompletionHandler(completion: ((URL?) -> Void)?) {
+            completeWithURL(nil)
+            self.completion = completion
+        }
+
+        func completeWithURL(_ url: URL?) {
+            // Make a copy of completion and set it to nil
+            // This will prevent other callers before the completion has completed completing
+            let compBlock = completion
+            completion = nil
+            compBlock?(url)
+        }
+
+    }
+
+    struct Constants {
+        static let sendCanonical = "sendCanonical"
+        static let canonicalKey = "canonical"
+        static let ruleListIdentifier = "blockImageRules"
+    }
+
+    private let completionHandler = CompletionHandler()
+    
+    private var webView: WKWebView?
+    private var imageBlockingRules: WKContentRuleList?
+    
+    private let linkCleaner: LinkCleaner
+    private let privacyManager: PrivacyConfigurationManager
+    private let contentBlockingManager: ContentBlockerRulesManager
+    private let errorReporting: EventMapping<AMPProtectionDebugEvents>?
+    
+    private var privacyConfig: PrivacyConfiguration { privacyManager.privacyConfig }
+    
+    public init(linkCleaner: LinkCleaner,
+                privacyManager: PrivacyConfigurationManager,
+                contentBlockingManager: ContentBlockerRulesManager,
+                errorReporting: EventMapping<AMPProtectionDebugEvents>? = nil) {
+        self.linkCleaner = linkCleaner
+        self.privacyManager = privacyManager
+        self.contentBlockingManager = contentBlockingManager
+        self.errorReporting = errorReporting
+        
+        super.init()
+        
+        loadImageBlockingRules()
+    }
+    
+    private func loadImageBlockingRules() {
+        WKContentRuleListStore.default().lookUpContentRuleList(forIdentifier: Constants.ruleListIdentifier) { [weak self] ruleList, _ in
+            if let ruleList = ruleList {
+                self?.imageBlockingRules = ruleList
+            } else {
+                self?.compileImageRules()
+            }
+        }
+    }
+    
+    private func compileImageRules() {
+        let ruleSource = """
+[
+    {
+        "trigger": {
+            "url-filter": ".*",
+            "resource-type": ["image"]
+        },
+        "action": {
+            "type": "block"
+        }
+    },
+    {
+        "trigger": {
+            "url-filter": ".*",
+            "resource-type": ["style-sheet"]
+        },
+        "action": {
+            "type": "block"
+        }
+    },
+]
+"""
+        
+        WKContentRuleListStore.default().compileContentRuleList(forIdentifier: Constants.ruleListIdentifier,
+                                                                encodedContentRuleList: ruleSource) { [weak self] ruleList, error  in
+            guard error != nil else {
+                print(error?.localizedDescription ?? "AMPCanonicalExtractor - Error compiling image blocking rules")
+                self?.errorReporting?.fire(.ampBlockingRulesCompilationFailed)
+                return
+            }
+            
+            self?.imageBlockingRules = ruleList
+        }
+    }
+    
+    public func urlContainsAMPKeyword(_ url: URL?) -> Bool {
+        linkCleaner.lastAMPURLString = nil
+        guard privacyConfig.isEnabled(featureKey: .ampLinks) else { return false }
+        guard let url = url, !linkCleaner.isURLExcluded(url: url) else { return false }
+        let urlStr = url.absoluteString
+        
+        let ampKeywords = TrackingLinkSettings(fromConfig: privacyConfig).ampKeywords
+        
+        for keyword in ampKeywords {
+            if urlStr.contains(keyword) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    private func buildUserScript() -> WKUserScript {
+        let source = """
+(function() {
+    document.addEventListener('DOMContentLoaded', (event) => {
+        const canonicalLinks = document.querySelectorAll('[rel="canonical"]')
+        window.webkit.messageHandlers.\(Constants.sendCanonical).postMessage({
+            \(Constants.canonicalKey): canonicalLinks.length > 0 ? canonicalLinks[0].href : undefined
+        })
+    })
+})()
+"""
+        
+        return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+    }
+    
+    public func cancelOngoingExtraction() {
+        webView?.stopLoading()
+        webView = nil
+        completionHandler.completeWithURL(nil)
+    }
+
+    public func getCanonicalURL(initiator: URL?,
+                                url: URL?,
+                                completion: @escaping ((URL?) -> Void)) {
+        cancelOngoingExtraction()
+        guard privacyConfig.isEnabled(featureKey: .ampLinks) else {
+            completion(nil)
+            return
+        }
+        guard let url = url, !linkCleaner.isURLExcluded(url: url) else {
+            completion(nil)
+            return
+        }
+
+        if let initiator = initiator, linkCleaner.isURLExcluded(url: initiator) {
+            completion(nil)
+            return
+        }
+        
+        completionHandler.setCompletionHandler(completion: completion)
+        
+        webView = WKWebView(frame: .zero, configuration: makeConfiguration())
+        webView?.navigationDelegate = self
+        webView?.load(URLRequest(url: url))
+    }
+    
+    public func getCanonicalUrl(initiator: URL?,
+                                url: URL?) async -> URL? {
+        await withCheckedContinuation { continuation in
+            getCanonicalURL(initiator: initiator, url: url) { url in
+                continuation.resume(returning: url)
+            }
+        }
+    }
+    
+    private func makeConfiguration() -> WKWebViewConfiguration {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        configuration.userContentController.add(self, name: Constants.sendCanonical)
+        configuration.userContentController.addUserScript(buildUserScript())
+        if let rulesList = contentBlockingManager.currentTDSRules?.rulesList {
+            configuration.userContentController.add(rulesList)
+        }
+        if let imageBlockingRules = imageBlockingRules {
+            configuration.userContentController.add(imageBlockingRules)
+        }
+        return configuration
+    }
+
+    deinit {
+        completionHandler.completeWithURL(nil)
+    }
+
+}
+
+extension AMPCanonicalExtractor: WKScriptMessageHandler {
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == Constants.sendCanonical else { return }
+        
+        webView = nil
+        
+        if let dict = message.body as? [String: AnyObject],
+           let canonical = dict[Constants.canonicalKey] as? String {
+            if let canonicalUrl = URL(string: canonical), !linkCleaner.isURLExcluded(url: canonicalUrl) {
+                linkCleaner.lastAMPURLString = canonicalUrl.absoluteString
+                completionHandler.completeWithURL(canonicalUrl)
+            } else {
+                completionHandler.completeWithURL(nil)
+            }
+        } else {
+            completionHandler.completeWithURL(nil)
+        }
+    }
+}
+
+extension AMPCanonicalExtractor: WKNavigationDelegate {
+    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        completionHandler.completeWithURL(nil)
+    }
+    
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        completionHandler.completeWithURL(nil)
+    }
+}

--- a/Sources/BrowserServicesKit/LinkProtection/AMPProtection.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/AMPProtection.swift
@@ -1,0 +1,123 @@
+//
+//  AMPProtection.swift
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import WebKit
+
+public struct AMPProtection {
+    
+    private let linkCleaner: LinkCleaner
+    private let ampExtractor: AMPCanonicalExtractor
+    
+    public init(privacyManager: PrivacyConfigurationManager, contentBlockingManager: ContentBlockerRulesManager, errorReporting: EventMapping<AMPProtectionDebugEvents>) {
+        linkCleaner = LinkCleaner(privacyManager: privacyManager)
+        ampExtractor = AMPCanonicalExtractor(linkCleaner: linkCleaner,
+                                             privacyManager: privacyManager,
+                                             contentBlockingManager: contentBlockingManager,
+                                             errorReporting: errorReporting)
+    }
+    
+    public func getCleanURL(from url: URL, onExtracting: () -> Void, completion: @escaping (URL) -> Void) {
+        var urlToLoad = url
+        if let cleanURL = linkCleaner.cleanTrackingParameters(initiator: nil, url: urlToLoad) {
+            urlToLoad = cleanURL
+        }
+        
+        if let cleanURL = linkCleaner.extractCanonicalFromAMPLink(initiator: nil, destination: urlToLoad) {
+            completion(cleanURL)
+        } else if ampExtractor.urlContainsAMPKeyword(urlToLoad) {
+            onExtracting()
+            ampExtractor.getCanonicalURL(initiator: nil, url: urlToLoad) { canonical in
+                if let canonical = canonical {
+                    completion(canonical)
+                } else {
+                    completion(urlToLoad)
+                }
+            }
+        } else {
+            completion(urlToLoad)
+        }
+    }
+    
+    public func getCleanURL(from url: URL, onExtracting: () -> Void) async -> URL {
+        await withCheckedContinuation { continuation in
+            getCleanURL(from: url, onExtracting: onExtracting) { url in
+                continuation.resume(returning: url)
+            }
+        }
+    }
+    
+    public func requestTrackingLinkRewrite(initiatingURL: URL?,
+                                           navigationAction: WKNavigationAction,
+                                           onExtracting: () -> Void,
+                                           onLinkRewrite: @escaping (URL, WKNavigationAction) -> Void,
+                                           policyDecisionHandler: @escaping (WKNavigationActionPolicy) -> Void) -> Bool {
+        let destinationURL = navigationAction.request.url
+        
+        var didRewriteLink = false
+        if let newURL = linkCleaner.extractCanonicalFromAMPLink(initiator: initiatingURL, destination: destinationURL) {
+            policyDecisionHandler(.cancel)
+            onLinkRewrite(newURL, navigationAction)
+            didRewriteLink = true
+        } else if ampExtractor.urlContainsAMPKeyword(destinationURL) {
+            onExtracting()
+            ampExtractor.getCanonicalURL(initiator: initiatingURL, url: destinationURL) { canonical in
+                guard let canonical = canonical, canonical != destinationURL else {
+                    policyDecisionHandler(.allow)
+                    return
+                }
+                
+                policyDecisionHandler(.cancel)
+                onLinkRewrite(canonical, navigationAction)
+            }
+            didRewriteLink = true
+        } else if let newURL = linkCleaner.cleanTrackingParameters(initiator: initiatingURL, url: destinationURL) {
+            if newURL != destinationURL {
+                policyDecisionHandler(.cancel)
+                onLinkRewrite(newURL, navigationAction)
+                didRewriteLink = true
+            }
+        }
+        
+        return didRewriteLink
+    }
+    
+    
+    public func requestTrackingLinkRewrite(initiatingURL: URL?,
+                                           navigationAction: WKNavigationAction,
+                                           onExtracting: () -> Void,
+                                           onLinkRewrite: @escaping (URL, WKNavigationAction) -> Void) async -> WKNavigationActionPolicy? {
+        await withCheckedContinuation { continuation in
+            let didRewriteLink = requestTrackingLinkRewrite(initiatingURL: initiatingURL,
+                                                            navigationAction: navigationAction,
+                                                            onExtracting: onExtracting,
+                                                            onLinkRewrite: onLinkRewrite) { navigationActionPolicy in
+                continuation.resume(returning: navigationActionPolicy)
+            }
+            
+            if !didRewriteLink {
+                continuation.resume(returning: nil)
+            }
+        }
+    }
+    
+    public func cancelOngoingExtraction() { ampExtractor.cancelOngoingExtraction() }
+    
+    public var lastAMPURLString: String? { linkCleaner.lastAMPURLString }
+    public var urlParametersRemoved: Bool { linkCleaner.urlParametersRemoved }
+    
+}

--- a/Sources/BrowserServicesKit/LinkProtection/AMPProtectionDebugEvents.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/AMPProtectionDebugEvents.swift
@@ -1,0 +1,26 @@
+//
+//  ContentBlockerDebugEvents.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public enum AMPProtectionDebugEvents {
+
+    case ampBlockingRulesCompilationFailed
+    
+}

--- a/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
@@ -1,0 +1,119 @@
+//
+//  LinkCleaner.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public class LinkCleaner {
+    
+    public var lastAMPURLString: String?
+    public var urlParametersRemoved: Bool = false
+    
+    private let privacyManager: PrivacyConfigurationManager
+    private var privacyConfig: PrivacyConfiguration { privacyManager.privacyConfig }
+
+    public init(privacyManager: PrivacyConfigurationManager) {
+        self.privacyManager = privacyManager
+    }
+    
+    public func ampFormat(matching url: URL) -> String? {
+        let ampFormats = TrackingLinkSettings(fromConfig: privacyConfig).ampLinkFormats
+        for format in ampFormats {
+            if url.absoluteString.matches(pattern: format) {
+                return format
+            }
+        }
+        
+        return nil
+    }
+    
+    public func isURLExcluded(url: URL, feature: PrivacyFeature = .ampLinks) -> Bool {
+        guard let host = url.host else { return true }
+        
+        return !privacyConfig.isFeature(feature, enabledForDomain: host)
+    }
+    
+    public func extractCanonicalFromAMPLink(initiator: URL?, destination url: URL?) -> URL? {
+        lastAMPURLString = nil
+        guard privacyConfig.isEnabled(featureKey: .ampLinks) else { return nil }
+        guard let url = url, !isURLExcluded(url: url) else { return nil }
+        if let initiator = initiator { }, isURLExcluded(url: initiator) {
+            return nil
+        }
+        
+        guard let ampFormat = ampFormat(matching: url) else { return nil }
+        
+        do {
+            let ampStr = url.absoluteString
+            let regex = try NSRegularExpression(pattern: ampFormat, options: [.caseInsensitive])
+            let matches = regex.matches(in: url.absoluteString,
+                                        options: [],
+                                        range: NSRange(ampStr.startIndex..<ampStr.endIndex,
+                                                       in: ampStr))
+            guard let match = matches.first else { return nil }
+            
+            let matchRange = match.range(at: 1)
+            if let substrRange = Range(matchRange, in: ampStr) {
+                var urlStr = String(ampStr[substrRange])
+                if !urlStr.hasPrefix("http") {
+                    urlStr = "https://\(urlStr)"
+                }
+                
+                if let cleanUrl = URL(string: urlStr), !isURLExcluded(url: cleanUrl) {
+                    lastAMPURLString = ampStr
+                    return cleanUrl
+                }
+            }
+        } catch {
+            return nil
+        }
+        
+        return nil
+    }
+    
+    public func cleanTrackingParameters(initiator: URL?, url: URL?) -> URL? {
+        urlParametersRemoved = false
+        guard privacyConfig.isEnabled(featureKey: .trackingParameters) else { return url }
+        guard let url = url, !isURLExcluded(url: url, feature: .trackingParameters) else { return url }
+        if let initiator = initiator, isURLExcluded(url: initiator, feature: .trackingParameters) {
+            return url
+        }
+        
+        guard var urlsComps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+        guard let queryParams = urlsComps.queryItems, queryParams.count > 0 else {
+            return url
+        }
+        
+        let trackingParams = TrackingLinkSettings(fromConfig: privacyConfig).trackingParameters
+        
+        let preservedParams: [URLQueryItem] = queryParams.filter { param in
+            if trackingParams.contains(where: { param.name.matches(pattern: "^\($0)$") }) {
+                urlParametersRemoved = true
+                return false
+            }
+            
+            return true
+        }
+        
+        urlsComps.queryItems = preservedParams.count > 0 ? preservedParams : nil
+        
+        return urlsComps.url
+    }
+}

--- a/Sources/BrowserServicesKit/LinkProtection/String+Utils.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/String+Utils.swift
@@ -1,0 +1,37 @@
+//
+//  LinkCleaner.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+// The code has been copied from the client and should be put inside a Utility lib
+extension String {
+    
+    private var fullRange: NSRange {
+        return NSRange(location: 0, length: count)
+    }
+
+    func matches(pattern: String) -> Bool {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return false
+        }
+        let matches = regex.matches(in: self, options: .anchored, range: fullRange)
+        return matches.count == 1
+    }
+    
+}

--- a/Sources/BrowserServicesKit/LinkProtection/TrackingLinkSettings.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/TrackingLinkSettings.swift
@@ -1,0 +1,43 @@
+//
+//  TrackingLinkSettings.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+struct TrackingLinkSettings {
+    
+    let ampLinkFormats: [String]
+    let ampKeywords: [String]
+    let trackingParameters: [String]
+    
+    struct Constants {
+        static let ampLinkFormats = "linkFormats"
+        static let ampKeywords = "keywords"
+        static let trackingParameters = "parameters"
+    }
+    
+    init(fromConfig config: PrivacyConfiguration) {
+        let ampFeatureSettings = config.settings(for: .ampLinks)
+        let trackingParametersSettings = config.settings(for: .trackingParameters)
+        
+        ampLinkFormats = ampFeatureSettings[Constants.ampLinkFormats] as? [String] ?? []
+        ampKeywords = ampFeatureSettings[Constants.ampKeywords] as? [String] ?? []
+        trackingParameters = trackingParametersSettings[Constants.trackingParameters] as? [String] ?? []
+    }
+    
+}

--- a/Tests/BrowserServicesKitTests/LinkProtection/AmpMatchingTests.swift
+++ b/Tests/BrowserServicesKitTests/LinkProtection/AmpMatchingTests.swift
@@ -1,0 +1,135 @@
+//
+//  AmpMatchingTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import os.log
+@testable import TrackerRadarKit
+@testable import BrowserServicesKit
+
+struct AmpRefTests: Decodable {
+    struct AmpFormatTests: Decodable {
+        let name: String
+        let desc: String
+        let tests: [AmpFormatTest]
+    }
+    
+    struct AmpFormatTest: Decodable {
+        let name: String
+        let ampURL: String
+        let expectURL: String
+        let exceptPlatforms: [String]?
+    }
+    
+    struct AmpKeywordTests: Decodable {
+        let name: String
+        let desc: String
+        let tests: [AmpKeywordTest]
+    }
+    
+    struct AmpKeywordTest: Decodable {
+        let name: String
+        let ampURL: String
+        let expectAmpDetected: Bool
+        let exceptPlatforms: [String]?
+    }
+    
+    let ampFormats: AmpFormatTests
+    let ampKeywords: AmpKeywordTests
+}
+
+final class AmpMatchingTests: XCTestCase {
+    
+    private enum Resource {
+        static let config = "Resources/privacy-reference-tests/amp-protections/config_reference.json"
+        static let tests = "Resources/privacy-reference-tests/amp-protections/tests.json"
+    }
+                
+    private static let data = JsonTestDataLoader()
+    private static let config = data.fromJsonFile(Resource.config)
+    
+    private var privacyManager: PrivacyConfigurationManager {
+        let embeddedDataProvider = MockEmbeddedDataProvider(data: Self.config,
+                                                            etag: "embedded")
+        let localProtection = MockDomainsProtectionStore()
+        localProtection.unprotectedDomains = []
+
+        return PrivacyConfigurationManager(fetchedETag: nil,
+                                           fetchedData: nil,
+                                           embeddedDataProvider: embeddedDataProvider,
+                                           localProtection: localProtection)
+    }
+    
+    private var contentBlockingManager: ContentBlockerRulesManager {
+        let listsSource = ContentBlockerRulesListSourceMock()
+        let exceptionsSource = ContentBlockerRulesExceptionsSourceMock()
+        return ContentBlockerRulesManager(rulesSource: listsSource, exceptionsSource: exceptionsSource)
+    }
+    
+    private lazy var ampTestSuite: AmpRefTests = {
+        let tests = Self.data.fromJsonFile(Resource.tests)
+        return try! JSONDecoder().decode(AmpRefTests.self, from: tests)
+    }()
+    
+    func testAmpFormats() throws {
+        let tests = ampTestSuite.ampFormats.tests
+        let linkCleaner = LinkCleaner(privacyManager: privacyManager)
+                
+        for test in tests {
+            let skip = test.exceptPlatforms?.contains("ios-browser")
+            if skip == true {
+                os_log("!!SKIPPING TEST: %s", test.name)
+                continue
+            }
+            
+            os_log("TEST: %s", test.name)
+            
+            let ampUrl = URL(string: test.ampURL)
+            let resultUrl = linkCleaner.extractCanonicalFromAMPLink(initiator: nil, destination: ampUrl)
+            
+            // Empty expectedUrl should be treated as nil
+            let expectedUrl = !test.expectURL.isEmpty ? test.expectURL : nil
+            XCTAssertEqual(resultUrl?.absoluteString, expectedUrl, "\(resultUrl!.absoluteString) not equal to expected: \(expectedUrl ?? "nil")")
+        }
+    }
+    
+    func testAmpKeywords() throws {
+        let tests = ampTestSuite.ampKeywords.tests
+        let linkCleaner = LinkCleaner(privacyManager: privacyManager)
+        
+        let ampExtractor = AMPCanonicalExtractor(linkCleaner: linkCleaner,
+                                                 privacyManager: privacyManager,
+                                                 contentBlockingManager: contentBlockingManager,
+                                                 errorReporting: nil)
+        
+        for test in tests {
+            let skip = test.exceptPlatforms?.contains("ios-browser")
+            if skip == true {
+                os_log("!!SKIPPING TEST: %s", test.name)
+                continue
+            }
+            
+            os_log("TEST: %s", test.name)
+            
+            let ampUrl = URL(string: test.ampURL)
+            let result = ampExtractor.urlContainsAMPKeyword(ampUrl)
+            XCTAssertEqual(result, test.expectAmpDetected, "\(test.ampURL) not correctly identified. Expected: \(test.expectAmpDetected.description)")
+        }
+    }
+
+}

--- a/Tests/BrowserServicesKitTests/LinkProtection/ContentBlockerManagerMock.swift
+++ b/Tests/BrowserServicesKitTests/LinkProtection/ContentBlockerManagerMock.swift
@@ -1,0 +1,34 @@
+//
+//  AmpMatchingTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import BrowserServicesKit
+import TrackerRadarKit
+
+struct ContentBlockerRulesListSourceMock: ContentBlockerRulesListsSource {
+    var contentBlockerRulesLists: [ContentBlockerRulesList] = []
+}
+
+struct ContentBlockerRulesExceptionsSourceMock: ContentBlockerRulesExceptionsSource {
+    var tempListEtag: String = ""
+    var tempList: [String] = []
+    var allowListEtag: String = ""
+    var allowList: [TrackerException] = []
+    var unprotectedSites: [String] = []
+}

--- a/Tests/BrowserServicesKitTests/LinkProtection/URLParameterTests.swift
+++ b/Tests/BrowserServicesKitTests/LinkProtection/URLParameterTests.swift
@@ -1,0 +1,96 @@
+//
+//  URLParameterTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import os.log
+@testable import TrackerRadarKit
+@testable import BrowserServicesKit
+
+struct URLParamRefTests: Decodable {
+    struct URLParamTests: Decodable {
+        let name: String
+        let desc: String
+        let tests: [URLParamTest]
+    }
+    
+    struct URLParamTest: Decodable {
+        let name: String
+        let testURL: String
+        let expectURL: String
+        let exceptPlatforms: [String]?
+    }
+    
+    let trackingParameters: URLParamTests
+}
+
+final class URLParameterTests: XCTestCase {
+        
+    private enum Resource {
+        static let config = "Resources/privacy-reference-tests/url-parameters/config_reference.json"
+        static let tests = "Resources/privacy-reference-tests/url-parameters/tests.json"
+    }
+                
+    private static let data = JsonTestDataLoader()
+    private static let config = data.fromJsonFile(Resource.config)
+    
+    private var privacyManager: PrivacyConfigurationManager {
+        let embeddedDataProvider = MockEmbeddedDataProvider(data: Self.config,
+                                                            etag: "embedded")
+        let localProtection = MockDomainsProtectionStore()
+        localProtection.unprotectedDomains = []
+
+        return PrivacyConfigurationManager(fetchedETag: nil,
+                                           fetchedData: nil,
+                                           embeddedDataProvider: embeddedDataProvider,
+                                           localProtection: localProtection)
+    }
+    
+    private lazy var urlParamTestSuite: URLParamRefTests = {
+        let tests = Self.data.fromJsonFile(Resource.tests)
+        return try! JSONDecoder().decode(URLParamRefTests.self, from: tests)
+    }()
+    
+    func testURLParamStripping() throws {
+        let tests = urlParamTestSuite.trackingParameters.tests
+        
+        let linkCleaner = LinkCleaner(privacyManager: privacyManager)
+        
+        for test in tests {
+            let skip = test.exceptPlatforms?.contains("ios-browser")
+            if skip == true {
+                os_log("!!SKIPPING TEST: %s", test.name)
+                continue
+            }
+            
+            os_log("TEST: %s", test.name)
+            
+            let testUrl = URL(string: test.testURL)
+            var resultUrl = linkCleaner.cleanTrackingParameters(initiator: nil, url: testUrl)
+            
+            if resultUrl == nil {
+                // Tests expect unchanged URLs to match testURL
+                resultUrl = testUrl
+            }
+            
+            XCTAssertEqual(resultUrl?.absoluteString, test.expectURL,
+                           "\(resultUrl?.absoluteString ?? "(nil)") not equal to expected: \(test.expectURL)")
+        }
+    }
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1201716942816245/f
iOS PR:  
macOS PR: 
Tech Design URL: https://app.asana.com/0/481882893211075/1201948311080451/f
CC: @tomasstrba 

**Description**:
AMP code that has been previously inside the iOS client now is being extracted into the BSK. Moreover, some code that was inside TabBarViewController is also part of the BSK now under AMPProtection class.

**Steps to test this PR**:
1. Run tests.

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
