### PR TITLE
Run unit tests with GitHub Actions on MacOS 11 and MacOS 12

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   swiftlint:
+
+    name: Run SwiftLint
+
     if: github.event_name == 'pull_request'
 
     runs-on: ubuntu-latest
@@ -26,12 +29,36 @@ jobs:
 
   unit-tests:
 
-    runs-on: macos-12
+    name: Run unit tests
+
+    strategy:
+      matrix:
+        os: [macos-11, macos-12]
+        include:
+          - skipped_tests: |
+              --skip 'BrowserServicesKitTests.TrackerAllowlistReferenceTests' \
+              --skip 'BrowserServicesKitTests.SurrogatesUserScriptsTests/.*AreNotInjected' \
+              --skip 'BrowserServicesKitTests.ContentBlockerRulesUserScriptsTests/.*(?:Site).*ReportedButNotBlocked' \
+            os: macos-12
+
+    runs-on: ${{ matrix.os }}
 
     steps:
+
     - name: Check out the code
       uses: actions/checkout@v3
       with:
         submodules: recursive
+
     - name: Run tests
-      run: swift test
+      run: |
+        swift test --parallel --num-workers=1 \
+          ${{ matrix.skipped_tests }} \
+          --xunit-output tests-${{ matrix.os }}.xml
+
+    - name: Publish Unit Tests Report
+      uses: mikepenz/action-junit-report@v3
+      if: always()
+      with:
+        check_name: Test Report (${{ matrix.os }})
+        report_paths: tests-${{ matrix.os }}.xml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,10 +35,11 @@ jobs:
       matrix:
         os: [macos-11, macos-12]
         include:
+          # Skipping tests that are known to be failing on MacOS 12
           - skipped_tests: |
               --skip 'BrowserServicesKitTests.TrackerAllowlistReferenceTests' \
-              --skip 'BrowserServicesKitTests.SurrogatesUserScriptsTests/.*AreNotInjected' \
-              --skip 'BrowserServicesKitTests.ContentBlockerRulesUserScriptsTests/.*(?:Site).*ReportedButNotBlocked' \
+              --skip 'BrowserServicesKitTests.SurrogatesUserScriptsTests' \
+              --skip 'BrowserServicesKitTests.ContentBlockerRulesUserScriptsTests' \
             os: macos-12
 
     runs-on: ${{ matrix.os }}
@@ -51,6 +52,9 @@ jobs:
         submodules: recursive
 
     - name: Run tests
+      # BSK does not support running tests in parallel, but the flag is required
+      # to make XUnit output work. Making it parallel with 1 worker then.
+      # https://stackoverflow.com/a/70040836
       run: |
         swift test --parallel --num-workers=1 \
           ${{ matrix.skipped_tests }} \

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
   unit-tests:
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     - name: Check out the code


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1202179326306991/f
iOS PR:  N/A
macOS PR: N/A
What kind of version bump will this require?: N/A

**Description**:
Use job matrix to run tests on macos-11 and macos-12 environments.
Since some tests are known to be [failing on MacOS 12](https://app.asana.com/0/1200194497630846/1202179326307010/f), they are skipped on that environment.
Whenever they are fixed we will re-enable them and we will remove MacOS 11 from the matrix.

**Steps to test this PR**:
1. Ensure that unit tests GitHub Action passes

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
