### PR TITLE
move removeParameter methods from iOS; replace parameter in addParameter

### DIFF
--- a/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
@@ -115,6 +115,7 @@ extension URL {
         }
         
         var percentEncodedQueryItems = components.percentEncodedQueryItems ?? [URLQueryItem]()
+        percentEncodedQueryItems.removeAll(where: { $0.name == percentEncodedName })
         percentEncodedQueryItems.append(URLQueryItem(name: percentEncodedName, value: percentEncodedValue))
         components.percentEncodedQueryItems = percentEncodedQueryItems
 
@@ -130,6 +131,22 @@ extension URL {
             queryItem.name == name
         })
         return queryItem?.value
+    }
+
+    public func removeParameter(name: String) -> URL {
+        return self.removeParameters(named: [name])
+    }
+
+    public func removeParameters(named parametersToRemove: Set<String>) -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return self }
+        guard let encodedQuery = components.percentEncodedQuery else { return self }
+        components.percentEncodedQuery = encodedQuery.encodingPlusesAsSpaces()
+        guard var query = components.queryItems else { return self }
+
+        query.removeAll { parametersToRemove.contains($0.name) }
+
+        components.queryItems = query
+        return components.url ?? self
     }
 
 }

--- a/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
@@ -88,4 +88,92 @@ final class URLExtensionTests: XCTestCase {
             URL(string: "https://duck.com/?domains=test.com,example.com%2Ftest,localhost:8000%2Fapi")!
         )
     }
+
+    func testWhenParamExistsThengetParameterReturnsCorrectValue() throws {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
+        let expected = "secondValue"
+        let actual = try url?.getParameter(name: "secondParam")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testWhenParamDoesNotExistThengetParameterIsNil() throws {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
+        let result = try url?.getParameter(name: "someOtherParam")
+        XCTAssertNil(result)
+    }
+
+    func testWhenParamExistsThenRemovingReturnUrlWithoutParam() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
+        let expected = URL(string: "http://test.com?secondParam=secondValue")
+        let actual = url?.removeParameter(name: "firstParam")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testWhenParamDoesNotExistThenRemovingReturnsSameUrl() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
+        let actual = url?.removeParameter(name: "someOtherParam")
+        XCTAssertEqual(actual, url)
+    }
+
+    func testWhenRemovingAParamThenRemainingUrlWebPlusesAreEncodedToEnsureTheyAreMaintainedAsSpaces_bugFix() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=45+%2B+5")
+        let expected = URL(string: "http://test.com?secondParam=45%20+%205")
+        let actual = url?.removeParameter(name: "firstParam")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testWhenRemovingParamsThenRemovingReturnsUrlWithoutParams() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue&thirdParam=thirdValue")
+        let expected = URL(string: "http://test.com?secondParam=secondValue")
+        let actual = url?.removeParameters(named: ["firstParam", "thirdParam"])
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testWhenParamsDoNotExistThenRemovingReturnsSameUrl() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
+        let actual = url?.removeParameters(named: ["someParam", "someOtherParam"])
+        XCTAssertEqual(actual, url)
+    }
+
+    func testWhenEmptyParamArrayIsUsedThenRemovingReturnsSameUrl() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
+        let actual = url?.removeParameters(named: [])
+        XCTAssertEqual(actual, url)
+    }
+
+    func testWhenRemovingParamsThenRemainingUrlWebPlusesAreEncodedToEnsureTheyAreMaintainedAsSpaces_bugFix() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=45+%2B+5")
+        let expected = URL(string: "http://test.com?secondParam=45%20+%205")
+        let actual = url?.removeParameters(named: ["firstParam"])
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testWhenNoParamsThenAddingAppendsQuery() throws {
+        let url = URL(string: "http://test.com")
+        let expected = URL(string: "http://test.com?aParam=aValue")
+        let actual = try url?.addParameter(name: "aParam", value: "aValue")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testWhenParamDoesNotExistThenAddingParamAppendsItToExistingQuery() throws {
+        let url = URL(string: "http://test.com?firstParam=firstValue")
+        let expected = URL(string: "http://test.com?firstParam=firstValue&anotherParam=anotherValue")
+        let actual = try url?.addParameter(name: "anotherParam", value: "anotherValue")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testWhenParamHasInvalidCharactersThenAddingParamAppendsEncodedVersion() throws {
+        let url = URL(string: "http://test.com")
+        let expected = URL(string: "http://test.com?aParam=43%20%2B%205")
+        let actual = try url?.addParameter(name: "aParam", value: "43 + 5")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testWhenParamExistsThenAddingNewValueUpdatesParam() throws {
+        let url = URL(string: "http://test.com?firstParam=firstValue")
+        let expected = URL(string: "http://test.com?firstParam=newValue")
+        let actual = try url?.addParameter(name: "firstParam", value: "newValue")
+        XCTAssertEqual(actual, expected)
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://github.com/duckduckgo/iOS/issues/1191
iOS PR: https://github.com/duckduckgo/iOS/pull/1192
macOS PR: 
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL:
CC: @miasma13 

**Description**:
- Moved URL.removeParameter from iOS codebase and tests
- Updated addParameter to replace URL query parameter if exists

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate addParameter works as expected
2. Validate iOS build works
3. Validate no API change required (minor version change)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
