### PR TITLE
Add support for email protection logout

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "Autofill",
+        "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
+        "state": {
+          "branch": null,
+          "revision": "a4bff09eb0f3b14005c3960c590ec4efb9c5a23c",
+          "version": "4.5.0"
+        }
+      },
+      {
         "package": "GRDB",
         "repositoryURL": "https://github.com/duckduckgo/GRDB.swift.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "BrowserServicesKit", targets: ["BrowserServicesKit"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("4.4.0")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("4.5.0")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.1.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.0.3")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0"))

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+Email.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+Email.swift
@@ -126,14 +126,14 @@ extension AutofillUserScript {
         }
     }
 
-    private struct DeviceCapabilities: Encodable {
+    private struct DeviceEmailCapabilities: Encodable {
         public let addUserData: Bool
         public let getUserData: Bool
         public let removeUserData: Bool
     }
 
     func emailGetDeviceCapabilities(_ message: AutofillMessage, _ replyHandler: @escaping MessageReplyHandler) {
-        let capabilities = DeviceCapabilities(addUserData: true, getUserData: true, removeUserData: true)
+        let capabilities = DeviceEmailCapabilities(addUserData: true, getUserData: true, removeUserData: true)
         if let json = try? JSONEncoder().encode(capabilities), let jsonString = String(data: json, encoding: .utf8) {
             replyHandler(jsonString)
         } else {

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+Email.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+Email.swift
@@ -29,6 +29,7 @@ public protocol AutofillEmailDelegate: AnyObject {
     func autofillUserScript(_: AutofillUserScript, didRequestStoreToken token: String, username: String, cohort: String?)
     func autofillUserScriptDidRequestUsernameAndAlias(_ : AutofillUserScript, completionHandler: @escaping UsernameAndAliasCompletion)
     func autofillUserScriptDidRequestUserData(_ : AutofillUserScript, completionHandler: @escaping UserDataCompletion)
+    func autofillUserScriptDidRequestSignOut(_ : AutofillUserScript)
     func autofillUserScriptDidRequestSignedInStatus(_: AutofillUserScript) -> Bool
 
 }
@@ -49,6 +50,11 @@ extension AutofillUserScript {
               let username = dict["username"] as? String else { return }
         let cohort = dict["cohort"] as? String
         emailDelegate?.autofillUserScript(self, didRequestStoreToken: token, username: username, cohort: cohort)
+        replyHandler(nil)
+    }
+
+    func emailRemoveToken(_ message: AutofillMessage, _ replyHandler: MessageReplyHandler) {
+        emailDelegate?.autofillUserScriptDidRequestSignOut(self)
         replyHandler(nil)
     }
 
@@ -117,6 +123,21 @@ extension AutofillUserScript {
             } else {
                 replyHandler(nil)
             }
+        }
+    }
+
+    private struct DeviceCapabilities: Encodable {
+        public let addUserData: Bool
+        public let getUserData: Bool
+        public let removeUserData: Bool
+    }
+
+    func emailGetDeviceCapabilities(_ message: AutofillMessage, _ replyHandler: @escaping MessageReplyHandler) {
+        let capabilities = DeviceCapabilities(addUserData: true, getUserData: true, removeUserData: true)
+        if let json = try? JSONEncoder().encode(capabilities), let jsonString = String(data: json, encoding: .utf8) {
+            replyHandler(jsonString)
+        } else {
+            replyHandler(nil)
         }
     }
 

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -90,26 +90,26 @@ public class AutofillUserScript: NSObject, UserScript {
         os_log("AutofillUserScript: received '%{public}s'", log: .userScripts, type: .debug, messageName)
 
         switch message {
-            case .emailHandlerStoreToken: return emailStoreToken
-            case .emailHandlerRemoveToken: return emailRemoveToken
-            case .emailHandlerGetAlias: return emailGetAlias
-            case .emailHandlerGetUserData: return emailGetUserData
-            case .emailHandlerGetCapabilities: return emailGetDeviceCapabilities
-            case .emailHandlerRefreshAlias: return emailRefreshAlias
-            case .emailHandlerGetAddresses: return emailGetAddresses
-            case .emailHandlerCheckAppSignedInStatus: return emailCheckSignedInStatus
+        case .emailHandlerStoreToken: return emailStoreToken
+        case .emailHandlerRemoveToken: return emailRemoveToken
+        case .emailHandlerGetAlias: return emailGetAlias
+        case .emailHandlerGetUserData: return emailGetUserData
+        case .emailHandlerGetCapabilities: return emailGetDeviceCapabilities
+        case .emailHandlerRefreshAlias: return emailRefreshAlias
+        case .emailHandlerGetAddresses: return emailGetAddresses
+        case .emailHandlerCheckAppSignedInStatus: return emailCheckSignedInStatus
 
-            case .pmHandlerGetAutofillInitData: return pmGetAutoFillInitData
+        case .pmHandlerGetAutofillInitData: return pmGetAutoFillInitData
 
-            case .pmHandlerStoreData: return pmStoreData
-            case .pmHandlerGetAccounts: return pmGetAccounts
-            case .pmHandlerGetAutofillCredentials: return pmGetAutofillCredentials
-            case .pmHandlerGetIdentity: return pmGetIdentity
-            case .pmHandlerGetCreditCard: return pmGetCreditCard
+        case .pmHandlerStoreData: return pmStoreData
+        case .pmHandlerGetAccounts: return pmGetAccounts
+        case .pmHandlerGetAutofillCredentials: return pmGetAutofillCredentials
+        case .pmHandlerGetIdentity: return pmGetIdentity
+        case .pmHandlerGetCreditCard: return pmGetCreditCard
 
-            case .pmHandlerOpenManageCreditCards: return pmOpenManageCreditCards
-            case .pmHandlerOpenManageIdentities: return pmOpenManageIdentities
-            case .pmHandlerOpenManagePasswords: return pmOpenManagePasswords
+        case .pmHandlerOpenManageCreditCards: return pmOpenManageCreditCards
+        case .pmHandlerOpenManageIdentities: return pmOpenManageIdentities
+        case .pmHandlerOpenManagePasswords: return pmOpenManagePasswords
         }
     }
 

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -27,8 +27,10 @@ public class AutofillUserScript: NSObject, UserScript {
 
     internal enum MessageName: String, CaseIterable {
         case emailHandlerStoreToken
+        case emailHandlerRemoveToken
         case emailHandlerGetAlias
         case emailHandlerGetUserData
+        case emailHandlerGetCapabilities
         case emailHandlerRefreshAlias
 
         case emailHandlerGetAddresses
@@ -89,8 +91,10 @@ public class AutofillUserScript: NSObject, UserScript {
 
         switch message {
             case .emailHandlerStoreToken: return emailStoreToken
+            case .emailHandlerRemoveToken: return emailRemoveToken
             case .emailHandlerGetAlias: return emailGetAlias
             case .emailHandlerGetUserData: return emailGetUserData
+            case .emailHandlerGetCapabilities: return emailGetDeviceCapabilities
             case .emailHandlerRefreshAlias: return emailRefreshAlias
             case .emailHandlerGetAddresses: return emailGetAddresses
             case .emailHandlerCheckAppSignedInStatus: return emailCheckSignedInStatus

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -252,6 +252,10 @@ extension EmailManager: AutofillEmailDelegate {
             completionHandler(self.username, alias, self.token, nil)
         }
     }
+
+    public func autofillUserScriptDidRequestSignOut(_: AutofillUserScript) {
+        self.signOut()
+    }
     
     public func autofillUserScript(_: AutofillUserScript,
                                    didRequestAliasAndRequiresUserPermission requiresUserPermission: Bool,

--- a/Tests/BrowserServicesKitTests/Autofill/AutofillEmailUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/AutofillEmailUserScriptTests.swift
@@ -268,6 +268,7 @@ class MockAutofillMessage: AutofillMessage {
 class MockAutofillEmailDelegate: AutofillEmailDelegate {
 
     var signedInCallback: (() -> Void)?
+    var signedOutCallback: (() -> Void)?
     var requestAliasCallback: (() -> Void)?
     var requestStoreTokenCallback: ((String, String, String?) -> Void)?
     var refreshAliasCallback: (() -> Void)?
@@ -303,6 +304,10 @@ class MockAutofillEmailDelegate: AutofillEmailDelegate {
     func autofillUserScriptDidRequestUserData(_: AutofillUserScript, completionHandler: @escaping UserDataCompletion) {
         requestUserDataCallback?()
         completionHandler("username", "alias", "token", nil)
+    }
+
+    func autofillUserScriptDidRequestSignOut(_: AutofillUserScript) {
+        signedOutCallback?()
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1202050175851751/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1150
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/581

What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL: 
CC:

**Description**:

Adds support to provide Email Protection web app with a list of email protection specific "capabilities", as well as ability to disable email protection on device (which logs the user out from the Email Protection web app).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

1. Use one of the iOS or macOS branches linked above
2. Go to https://duckduckgo.com/email/settings and log in
   - Confirm that the device has email autofill **enabled**
3. A "Sign Out" button should be visible at the bottom of the Email Protection settings page
4. Click the "Sign Out" button -- you should be logged out of the settings page without needing to refresh the page
   - Confirm that the device has email autofill **disabled**

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
