### PR TITLE
Fix threading issue and identifier mismatch in intial rule population

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesIdentifier.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesIdentifier.swift
@@ -21,11 +21,11 @@ import Foundation
 
 public class ContentBlockerRulesIdentifier: Equatable, Codable {
     
-    private let name: String
-    private let tdsEtag: String
-    private let tempListEtag: String
-    private let allowListEtag: String
-    private let unprotectedSitesHash: String
+    let name: String
+    let tdsEtag: String
+    let tempListEtag: String
+    let allowListEtag: String
+    let unprotectedSitesHash: String
     
     public var stringValue: String {
         return name + tdsEtag + tempListEtag + unprotectedSitesHash

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -196,27 +196,35 @@ public class ContentBlockerRulesManager {
         let initialCompilationTask = InitialCompilationTask(sourceRules: rulesSource.contentBlockerRulesLists,
                                                             lastCompiledRules: lastCompiledRules)
         self.workQueue.async {
-            Task {
-                let result = await initialCompilationTask.start()
-                let rules = self.generateRules(from: result)
-                
-                self.applyRules(rules)
-                self.scheduleCompilation()
+            let mutex = DispatchSemaphore(value: 0)
+            var result = [InitialCompilationTask.CachedRulesList]()
+            withUnsafeMutablePointer(to: &result) { pointer in
+                Task {
+                    pointer.pointee = await initialCompilationTask.start()
+                    // Leave context of current thread (most likely Main Thread, casue of await above) as soon as possible.
+                    mutex.signal()
+                }
+                // We want to confine Compilation work to WorkQueue, so we wait to come back from async Task
+                mutex.wait()
             }
+
+            let rules = self.generateRules(from: result)
+            self.applyRules(rules)
+            self.scheduleCompilation()
         }
     }
     
-    private func generateRules(from result: [(ruleList: WKContentRuleList, model: ContentBlockerRulesSourceModel)]) -> [Rules] {
+    private func generateRules(from result: [InitialCompilationTask.CachedRulesList]) -> [Rules] {
         result.map {
-            let surrogateTDS = Self.extractSurrogates(from: $0.model.tds)
+            let surrogateTDS = Self.extractSurrogates(from: $0.tds)
             let encodedData = try? JSONEncoder().encode(surrogateTDS)
             let encodedTrackerData = String(data: encodedData!, encoding: .utf8)!
-            return Rules(name: $0.model.name,
-                         rulesList: $0.ruleList,
-                         trackerData: $0.model.tds,
+            return Rules(name: $0.name,
+                         rulesList: $0.rulesList,
+                         trackerData: $0.tds,
                          encodedTrackerData: encodedTrackerData,
-                         etag: $0.model.tdsIdentifier,
-                         identifier: $0.model.rulesIdentifier)
+                         etag: $0.rulesIdentifier.tdsEtag,
+                         identifier: $0.rulesIdentifier)
         }
     }
     

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -23,6 +23,8 @@ import os.log
 import TrackerRadarKit
 import Combine
 
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
 public protocol ContentBlockerRulesCaching: AnyObject {
     var contentRulesCache: [String: Date] { get set }
     var contentRulesCacheInterval: TimeInterval { get }
@@ -170,7 +172,6 @@ public class ContentBlockerRulesManager {
         return token
     }
 
-    
     /// Returns true if the compilation should be executed immediately
     private func updateCompilationState(token: CompletionToken) -> Bool {
         os_log("Requesting compilation...", log: logger, type: .default)
@@ -251,7 +252,7 @@ public class ContentBlockerRulesManager {
 
     private func executeNextTask() {
         if let nextTask = currentTasks.first(where: { !$0.completed }) {
-            nextTask.start { success in
+            nextTask.start { _ in
                 self.executeNextTask()
             }
         } else {
@@ -433,3 +434,6 @@ extension ContentBlockerRulesManager {
     }
 
 }
+
+// swiftlint:enable type_body_length
+// swiftlint:enable file_length


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1202648064853354
iOS PR:  
macOS PR: 
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

Fix ID mismatch and synchronize work between async queues.
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Validate initial load of compiled rules and compilation paths.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [x] iOS 14
* [x] iOS 15
* [ ] macOS 10.15
* [x] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
