### PR TITLE
Import content-scope-scripts package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Sources/BrowserServicesKit/Resources/content-scope-scripts"]
-	path = Sources/BrowserServicesKit/Resources/content-scope-scripts
-	url = https://github.com/duckduckgo/content-scope-scripts
 [submodule "Tests/BrowserServicesKitTests/Resources/privacy-reference-tests"]
 	path = Tests/BrowserServicesKitTests/Resources/privacy-reference-tests
 	url = https://github.com/duckduckgo/privacy-reference-tests

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "ContentScopeScripts",
         "repositoryURL": "https://github.com/duckduckgo/content-scope-scripts",
         "state": {
-          "branch": "jkt/remote-values",
-          "revision": "89fec8c33afaad59715dd313baf250273c1c9b3a",
-          "version": null
+          "branch": null,
+          "revision": "b06512e7e757ae8cdba5a538b0dae13adc61b50d",
+          "version": "2.3.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "ContentScopeScripts",
+        "repositoryURL": "https://github.com/duckduckgo/content-scope-scripts",
+        "state": {
+          "branch": "jkt/remote-values",
+          "revision": "89fec8c33afaad59715dd313baf250273c1c9b3a",
+          "version": null
+        }
+      },
+      {
         "package": "Autofill",
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             name: "BrowserServicesKit",
             dependencies: [
                 "Autofill",
-                "ContentScopeScripts",
+                .product(name: "ContentScopeScripts", package: "content-scope-scripts"),
                 "GRDB",
                 "TrackerRadarKit",
                 .product(name: "Punnycode", package: "Punycode"),

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("4.7.1")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.1.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.0.4")),
-        .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0"))
+        .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", .branch("jkt/remote-values"))
     ],
     targets: [
         
@@ -30,25 +31,9 @@ let package = Package(
                 .product(name: "Punnycode", package: "Punycode"),
                 "BloomFilterWrapper"
             ],
-            exclude: [
-                "Resources/content-scope-scripts/README.md",
-                "Resources/content-scope-scripts/package-lock.json",
-                "Resources/content-scope-scripts/package.json",
-                "Resources/content-scope-scripts/LICENSE.md",
-                "Resources/content-scope-scripts/src/",
-                "Resources/content-scope-scripts/unit-test/",
-                "Resources/content-scope-scripts/integration-test/",
-                "Resources/content-scope-scripts/scripts/",
-                "Resources/content-scope-scripts/inject/",
-                "Resources/content-scope-scripts/lib/",
-                "Resources/content-scope-scripts/build/chrome/",
-                "Resources/content-scope-scripts/build/firefox/",
-                "Resources/content-scope-scripts/build/integration/"
-            ],
             resources: [
                 .process("ContentBlocking/UserScripts/contentblockerrules.js"),
-                .process("ContentBlocking/UserScripts/surrogates.js"),
-                .process("Resources/content-scope-scripts/build/apple/contentScope.js")
+                .process("ContentBlocking/UserScripts/surrogates.js")
             ]),
         .target(
             name: "BloomFilterWrapper",

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
             name: "BrowserServicesKit",
             dependencies: [
                 "Autofill",
+                "ContentScopeScripts",
                 "GRDB",
                 "TrackerRadarKit",
                 .product(name: "Punnycode", package: "Punycode"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.1.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.0.4")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", .branch("jkt/remote-values"))
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", .exact("2.3.0"))
     ],
     targets: [
         

--- a/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
@@ -19,6 +19,7 @@
 import Foundation
 import WebKit
 import Combine
+import ContentScopeScripts
 
 public final class ContentScopeProperties: Encodable {
     public let globalPrivacyControlValue: Bool
@@ -119,7 +120,7 @@ public final class ContentScopeUserScript: NSObject, UserScript {
             return ""
         }
         
-        return loadJS("contentScope", from: Bundle.module, withReplacements: [
+        return loadJS("contentScope", from: ContentScopeScripts.Bundle, withReplacements: [
             "$CONTENT_SCOPE$": privacyConfigJson,
             "$USER_UNPROTECTED_DOMAINS$": userUnprotectedDomainsString,
             "$USER_PREFERENCES$": jsonPropertiesString


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/inbox/1164476816701138/1200810841420629/1202639355018975
iOS PR: https://github.com/duckduckgo/iOS/pull/1250
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/648
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL: https://app.asana.com/0/481882893211075/1202623399558035/f
CC: @tomasstrba @jonathanKingston @bwaresiak 

**Description**:
This PR migrates content-scope-scripts from a submodule dependency to a Swift module. This will aid future updates to this module. In addition it updates content-scope-scripts to a version which supports configurable fingerprinting values. An updated version of the config will enabled these features.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Force the local privacy config to load by commenting lines 102-106 and lines 114-116 in [this file](https://github.com/duckduckgo/BrowserServicesKit/blob/e6e859fb643d2530f2a6dc2d40001f66d2b705a4/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationManager.swift#L102) (Alternatively build [this branch](https://github.com/duckduckgo/privacy-configuration/pull/324) of the config and modify the mac to load from a local server)
1. Visit https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/
1. Ensure "Include all headers..." is checked, run the tests, and expand the results
3. Ensure the following results are displayed:
    - `navigator.hardwareConcurrency`: 4
    - `screen.availTop`: 0
    - `screen.availLeft`: 0
    - `screen.availWidth` == `screen.width`
    - `screen.availHeight` == `screen.height`
    - `screen.colorDepth`: 24
    - `screen.pixelDepth`: 24
4. Visit https://privacy-test-pages.glitch.me/features/canvas-draw.html and click "Draw Pattern"
6. In a separate tab visit https://good.third-party.site/features/canvas-draw.html and click "Draw Pattern" again
8. Ensure output strings under the canvases are different between the tabs.
9. Visit https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/canvas.html All tests should pass.
10. Disable protections. 1st and 3rd tests should fail.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15
* [x] macOS 10.15
* [x] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
