### PR TITLE
Add interface for caching mainFrame URL and ignore redirects

### DIFF
--- a/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
@@ -25,7 +25,9 @@ public struct LinkProtection {
     
     private var mainFrameUrl: URL?
     
-    public init(privacyManager: PrivacyConfigurationManager, contentBlockingManager: ContentBlockerRulesManager, errorReporting: EventMapping<AMPProtectionDebugEvents>) {
+    public init(privacyManager: PrivacyConfigurationManager,
+                contentBlockingManager: ContentBlockerRulesManager,
+                errorReporting: EventMapping<AMPProtectionDebugEvents>) {
         linkCleaner = LinkCleaner(privacyManager: privacyManager)
         ampExtractor = AMPCanonicalExtractor(linkCleaner: linkCleaner,
                                              privacyManager: privacyManager,
@@ -71,6 +73,7 @@ public struct LinkProtection {
         }
     }
     
+    // swiftlint:disable function_parameter_count
     public func requestTrackingLinkRewrite(initiatingURL: URL?,
                                            navigationAction: WKNavigationAction,
                                            onStartExtracting: () -> Void,
@@ -112,7 +115,7 @@ public struct LinkProtection {
         
         return didRewriteLink
     }
-    
+    // swiftlint:enable function_parameter_count
     
     public func requestTrackingLinkRewrite(initiatingURL: URL?,
                                            navigationAction: WKNavigationAction,

--- a/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
@@ -23,12 +23,18 @@ public struct LinkProtection {
     private let linkCleaner: LinkCleaner
     private let ampExtractor: AMPCanonicalExtractor
     
+    private var mainFrameUrl: URL?
+    
     public init(privacyManager: PrivacyConfigurationManager, contentBlockingManager: ContentBlockerRulesManager, errorReporting: EventMapping<AMPProtectionDebugEvents>) {
         linkCleaner = LinkCleaner(privacyManager: privacyManager)
         ampExtractor = AMPCanonicalExtractor(linkCleaner: linkCleaner,
                                              privacyManager: privacyManager,
                                              contentBlockingManager: contentBlockingManager,
                                              errorReporting: errorReporting)
+    }
+    
+    public func setMainFrameUrl(_ url: URL?) {
+        mainFrameUrl = url
     }
     
     public func getCleanURL(from url: URL,
@@ -72,6 +78,11 @@ public struct LinkProtection {
                                            onLinkRewrite: @escaping (URL, WKNavigationAction) -> Void,
                                            policyDecisionHandler: @escaping (WKNavigationActionPolicy) -> Void) -> Bool {
         let destinationURL = navigationAction.request.url
+        if let mainFrameUrl = mainFrameUrl, destinationURL != mainFrameUrl {
+            // If mainFrameUrl is set and is different from destinationURL we will assume this is a redirect
+            // We do not rewrite redirects due to breakage concerns
+            return false
+        }
         
         var didRewriteLink = false
         if let newURL = linkCleaner.extractCanonicalFromAMPLink(initiator: initiatingURL, destination: destinationURL) {

--- a/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
@@ -33,7 +33,7 @@ public struct LinkProtection {
                                              errorReporting: errorReporting)
     }
     
-    public func setMainFrameUrl(_ url: URL?) {
+    public mutating func setMainFrameUrl(_ url: URL?) {
         mainFrameUrl = url
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1163321984198618/1202227967754334/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1158
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/591
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL:
CC: @bwaresiak 

**Description**:
This PR exposes a method in the LinkProtection module for caching the main frame URL which is used in `requestTrackingLinkRewrite` to detect if the request is a redirect. If it is a redirect we will **not** rewrite the link.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See platform PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15
* [x] macOS 10.15
* [x] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
