### PR TITLE
Normalize domain names for Content Blocking

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "Punycode",
+        "repositoryURL": "https://github.com/gumob/PunycodeSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "4356ec54e073741449640d3d50a1fd24fd1e1b8b",
+          "version": "2.1.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.1.0")),
-        .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.0.3"))
+        .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.0.3")),
+        .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0"))
     ],
     targets: [
         
@@ -24,6 +25,7 @@ let package = Package(
             dependencies: [
                 "GRDB",
                 "TrackerRadarKit",
+                .product(name: "Punnycode", package: "Punycode"),
                 "BloomFilterWrapper"
             ],
             exclude: [

--- a/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import Punycode
 
 extension String {
 
@@ -55,5 +56,15 @@ extension String {
         return normalizedString
     }
 
+}
+
+// MARK: - Punycode
+extension String {
+    public var punycodeEncodedHostname: String {
+        return self.split(separator: ".")
+            .map { String($0) }
+            .map { $0.idnaEncoded ?? $0 }
+            .joined(separator: ".")
+    }
 }
 

--- a/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
@@ -67,4 +67,3 @@ extension String {
             .joined(separator: ".")
     }
 }
-

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
@@ -91,7 +91,7 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
         let config = privacyConfigManager.privacyConfig
         var tempUnprotected = config.tempUnprotectedDomains.filter { !$0.trimWhitespace().isEmpty }
         tempUnprotected.append(contentsOf: config.exceptionsList(forFeature: .contentBlocking))
-        return tempUnprotected
+        return tempUnprotected.normalizeDomains()
     }
 
     public var allowListEtag: String {
@@ -103,7 +103,7 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
     }
 
     public var unprotectedSites: [String] {
-        return privacyConfigManager.privacyConfig.userUnprotectedDomains
+        return privacyConfigManager.privacyConfig.userUnprotectedDomains.normalizeDomains()
     }
 
     public class func transform(allowList: PrivacyConfigurationData.TrackerAllowlistData) -> [TrackerException] {
@@ -116,9 +116,18 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
             if entry.domains.contains("<all>") {
                 return TrackerException(rule: entry.rule, matching: .all)
             } else {
-                return TrackerException(rule: entry.rule, matching: .domains(entry.domains))
+                return TrackerException(rule: entry.rule, matching: .domains(entry.domains.normalizeDomains()))
             }
         }
     }
 
+}
+
+fileprivate extension Array where Element == String {
+    
+    func normalizeDomains() -> [String] {
+        map { domain in
+            domain.punycodeEncodedHostname.lowercased()
+        }
+    }
 }

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
@@ -91,7 +91,7 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
         let config = privacyConfigManager.privacyConfig
         var tempUnprotected = config.tempUnprotectedDomains.filter { !$0.trimWhitespace().isEmpty }
         tempUnprotected.append(contentsOf: config.exceptionsList(forFeature: .contentBlocking))
-        return tempUnprotected.normalizeDomains()
+        return tempUnprotected
     }
 
     public var allowListEtag: String {
@@ -103,7 +103,7 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
     }
 
     public var unprotectedSites: [String] {
-        return privacyConfigManager.privacyConfig.userUnprotectedDomains.normalizeDomains()
+        return privacyConfigManager.privacyConfig.userUnprotectedDomains
     }
 
     public class func transform(allowList: PrivacyConfigurationData.TrackerAllowlistData) -> [TrackerException] {
@@ -116,18 +116,9 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
             if entry.domains.contains("<all>") {
                 return TrackerException(rule: entry.rule, matching: .all)
             } else {
-                return TrackerException(rule: entry.rule, matching: .domains(entry.domains.normalizeDomains()))
+                return TrackerException(rule: entry.rule, matching: .domains(entry.domains.normalizedDomainsForContentBlocking()))
             }
         }
     }
 
-}
-
-fileprivate extension Array where Element == String {
-    
-    func normalizeDomains() -> [String] {
-        map { domain in
-            domain.punycodeEncodedHostname.lowercased()
-        }
-    }
 }

