### PR TITLE
Fix autofill on Catalina by disabling top autofill

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SourceProvider.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SourceProvider.swift
@@ -34,12 +34,15 @@ public class DefaultAutofillSourceProvider: AutofillUserScriptSourceProvider {
     public init(privacyConfigurationManager: PrivacyConfigurationManager, properties: ContentScopeProperties) {
         var replacements: [String: String] = [:]
         #if os(macOS)
-            replacements["// INJECT supportsTopFrame HERE"] = "supportsTopFrame = true;"
             replacements["// INJECT isApp HERE"] = "isApp = true;"
         #endif
 
         if #available(iOS 14, macOS 11, *) {
             replacements["// INJECT hasModernWebkitAPI HERE"] = "hasModernWebkitAPI = true;"
+            
+            #if os(macOS)
+                replacements["// INJECT supportsTopFrame HERE"] = "supportsTopFrame = true;"
+            #endif
         }
         
         guard let privacyConfigJson = String(data: privacyConfigurationManager.currentConfig, encoding: .utf8),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199178362774117/1202127639259814/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1128
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/551

**Description**:
Fixes autofill tooltip in Catalina by disabling top autofill (uses the old in-page tooltip).

**Steps to test this PR**:
1. Try using autofill in Catalina.
2. If you can click it and it autofill, it works 🎉!

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [x] macOS 10.15
* [x] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
