### PR TITLE
Always block trackers on app start

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesIdentifier.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesIdentifier.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-public class ContentBlockerRulesIdentifier: Equatable {
+public class ContentBlockerRulesIdentifier: Equatable, Codable {
     
     private let name: String
     private let tdsEtag: String

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -108,26 +108,32 @@ public class ContentBlockerRulesManager {
     private var compilationStartTime: TimeInterval?
 
     private let workQueue = DispatchQueue(label: "ContentBlockerManagerQueue", qos: .userInitiated)
+    
+    private let lastCompiledRulesStore: LastCompiledRulesStore?
 
     public init(rulesSource: ContentBlockerRulesListsSource,
                 exceptionsSource: ContentBlockerRulesExceptionsSource,
+                lastCompiledRulesStore: LastCompiledRulesStore? = nil,
                 cache: ContentBlockerRulesCaching? = nil,
                 errorReporting: EventMapping<ContentBlockerDebugEvents>? = nil,
                 logger: OSLog = .disabled) {
         self.rulesSource = rulesSource
         self.exceptionsSource = exceptionsSource
+        self.lastCompiledRulesStore = lastCompiledRulesStore
         self.cache = cache
         self.errorReporting = errorReporting
         self.logger = logger
 
-        requestCompilation(token: "")
+        updateCompilationState(token: "")
+        startInitialCompilationProcess()
     }
+    
     /**
      Variables protected by this lock:
       - state
       - currentRules
      */
-    private let lock = NSLock()
+    private let lock = NSRecursiveLock()
 
     private var state = State.idle
 
@@ -152,12 +158,13 @@ public class ContentBlockerRulesManager {
     public func scheduleCompilation() -> CompletionToken {
         let token = UUID().uuidString
         workQueue.async {
-            self.requestCompilation(token: token)
+            self.updateCompilationState(token: token)
+            self.startCompilationProcess()
         }
         return token
     }
 
-    private func requestCompilation(token: CompletionToken) {
+    private func updateCompilationState(token: CompletionToken) {
         os_log("Requesting compilation...", log: logger, type: .default)
         lock.lock()
         guard case .idle = state else {
@@ -172,15 +179,42 @@ public class ContentBlockerRulesManager {
         }
 
         state = .recompiling(currentTokens: [token])
-        self.compilationStartTime = self.compilationStartTime ?? CACurrentMediaTime()
+        compilationStartTime = compilationStartTime ?? CACurrentMediaTime()
         lock.unlock()
-
-        startCompilationProcess()
     }
-
+    
+    private func startInitialCompilationProcess() {
+        
+        guard let lastCompiledRules = lastCompiledRulesStore?.rules else { return }
+        let initialCompilationTask = InitialCompilationTask(sourceRules: rulesSource.contentBlockerRulesLists,
+                                                            lastCompiledRules: lastCompiledRules)
+        
+        Task {
+            let result = await initialCompilationTask.start()
+            let rules = generateRules(from: result)
+            
+            applyRules(rules)
+            scheduleCompilation()
+        }
+    }
+    
+    private func generateRules(from result: [(ruleList: WKContentRuleList, model: ContentBlockerRulesSourceModel)]) -> [Rules] {
+        result.map {
+            let surrogateTDS = Self.extractSurrogates(from: $0.model.tds)
+            let encodedData = try? JSONEncoder().encode(surrogateTDS)
+            let encodedTrackerData = String(data: encodedData!, encoding: .utf8)!
+            return Rules(name: $0.model.name,
+                         rulesList: $0.ruleList,
+                         trackerData: $0.model.tds,
+                         encodedTrackerData: encodedTrackerData,
+                         etag: $0.model.tdsIdentifier,
+                         identifier: $0.model.rulesIdentifier)
+        }
+    }
+    
     private func startCompilationProcess() {
         // Prepare compilation tasks based on the sources
-        currentTasks = rulesSource.contentBlockerRulesLists.map({ rulesList in
+        currentTasks = rulesSource.contentBlockerRulesLists.map { rulesList in
 
             let sourceManager: ContentBlockerRulesSourceManager
             if let manager = self.sourceManagers[rulesList.name] {
@@ -194,7 +228,7 @@ public class ContentBlockerRulesManager {
                 self.sourceManagers[rulesList.name] = sourceManager
             }
             return CompilationTask(workQueue: workQueue, rulesList: rulesList, sourceManager: sourceManager)
-        })
+        }
 
         executeNextTask()
     }
@@ -275,10 +309,19 @@ public class ContentBlockerRulesManager {
                          identifier: result.model.rulesIdentifier)
         }
 
-        _currentRules = newRules
+        lastCompiledRulesStore?.update(with: newRules)
+        applyRules(newRules, changes: changes)
+
+        lock.unlock()
+    }
+    
+    private func applyRules(_ rules: [Rules], changes: [String: ContentBlockerRulesIdentifier.Difference] = [:]) {
+        lock.lock()
+        
+        _currentRules = rules
 
         let completionTokens: [CompletionToken]
-        let compilationTime = self.compilationStartTime.map { start in CACurrentMediaTime() - start }
+        let compilationTime = compilationStartTime.map { start in CACurrentMediaTime() - start }
         switch state {
         case .recompilingAndScheduled(let currentTokens, let pendingTokens):
             // New work has been scheduled - prepare for execution.
@@ -288,22 +331,22 @@ public class ContentBlockerRulesManager {
 
             completionTokens = currentTokens
             state = .recompiling(currentTokens: pendingTokens)
-            self.compilationStartTime = CACurrentMediaTime()
+            compilationStartTime = CACurrentMediaTime()
 
         case .recompiling(let currentTokens):
             completionTokens = currentTokens
             state = .idle
-            self.compilationStartTime = nil
+            compilationStartTime = nil
 
         case .idle:
             assertionFailure("Unexpected state")
             completionTokens = []
         }
-
+        
         lock.unlock()
-
-        let currentIdentifiers: [String] = newRules.map { $0.identifier.stringValue }
-        self.updatesSubject.send( UpdateEvent(rules: newRules, changes: changes, completionTokens: completionTokens) )
+        
+        let currentIdentifiers: [String] = rules.map { $0.identifier.stringValue }
+        updatesSubject.send(UpdateEvent(rules: rules, changes: changes, completionTokens: completionTokens))
 
         DispatchQueue.main.async {
             if let compilationTime = compilationTime {
@@ -345,12 +388,14 @@ extension ContentBlockerRulesManager {
 
     public convenience init(rulesSource: ContentBlockerRulesListsSource,
                             exceptionsSource: ContentBlockerRulesExceptionsSource,
+                            lastCompiledRulesStore: LastCompiledRulesStore? = nil,
                             cache: ContentBlockerRulesCaching? = nil,
                             updateListener: ContentBlockerRulesUpdating,
                             errorReporting: EventMapping<ContentBlockerDebugEvents>? = nil,
                             logger: OSLog = .disabled) {
         self.init(rulesSource: rulesSource,
                   exceptionsSource: exceptionsSource,
+                  lastCompiledRulesStore: lastCompiledRulesStore,
                   cache: cache,
                   errorReporting: errorReporting,
                   logger: logger)

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -125,7 +125,11 @@ public class ContentBlockerRulesManager {
         self.logger = logger
 
         updateCompilationState(token: "")
-        startInitialCompilationProcess()
+        if let lastCompiledRules = lastCompiledRulesStore?.rules {
+            startInitialCompilationProcess(with: lastCompiledRules)
+        } else {
+            startCompilationProcess()
+        }
     }
     
     /**
@@ -183,9 +187,8 @@ public class ContentBlockerRulesManager {
         lock.unlock()
     }
     
-    private func startInitialCompilationProcess() {
+    private func startInitialCompilationProcess(with lastCompiledRules: [LastCompiledRules]) {
         
-        guard let lastCompiledRules = lastCompiledRulesStore?.rules else { return }
         let initialCompilationTask = InitialCompilationTask(sourceRules: rulesSource.contentBlockerRulesLists,
                                                             lastCompiledRules: lastCompiledRules)
         

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
@@ -62,16 +62,16 @@ open class DefaultContentBlockerRulesListsSource: ContentBlockerRulesListsSource
         public static let trackerDataSetRulesListName = "TrackerDataSet"
     }
 
-    private let trackerDataManger: TrackerDataManager
+    private let trackerDataManager: TrackerDataManager
 
-    public init(trackerDataManger: TrackerDataManager) {
-        self.trackerDataManger = trackerDataManger
+    public init(trackerDataManager: TrackerDataManager) {
+        self.trackerDataManager = trackerDataManager
     }
     
     open var contentBlockerRulesLists: [ContentBlockerRulesList] {
         return [ContentBlockerRulesList(name: Constants.trackerDataSetRulesListName,
-                                        trackerData: trackerDataManger.fetchedData,
-                                        fallbackTrackerData: trackerDataManger.embeddedData)]
+                                        trackerData: trackerDataManager.fetchedData,
+                                        fallbackTrackerData: trackerDataManager.embeddedData)]
     }
 }
 

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesCompilationTask.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesCompilationTask.swift
@@ -122,7 +122,7 @@ extension ContentBlockerRulesManager {
 
             let ruleList = String(data: data, encoding: .utf8)!
             WKContentRuleListStore.default().compileContentRuleList(forIdentifier: model.rulesIdentifier.stringValue,
-                                         encodedContentRuleList: ruleList) { ruleList, error in
+                                                                    encodedContentRuleList: ruleList) { ruleList, error in
 
                 if let ruleList = ruleList {
                     self.compilationSucceded(with: ruleList, model: model, completionHandler: completionHandler)

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesInitialCompilationTask.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesInitialCompilationTask.swift
@@ -1,0 +1,62 @@
+//
+//  ContentBlockerRulesSourceManager.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+
+extension ContentBlockerRulesManager {
+    
+    final class InitialCompilationTask {
+        
+        private let sourceRules: [ContentBlockerRulesList]
+        private let lastCompiledRules: [LastCompiledRules]
+        
+        init(sourceRules: [ContentBlockerRulesList], lastCompiledRules: [LastCompiledRules]) {
+            self.sourceRules = sourceRules
+            self.lastCompiledRules = lastCompiledRules
+        }
+        
+        @MainActor
+        func start() async -> [(WKContentRuleList, ContentBlockerRulesSourceModel)] {
+            let sourceRulesNames = sourceRules.map { $0.name }
+            let filteredBySourceLastCompiledRules = lastCompiledRules.filter { sourceRulesNames.contains($0.name) }
+            
+            var result: [(WKContentRuleList, ContentBlockerRulesSourceModel)] = []
+            for rules in filteredBySourceLastCompiledRules {
+                guard let ruleList = await WKContentRuleListStore.default()?.lookUpContentRuleList(forIdentifier: rules.identifier.stringValue) else { continue }
+                result.append((ruleList, ContentBlockerRulesSourceModel(name: rules.name, tdsIdentfier: rules.etag, tds: rules.trackerData)))
+            }
+            return result
+        }
+        
+    }
+    
+}
+
+private extension WKContentRuleListStore {
+    
+    func lookUpContentRuleList(forIdentifier identifier: String) async -> WKContentRuleList? {
+        await withCheckedContinuation { continuation in
+            lookUpContentRuleList(forIdentifier: identifier) { ruleList, _ in
+                continuation.resume(returning: ruleList)
+            }
+        }
+    }
+    
+}

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesInitialCompilationTask.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesInitialCompilationTask.swift
@@ -39,7 +39,8 @@ extension ContentBlockerRulesManager {
             
             var result: [(WKContentRuleList, ContentBlockerRulesSourceModel)] = []
             for rules in filteredBySourceLastCompiledRules {
-                guard let ruleList = await WKContentRuleListStore.default()?.lookUpContentRuleList(forIdentifier: rules.identifier.stringValue) else { continue }
+                guard let ruleList = await WKContentRuleListStore.default()?
+                    .lookUpContentRuleList(forIdentifier: rules.identifier.stringValue) else { continue }
                 result.append((ruleList, ContentBlockerRulesSourceModel(name: rules.name, tdsIdentfier: rules.etag, tds: rules.trackerData)))
             }
             return result

--- a/Sources/BrowserServicesKit/ContentBlocking/LastCompiledRulesStore.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/LastCompiledRulesStore.swift
@@ -1,0 +1,37 @@
+//
+//  LastCompiledRulesStore.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import TrackerRadarKit
+
+public protocol LastCompiledRules {
+    
+    var name: String { get }
+    var trackerData: TrackerData { get }
+    var etag: String { get }
+    var identifier: ContentBlockerRulesIdentifier { get }
+    
+}
+
+public protocol LastCompiledRulesStore {
+    
+    var rules: [LastCompiledRules] { get }
+    func update(with contentBlockerRules: [ContentBlockerRulesManager.Rules])
+    
+}

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerInitialCompilationTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerInitialCompilationTests.swift
@@ -1,0 +1,92 @@
+//
+//  ContentBlockerRulesManagerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import TrackerRadarKit
+import BrowserServicesKit
+import WebKit
+import XCTest
+
+final class ContentBlockerRulesManagerInitialCompilationTests: XCTestCase {
+    
+    private static let fakeEmbeddedDataSet = ContentBlockerRulesManagerTests.makeDataSet(tds: ContentBlockerRulesManagerTests.validRules, etag: "\"\(UUID().uuidString)\"")
+    private let rulesUpdateListener = RulesUpdateListener()
+    
+    func testSuccessfulCompilationStoresLastCompiledRules() {
+        
+        let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: ContentBlockerRulesManagerTests.makeDataSet(tds: ContentBlockerRulesManagerTests.validRules,
+                                                                                                                                etag: ContentBlockerRulesManagerTests.makeEtag()),
+                                                                       embeddedTrackerData: Self.fakeEmbeddedDataSet)
+        let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
+        let mockLastCompiledRulesStore = MockLastCompiledRulesStore()
+        
+        let exp = expectation(description: "Rules Compiled")
+        rulesUpdateListener.onRulesUpdated = { _ in
+            exp.fulfill()
+        }
+        
+        _ = ContentBlockerRulesManager(rulesSource: mockRulesSource,
+                                       exceptionsSource: mockExceptionsSource,
+                                       lastCompiledRulesStore: mockLastCompiledRulesStore,
+                                       updateListener: rulesUpdateListener)
+        
+        wait(for: [exp], timeout: 15.0)
+        
+        XCTAssertNotNil(mockLastCompiledRulesStore.rules)
+        XCTAssertEqual(mockLastCompiledRulesStore.rules.first?.etag, mockRulesSource.trackerData?.etag)
+        XCTAssertEqual(mockLastCompiledRulesStore.rules.first?.name, mockRulesSource.rukeListName)
+        XCTAssertEqual(mockLastCompiledRulesStore.rules.first?.trackerData, mockRulesSource.trackerData?.tds)
+        
+        XCTAssertEqual(mockLastCompiledRulesStore.rules.first?.identifier,
+                       ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
+                                                     tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
+                                                     tempListEtag: nil,
+                                                     allowListEtag: nil,
+                                                     unprotectedSitesHash: nil))
+    }
+    
+    // func last compiled rules == mockRulesSource -> 1 compilation (?)
+    // func last compiled rules and no source
+    // func last compiled rules == changed config in the meantime, we have to do 2 compilations
+    
+    struct MockLastCompiledRules: LastCompiledRules {
+        
+        var name: String
+        var trackerData: TrackerData
+        var etag: String
+        var identifier: ContentBlockerRulesIdentifier
+    
+    }
+    
+    final class MockLastCompiledRulesStore: LastCompiledRulesStore {
+        
+        var rules: [LastCompiledRules] = []
+        
+        func update(with contentBlockerRules: [ContentBlockerRulesManager.Rules]) {
+            rules = contentBlockerRules.map { rules in
+                MockLastCompiledRules(name: rules.name,
+                                      trackerData: rules.trackerData,
+                                      etag: rules.etag,
+                                      identifier: rules.identifier)
+            }
+        }
+        
+    }
+    
+}

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerInitialCompilationTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerInitialCompilationTests.swift
@@ -32,6 +32,7 @@ final class CountedFulfillmentTestExpectation: XCTestExpectation {
     }
 }
 
+// swiftlint:disable line_length
 final class ContentBlockerRulesManagerInitialCompilationTests: XCTestCase {
     
     private static let fakeEmbeddedDataSet = ContentBlockerRulesManagerTests.makeDataSet(tds: ContentBlockerRulesManagerTests.validRules, etag: "\"\(UUID().uuidString)\"")
@@ -112,6 +113,7 @@ final class ContentBlockerRulesManagerInitialCompilationTests: XCTestCase {
         }
     }
     
+    // swiftlint:disable:next function_body_length
     func testInitialCompilation_WhenThereAreChangesToTDS_ShouldBuildRulesUsingLastCompiledRulesAndScheduleRecompilationWithNewSource() {
         
         let oldEtag = ContentBlockerRulesManagerTests.makeEtag()

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
@@ -174,13 +174,13 @@ class ContentBlockerRulesManagerTests: XCTestCase {
 
 final class RulesUpdateListener: ContentBlockerRulesUpdating {
 
-    var onRulesUpdated: ([String: ContentBlockerRulesIdentifier.Difference]) -> Void = { _ in }
+    var onRulesUpdated: ([ContentBlockerRulesManager.Rules]) -> Void = { _ in }
 
     func rulesManager(_ manager: ContentBlockerRulesManager,
-                      didUpdateRules: [ContentBlockerRulesManager.Rules],
+                      didUpdateRules rules: [ContentBlockerRulesManager.Rules],
                       changes: [String: ContentBlockerRulesIdentifier.Difference],
                       completionTokens: [ContentBlockerRulesManager.CompletionToken]) {
-        onRulesUpdated(changes)
+        onRulesUpdated(rules)
     }
 }
 


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/72649045549333/1201955257558990/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1207
macOS PR: 
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL: https://app.asana.com/0/0/1201985695010211/f
CC:

**Description**:
Make sure that trackers are always blocked on start.

**Steps to test this PR**:
1. Compile rules and cache these.
1. Kill the app.
1. Update Privacy config or TDS (along with ETag).
1. See that:
rules are returned quickly (no delay on startup)
trackers are blocked on startup
rules are recompiled to latest correct state within few seconds from browser start

**OS Testing**:

* [ ] iOS 15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
