### PR TITLE
Support privacy config v2

### DIFF
--- a/Sources/BrowserServicesKit/Common/Extensions/BundleExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/BundleExtension.swift
@@ -1,0 +1,31 @@
+//
+//  BundleExtension.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension Bundle {
+    
+    struct Keys {
+        static let versionNumber = "CFBundleShortVersionString"
+    }
+    
+    var releaseVersionNumber: String? {
+        return infoDictionary?[Keys.versionNumber] as? String
+    }
+}

--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -46,10 +46,37 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         return data.trackerAllowlist.state == PrivacyConfigurationData.State.enabled ? data.trackerAllowlist.entries : [:]
     }
     
-    public func isEnabled(featureKey: PrivacyFeature) -> Bool {
+    func parse(versionString: String) -> [Int] {
+        return versionString.split(separator: ".").map { Int($0) ?? 0 }
+    }
+    
+    func staisfiesMinVersion(feature: PrivacyConfigurationData.PrivacyFeature,
+                             versionProvider: AppVersionProvider) -> Bool {
+        if let minSupportedVersion = feature.minSupportedVersion,
+           let appVersion = versionProvider.appVersion() {
+            let minVersion = parse(versionString: minSupportedVersion)
+            let currentVersion = parse(versionString: appVersion)
+            if minVersion.count != currentVersion.count {
+                // Config error
+                return false
+            }
+            
+            for i in 0..<minVersion.count {
+                if minVersion[i] > currentVersion[i] {
+                    return false
+                }
+            }
+        }
+        
+        return true
+    }
+    
+    public func isEnabled(featureKey: PrivacyFeature,
+                          versionProvider: AppVersionProvider = AppVersionProvider()) -> Bool {
         guard let feature = data.features[featureKey.rawValue] else { return false }
         
-        return feature.state == PrivacyConfigurationData.State.enabled
+        return staisfiesMinVersion(feature: feature, versionProvider: versionProvider)
+                && feature.state == PrivacyConfigurationData.State.enabled
     }
     
     public func exceptionsList(forFeature featureKey: PrivacyFeature) -> [String] {

--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -50,19 +50,21 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         return versionString.split(separator: ".").map { Int($0) ?? 0 }
     }
     
-    func staisfiesMinVersion(feature: PrivacyConfigurationData.PrivacyFeature,
+    func satisfiesMinVersion(feature: PrivacyConfigurationData.PrivacyFeature,
                              versionProvider: AppVersionProvider) -> Bool {
         if let minSupportedVersion = feature.minSupportedVersion,
            let appVersion = versionProvider.appVersion() {
             let minVersion = parse(versionString: minSupportedVersion)
             let currentVersion = parse(versionString: appVersion)
-            if minVersion.count != currentVersion.count {
-                // Config error
-                return false
-            }
             
-            for i in 0..<minVersion.count {
-                if minVersion[i] > currentVersion[i] {
+            for i in 0..<max(minVersion.count, currentVersion.count) {
+                let minSegment = i < minVersion.count ? minVersion[i] : 0
+                let currSegment = i < currentVersion.count ? currentVersion[i] : 0
+                
+                if currSegment > minSegment {
+                    return true
+                }
+                if currSegment < minSegment {
                     return false
                 }
             }
@@ -75,7 +77,7 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
                           versionProvider: AppVersionProvider = AppVersionProvider()) -> Bool {
         guard let feature = data.features[featureKey.rawValue] else { return false }
         
-        return staisfiesMinVersion(feature: feature, versionProvider: versionProvider)
+        return satisfiesMinVersion(feature: feature, versionProvider: versionProvider)
                 && feature.state == PrivacyConfigurationData.State.enabled
     }
     

--- a/Sources/BrowserServicesKit/PrivacyConfig/AppVersionProvider.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppVersionProvider.swift
@@ -1,0 +1,30 @@
+//
+//  AppVersionProvider.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+open class AppVersionProvider {
+    open func appVersion() -> String? {
+        return Bundle.main.releaseVersionNumber
+    }
+    
+    public init() {
+        
+    }
+}

--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
@@ -37,7 +37,7 @@ public protocol PrivacyConfiguration {
     /// Trackers that has been allow listed because of site breakage
     var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlistData { get }
 
-    func isEnabled(featureKey: PrivacyFeature) -> Bool
+    func isEnabled(featureKey: PrivacyFeature, versionProvider: AppVersionProvider) -> Bool
 
     /// Domains for which given PrivacyFeature is disabled.
     ///
@@ -82,6 +82,12 @@ public protocol PrivacyConfiguration {
     func userEnabledProtection(forDomain: String)
     /// Adds given domain to locally unprotected list.
     func userDisabledProtection(forDomain: String)
+}
+
+extension PrivacyConfiguration {
+    func isEnabled(featureKey: PrivacyFeature) -> Bool {
+        return isEnabled(featureKey: featureKey, versionProvider: AppVersionProvider())
+    }
 }
 
 public enum PrivacyFeature: String {

--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
@@ -84,7 +84,7 @@ public protocol PrivacyConfiguration {
     func userDisabledProtection(forDomain: String)
 }
 
-extension PrivacyConfiguration {
+public extension PrivacyConfiguration {
     func isEnabled(featureKey: PrivacyFeature) -> Bool {
         return isEnabled(featureKey: featureKey, versionProvider: AppVersionProvider())
     }

--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
@@ -88,16 +88,19 @@ public struct PrivacyConfigurationData {
         public typealias FeatureState = String
         public typealias ExceptionList = [ExceptionEntry]
         public typealias FeatureSettings = [String: Any]
+        public typealias FeatureSupportedVersion = String
 
         enum CodingKeys: String {
             case state
             case exceptions
             case settings
+            case minSupportedVersion
         }
 
         public let state: FeatureState
         public let exceptions: ExceptionList
         public let settings: FeatureSettings
+        public let minSupportedVersion: FeatureSupportedVersion?
 
         public init?(json: [String: Any]) {
             guard let state = json[CodingKeys.state.rawValue] as? String else { return nil }
@@ -110,12 +113,14 @@ public struct PrivacyConfigurationData {
             }
 
             self.settings = (json[CodingKeys.settings.rawValue] as? [String: Any]) ?? [:]
+            self.minSupportedVersion = json[CodingKeys.minSupportedVersion.rawValue] as? String
         }
 
-        public init(state: String, exceptions: [ExceptionEntry], settings: [String: Any] = [:]) {
+        public init(state: String, exceptions: [ExceptionEntry], settings: [String: Any] = [:], minSupportedVersion: String? = nil) {
             self.state = state
             self.exceptions = exceptions
             self.settings = settings
+            self.minSupportedVersion = minSupportedVersion
         }
     }
 

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
@@ -325,6 +325,10 @@ class AppPrivacyConfigurationTests: XCTestCase {
         
         appVersion = MockAppVersionProvider(appVersion: "0.22.3")
         XCTAssertTrue(config.isEnabled(featureKey: .trackingParameters, versionProvider: appVersion))
+        appVersion = MockAppVersionProvider(appVersion: "1.0.0")
+        XCTAssertTrue(config.isEnabled(featureKey: .trackingParameters, versionProvider: appVersion))
+        appVersion = MockAppVersionProvider(appVersion: "1.0.0.0")
+        XCTAssertTrue(config.isEnabled(featureKey: .trackingParameters, versionProvider: appVersion))
         
         // Test invalid version format
         XCTAssertFalse(config.isEnabled(featureKey: .ampLinks, versionProvider: appVersion))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200890834746050/1201683113648489/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1119
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/528

**Optional**:

Tech Design URL:
CC: @tomasstrba @bwaresiak @jonathanKingston 

**Description**:
This PR adds support for checking `minSupportedVersion` in the privacy config.

**Steps to test this PR**:
1. Run `swift test`. If it comes back green leave a ✅

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15
* [x] macOS 10.15
* [x] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
