### PR TITLE
Fix possible compilation loop in Content Blocking

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSourceManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSourceManager.swift
@@ -74,18 +74,10 @@ public class ContentBlockerRulesSourceManager {
     
     public class RulesSourceBreakageInfo {
 
-        public let name: String
         public internal(set) var tdsIdentifier: String?
-
         public internal(set) var tempListIdentifier: String?
-
         public internal(set) var allowListIdentifier: String?
-
         public internal(set) var unprotectedSitesIdentifier: String?
-
-        init(name: String) {
-            self.name = name
-        }
     }
 
     /**
@@ -178,7 +170,7 @@ public class ContentBlockerRulesSourceManager {
      */
     func compilationFailed(for input: ContentBlockerRulesSourceIdentifiers, with error: Error) {
         guard let brokenSources = brokenSources else {
-            let brokenSources = RulesSourceBreakageInfo(name: rulesList.name)
+            let brokenSources = RulesSourceBreakageInfo()
             self.brokenSources = brokenSources
             compilationFailed(for: input, with: error, brokenSources: brokenSources)
             return

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
@@ -601,6 +601,82 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
                                                      allowListEtag: nil,
                                                      unprotectedSitesHash: nil))
     }
+    
+    func test_CurrentTDSEqualToFallbackTDS_ValidTempList_ValidAllowList_BrokenUnprotectedSites() {
+        
+        let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.fakeEmbeddedDataSet,
+                                                                       embeddedTrackerData: Self.fakeEmbeddedDataSet)
+        let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
+        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempList = validTempSites
+        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowList = validAllowList
+        mockExceptionsSource.unprotectedSites = ["broken site Ltd. . 😉.com"]
+        
+        XCTAssertEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
+        
+        let exp = expectation(description: "Rules Compiled")
+        rulesUpdateListener.onRulesUpdated = { _ in
+            exp.fulfill()
+        }
+        
+        let errorExp = expectation(description: "Error reported")
+        errorExp.expectedFulfillmentCount = 4
+        var errorEvents = [ContentBlockerDebugEvents]()
+        let errorHandler = EventMapping<ContentBlockerDebugEvents>.init { event, scope, _, params, _ in
+            switch event {
+            case .contentBlockingTempListCompilationFailed,
+                    .contentBlockingAllowListCompilationFailed,
+                    .contentBlockingUnpSitesCompilationFailed:
+                XCTAssertEqual(scope, DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName)
+                errorEvents.append(event)
+                errorExp.fulfill()
+            case .contentBlockingCompilationTime:
+                XCTAssertNil(scope)
+                XCTAssertNotNil(params?["compilationTime"])
+
+                errorExp.fulfill()
+            default:
+                XCTFail("Unexpected \(event)")
+            }
+        }
+
+        let cbrm = ContentBlockerRulesManager(rulesSource: mockRulesSource,
+                                              exceptionsSource: mockExceptionsSource,
+                                              updateListener: rulesUpdateListener,
+                                              errorReporting: errorHandler,
+                                              logger: .disabled)
+
+        wait(for: [exp, errorExp], timeout: 15.0)
+        
+        XCTAssertEqual(Set(errorEvents), Set([.contentBlockingTempListCompilationFailed,
+                                              .contentBlockingAllowListCompilationFailed,
+                                              .contentBlockingUnpSitesCompilationFailed]))
+        
+        XCTAssertNotNil(cbrm.currentRules.first?.etag)
+        XCTAssertEqual(cbrm.currentRules.first?.etag, mockRulesSource.embeddedTrackerData.etag)
+        
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier)
+        
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier,
+                       mockExceptionsSource.tempListEtag)
+
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier,
+                       mockExceptionsSource.allowListEtag)
+        
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier,
+                       mockExceptionsSource.unprotectedSitesHash)
+
+        XCTAssertEqual(cbrm.currentRules.first?.identifier,
+                       ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
+                                                     tdsEtag: mockRulesSource.embeddedTrackerData.etag,
+                                                     tempListEtag: nil,
+                                                     allowListEtag: nil,
+                                                     unprotectedSitesHash: nil))
+    }
 }
 
 class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
@@ -264,7 +264,7 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
 
                 errorExp.fulfill()
             default:
-                XCTFail()
+                XCTFail("Unexpected event received: \(event)")
             }
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/inbox/856498667309057/1202191081651324/1202192017059431
iOS PR:  Not needed, test against develop.
macOS PR: Not needed, test against develop.
What kind of version bump will this require?: Major/Minor/Patch: Patch

**Description**:
Prevent compilation loops in case current TDS is same as fallback TDS and error occurs.

**Steps to test this PR**:

1. Drop this into iOS project.
2. Run update embedded script to make sure embedded TDS matches remote one.
3. Test scenario: 
 - Open app to unprotected sites in settings.
 - Add unprotected site with uppercase letter e.g. 'Test.com'
 - Make sure compilation works without loop.

General smoke tests.

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
