### PR TITLE
Revert "Move secure vault to group"

### DIFF
--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
@@ -68,7 +68,6 @@ final class DefaultDatabaseProvider: SecureVaultDatabaseProvider {
         var config = Configuration()
         config.prepareDatabase {
             try $0.usePassphrase(key)
-            try $0.execute(sql: "PRAGMA journal_mode = WAL;")
         }
 
         do {
@@ -651,16 +650,6 @@ struct MigrationUtility {
 
 extension DefaultDatabaseProvider {
 
-#if os(iOS)
-    static let groupIdPrefix: String = {
-        let groupIdPrefixKey = "DuckDuckGoGroupIdentifierPrefix"
-        guard let groupIdPrefix = Bundle.main.object(forInfoDictionaryKey: groupIdPrefixKey) as? String else {
-            fatalError("Info.plist must contain a \"\(groupIdPrefixKey)\" entry with a string value")
-        }
-        return groupIdPrefix
-    }()
-#endif
-
     static internal func dbFile() -> URL {
 
         let fm = FileManager.default
@@ -671,9 +660,8 @@ extension DefaultDatabaseProvider {
         let libraryURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!
         let dir = libraryURL.appendingPathComponent(sandboxPathComponent)
 #else
-        let groupName = "\(Self.groupIdPrefix).vault"
-        guard let dir = fm.containerURL(forSecurityApplicationGroupIdentifier: groupName) else {
-            fatalError("Could not find vault container")
+        guard let dir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            fatalError("Could not find application support directory")
         }
 #endif
         let subDir = dir.appendingPathComponent("Vault")

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -35,8 +35,6 @@ public struct AutofillData {
 }
 
 public protocol SecureVaultManagerDelegate: SecureVaultErrorReporting {
-    
-    func secureVaultManagerIsEnabledStatus(_: SecureVaultManager) -> Bool
 
     func secureVaultManager(_: SecureVaultManager, promptUserToStoreAutofillData data: AutofillData)
     
@@ -76,10 +74,6 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                                                                  [SecureVaultModels.CreditCard]) -> Void) {
 
         do {
-            guard let delegate = delegate, delegate.secureVaultManagerIsEnabledStatus(self) else {
-                completionHandler([], [], [])
-                return
-            }
             let vault = try self.vault ?? SecureVaultFactory.default.makeVault(errorReporter: self.delegate)
             let accounts = try vault.accountsFor(domain: domain)
             let identities = try vault.identities()

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
@@ -226,10 +226,6 @@ private class MockSecureVaultManagerDelegate: SecureVaultManagerDelegate {
     
     private(set) var promptedAutofillData: AutofillData?
     
-    func secureVaultManagerIsEnabledStatus(_: SecureVaultManager) -> Bool {
-        return true
-    }
-    
     func secureVaultManager(_: SecureVaultManager, promptUserToStoreAutofillData data: AutofillData) {
         self.promptedAutofillData = data
     }


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:
Task/Issue URL: https://app.asana.com/0/0/1202546257736894/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1224
macOS PR:  https://github.com/more-duckduckgo-org/macos-browser/pull/634
What kind of version bump will this require?: Major


**Description:**
Reverts duckduckgo/BrowserServicesKit#113
