### PR TITLE
Use the percentEncodedQueryItems instead of queryItems to store and r…

### DIFF
--- a/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
@@ -112,8 +112,10 @@ public class LinkCleaner {
             return true
         }
         
-        urlsComps.percentEncodedQueryItems = preservedParams.count > 0 ? preservedParams : nil
-        
-        return urlsComps.url
+        if urlParametersRemoved {
+            urlsComps.percentEncodedQueryItems = preservedParams.count > 0 ? preservedParams : nil
+            return urlsComps.url
+        }
+        return url
     }
 }

--- a/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
@@ -97,7 +97,7 @@ public class LinkCleaner {
         guard var urlsComps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return url
         }
-        guard let queryParams = urlsComps.queryItems, queryParams.count > 0 else {
+        guard let queryParams = urlsComps.percentEncodedQueryItems, queryParams.count > 0 else {
             return url
         }
         
@@ -112,7 +112,7 @@ public class LinkCleaner {
             return true
         }
         
-        urlsComps.queryItems = preservedParams.count > 0 ? preservedParams : nil
+        urlsComps.percentEncodedQueryItems = preservedParams.count > 0 ? preservedParams : nil
         
         return urlsComps.url
     }


### PR DESCRIPTION
…ebuild the url after we strip tracking params

Task/Issue URL: https://app.asana.com/0/0/1202080405650495/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1113
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/513

CC: @ayoy 

**Description**:

We can use the percentEncodedQueryItems on URLComponents instead of queryItems. It will ensure that after we strip some parameters we will use *exactly* the same ones (same format) from before the stripping (obviously without parameters we deliberately removed).

It won't harm the stripping logic because there we match against param names rather than param values, and param names are not affected by encoding issues.

One thing to remember though, this logic can fail if there are any param names which can be affected by percent encoding. If so, we should send them in privacy config in encoded format.

There is also additional safe check - if we do not remove any params, we return the original URL.

**Steps to test this PR**:
1. Open problematic URL from Asana task
1. See if the .pkg file downloads

