### PR TITLE
Conditionally allow reserved characters in URL.addParameter

### DIFF
--- a/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
@@ -98,11 +98,18 @@ extension URL {
         return url
     }
 
-    public func addParameter(name: String, value: String) throws -> URL {
+    public func addParameter(name: String, value: String, allowedReservedCharacters: CharacterSet? = nil) throws -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { throw ParameterError.parsingFailed }
         
-        guard let percentEncodedName = name.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed),
-              let percentEncodedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed)
+        let allowedCharacters: CharacterSet = {
+            if let allowedReservedCharacters = allowedReservedCharacters {
+                return .urlQueryParameterAllowed.union(allowedReservedCharacters)
+            }
+            return .urlQueryParameterAllowed
+        }()
+        
+        guard let percentEncodedName = name.addingPercentEncoding(withAllowedCharacters: allowedCharacters),
+              let percentEncodedValue = value.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
         else {
             throw ParameterError.encodingFailed
         }

--- a/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
@@ -75,4 +75,17 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertEqual(try url.addParameter(name: ";", value: ";"), URL(string: "https://duck.com/?%3B=%3B")!)
         XCTAssertEqual(try url.addParameter(name: "=", value: "="), URL(string: "https://duck.com/?%3D=%3D")!)
     }
+
+    func testWhenAddParameterIsCalled_ThenItAllowsUnescapedReservedCharactersAsSpecified() {
+        let url = URL(string: "https://duck.com/")!
+
+        XCTAssertEqual(
+            try url.addParameter(
+                name: "domains",
+                value: "test.com,example.com/test,localhost:8000/api",
+                allowedReservedCharacters: .init(charactersIn: ",:")
+            ),
+            URL(string: "https://duck.com/?domains=test.com,example.com%2Ftest,localhost:8000%2Fapi")!
+        )
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1163321984198618/1202033667108435/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1108
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/498

**Description**:
Add an optional argument to `URL.addParameter` to specify reserved characters (as per [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.2) that should not be percent-encoded, for example because they play a special role in the payload, as defined by the API provider.

By default we percent-encode all reserved characters, which should be a safe default, unless specific API providers instruct to allow certain characters. This is the case for Website Breakage reports where comma is used to delimit blocked trackers domains.

**Steps to test this PR**:
This is an macOS-only change, as iOS does not use the `URL.addParameter` at this time. Furthermore, it's an opt-in API, so by default nothing will change for existing callers.
1. Ensure that unit tests pass

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
