### PR TITLE
Added a flag for inline credentials icon

### DIFF
--- a/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
@@ -59,7 +59,14 @@ public struct ContentScopeFeatureToggles: Encodable {
     public let inlineIconCredentials: Bool
     
     // Explicitly defined memberwise init only so it can be public
-    public init(emailProtection: Bool, credentialsAutofill: Bool, identitiesAutofill: Bool, creditCardsAutofill: Bool, credentialsSaving: Bool, passwordGeneration: Bool, inlineIconCredentials: Bool) {
+    public init(emailProtection: Bool,
+                credentialsAutofill: Bool,
+                identitiesAutofill: Bool,
+                creditCardsAutofill: Bool,
+                credentialsSaving: Bool,
+                passwordGeneration: Bool,
+                inlineIconCredentials: Bool) {
+        
         self.emailProtection = emailProtection
         self.credentialsAutofill = credentialsAutofill
         self.identitiesAutofill = identitiesAutofill

--- a/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
@@ -56,14 +56,17 @@ public struct ContentScopeFeatureToggles: Encodable {
     
     public let passwordGeneration: Bool
     
+    public let inlineIconCredentials: Bool
+    
     // Explicitly defined memberwise init only so it can be public
-    public init(emailProtection: Bool, credentialsAutofill: Bool, identitiesAutofill: Bool, creditCardsAutofill: Bool, credentialsSaving: Bool, passwordGeneration: Bool) {
+    public init(emailProtection: Bool, credentialsAutofill: Bool, identitiesAutofill: Bool, creditCardsAutofill: Bool, credentialsSaving: Bool, passwordGeneration: Bool, inlineIconCredentials: Bool) {
         self.emailProtection = emailProtection
         self.credentialsAutofill = credentialsAutofill
         self.identitiesAutofill = identitiesAutofill
         self.creditCardsAutofill = creditCardsAutofill
         self.credentialsSaving = credentialsSaving
         self.passwordGeneration = passwordGeneration
+        self.inlineIconCredentials = inlineIconCredentials
     }
     
     enum CodingKeys: String, CodingKey {
@@ -76,6 +79,8 @@ public struct ContentScopeFeatureToggles: Encodable {
         case credentialsSaving = "credentials_saving"
         
         case passwordGeneration = "password_generation"
+        
+        case inlineIconCredentials = "inlineIcon_credentials"
     }
 }
 

--- a/Tests/BrowserServicesKitTests/UserScript/ContentScopePropertiesMocks.swift
+++ b/Tests/BrowserServicesKitTests/UserScript/ContentScopePropertiesMocks.swift
@@ -14,5 +14,6 @@ extension ContentScopeFeatureToggles {
                                                          identitiesAutofill: true,
                                                          creditCardsAutofill: true,
                                                          credentialsSaving: true,
-                                                         passwordGeneration: true)
+                                                         passwordGeneration: true,
+                                                         inlineIconCredentials: true)
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1202330323073689/f
iOS PR: 
macOS PR: 

What kind of version bump will this require?: Patch

CC: @THISISDINOSAUR 

**Description**:

This adds a new feature toggle so that iOS can remove the the 'key' icon when integrating with the new Autofill changes.

**Steps to test this PR**:
1. Ensure the autofill script loads and operates as normal.
1. There should be no visible changes on iOS or macOS yet.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
