### PR TITLE
Add script load types to AMP CBRs

### DIFF
--- a/Sources/BrowserServicesKit/LinkProtection/AMPCanonicalExtractor.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/AMPCanonicalExtractor.swift
@@ -89,21 +89,12 @@ public class AMPCanonicalExtractor: NSObject {
     {
         "trigger": {
             "url-filter": ".*",
-            "resource-type": ["image"]
+            "resource-type": ["image", "style-sheet", "script"]
         },
         "action": {
             "type": "block"
         }
-    },
-    {
-        "trigger": {
-            "url-filter": ".*",
-            "resource-type": ["style-sheet"]
-        },
-        "action": {
-            "type": "block"
-        }
-    },
+    }
 ]
 """
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1202198075905303/1202519457279975/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1216
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/627
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description:**
This PR updates AMP deep extraction CBRs to block script load types.

**Steps to test this PR:**
1. Visit https://privacy-test-pages.glitch.me/privacy-protections/amp/
2. Ensure the links on this page take you to the expected sites.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15
* [x] macOS 10.15
* [x] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
