### PR TITLE
Bump autofill version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "403a731aa5eee65b7ca833bfad5890360e0dfcd7",
-          "version": "4.7.0"
+          "revision": "27a4cff621893ef9d1b96ec62c99b137a3a73450",
+          "version": "4.7.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "BrowserServicesKit", targets: ["BrowserServicesKit"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("4.7.0")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("4.7.1")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.1.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.0.4")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0"))


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1202606879030948/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1238
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/640
What kind of version bump will this require?: Minor

**Description**:
Bump autofill version. Minor fixes and improvements.

**Steps to test this PR**:
1. Visit instagram.com and click on login and signup. The forms are correctly identified as a login form (you can autofill if you have credentials, otherwise nothing) and a signup form (offers to autofill the email).

**OS Testing**:

* [ ] iOS 15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