--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -27,8 +27,8 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
     private let locallyUnprotected: DomainsProtectionStore
 
     public init(data: PrivacyConfigurationData,
-         identifier: String,
-         localProtection: DomainsProtectionStore) {
+                identifier: String,
+                localProtection: DomainsProtectionStore) {
         self.data = data
         self.identifier = identifier
         self.locallyUnprotected = localProtection

--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -146,7 +146,10 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
     }
 
     public func userEnabledProtection(forDomain domain: String) {
-        locallyUnprotected.enableProtection(forDomain: domain)
+        let domainToRemove = locallyUnprotected.unprotectedDomains.first { unprotectedDomain in
+            unprotectedDomain.punycodeEncodedHostname.lowercased() == domain
+        }
+        locallyUnprotected.enableProtection(forDomain: domainToRemove ?? domain)
     }
 
     public func userDisabledProtection(forDomain domain: String) {

--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -35,11 +35,11 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
     }
 
     public var userUnprotectedDomains: [String] {
-        return Array(locallyUnprotected.unprotectedDomains)
+        return Array(locallyUnprotected.unprotectedDomains).normalizedDomainsForContentBlocking()
     }
     
     public var tempUnprotectedDomains: [String] {
-        return data.unprotectedTemporary.map { $0.domain }
+        return data.unprotectedTemporary.map { $0.domain }.normalizedDomainsForContentBlocking()
     }
 
     public var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlistData {
@@ -84,7 +84,7 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
     public func exceptionsList(forFeature featureKey: PrivacyFeature) -> [String] {
         guard let feature = data.features[featureKey.rawValue] else { return [] }
         
-        return feature.exceptions.map { $0.domain }
+        return feature.exceptions.map { $0.domain }.normalizedDomainsForContentBlocking()
     }
 
     public func isFeature(_ feature: PrivacyFeature, enabledForDomain domain: String?) -> Bool {
@@ -111,7 +111,7 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
     public func isUserUnprotected(domain: String?) -> Bool {
         guard let domain = domain else { return false }
 
-        return locallyUnprotected.unprotectedDomains.contains(domain)
+        return userUnprotectedDomains.contains(domain)
     }
 
     public func isTempUnprotected(domain: String?) -> Bool {
@@ -153,4 +153,13 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         locallyUnprotected.disableProtection(forDomain: domain)
     }
     
+}
+
+extension Array where Element == String {
+    
+    func normalizedDomainsForContentBlocking() -> [String] {
+        map { domain in
+            domain.punycodeEncodedHostname.lowercased()
+        }
+    }
 }

--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -153,7 +153,7 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
     }
 
     public func userDisabledProtection(forDomain domain: String) {
-        locallyUnprotected.disableProtection(forDomain: domain)
+        locallyUnprotected.disableProtection(forDomain: domain.punycodeEncodedHostname.lowercased())
     }
     
 }

--- a/Tests/BrowserServicesKitTests/Common/Extensions/StringExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/StringExtensionTests.swift
@@ -17,7 +17,6 @@
 //
 
 import Foundation
-
 import XCTest
 @testable import BrowserServicesKit
 
@@ -64,5 +63,11 @@ final class StringExtensionTests: XCTestCase {
         
         XCTAssertEqual(normalizedString, "dax")
     }
-
+    
+    func testWhenEmojisArePresentInDomains_ThenTheseCanBePunycoded() {
+        
+        XCTAssertEqual("example.com".punycodeEncodedHostname, "example.com")
+        XCTAssertEqual("Dax🤔.com".punycodeEncodedHostname, "xn--dax-v153b.com")
+        XCTAssertEqual("🤔.com".punycodeEncodedHostname, "xn--wp9h.com")
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/856498667320406/1202191081651325
iOS PR:  https://github.com/duckduckgo/iOS/pull/1134
macOS PR: N/A, test against develop.
What kind of version bump will this require?: Patch

**Description**:

Normalize domain names:
 - Make sure these are lower-case.
 - Punycode if needed.

**Steps to test this PR**:

For iOS refer to iOS PR.

For Mac OS - generic smoke tests for User unprotected sites and site exceptions.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
