### PR TITLE
Email Manager keychain error reporting

### DIFF
--- a/Sources/BrowserServicesKit/Email/EmailKeychainManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailKeychainManager.swift
@@ -171,7 +171,7 @@ private extension EmailKeychainManager {
             return
         }
 
-        try deleteAuthenticationState()
+        deleteAuthenticationState()
         
         try add(data: tokenData, forField: .token)
         try add(data: usernameData, forField: .username)

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -43,7 +43,7 @@ public enum EmailKeychainAccessError: Error, Equatable {
         case .failedToDecodeKeychainValueAsData: return "failedToDecodeKeychainValueAsData"
         case .failedToDecodeKeychainDataAsString: return "failedToDecodeKeychainDataAsString"
         case .failedToDecodeKeychainDataAsInt: return "failedToDecodeKeychainDataAsInt"
-        case .keychainAccessFailure(_): return "keychainAccessFailure"
+        case .keychainAccessFailure: return "keychainAccessFailure"
         }
     }
 }

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -38,6 +38,15 @@ public enum EmailKeychainAccessError: Error, Equatable {
     case failedToDecodeKeychainDataAsString
     case failedToDecodeKeychainDataAsInt
     case keychainAccessFailure(OSStatus)
+    
+    public var errorDescription: String {
+        switch self {
+        case .failedToDecodeKeychainValueAsData: return "failedToDecodeKeychainValueAsData"
+        case .failedToDecodeKeychainDataAsString: return "failedToDecodeKeychainDataAsString"
+        case .failedToDecodeKeychainDataAsInt: return "failedToDecodeKeychainDataAsInt"
+        case .keychainAccessFailure(_): return "keychainAccessFailure"
+        }
+    }
 }
 
 public protocol EmailManagerStorage: AnyObject {

--- a/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
@@ -628,10 +628,26 @@ class EmailManagerTests: XCTestCase {
 
         wait(for: [dateStoredExpectation], timeout: 1.0)
     }
+    
+    func testWhenGettingUsername_AndKeychainAccessFails_ThenRequestDelegateIsCalled() {
+        let username = "dax"
+        let storage = MockEmailManagerStorage()
+        storage.mockError = .keychainAccessFailure(errSecInternalError)
+        storage.mockUsername = username
+        let emailManager = EmailManager(storage: storage)
+        
+        let requestDelegate = MockEmailManagerRequestDelegate()
+        emailManager.requestDelegate = requestDelegate
+
+        XCTAssertNil(emailManager.userEmail)
+        XCTAssertEqual(requestDelegate.keychainAccessErrorAccessType, .getUsername)
+        XCTAssertEqual(requestDelegate.keychainAccessError, .keychainAccessFailure(errSecInternalError))
+    }
+    
 }
 
 class MockEmailManagerRequestDelegate: EmailManagerRequestDelegate {
-
+    
     var mockAliases: [String] = []
     var waitlistTimestamp: Int = 1
     
@@ -653,6 +669,14 @@ class MockEmailManagerRequestDelegate: EmailManagerRequestDelegate {
         }
     }
     // swiftlint:enable function_parameter_count
+    
+    var keychainAccessErrorAccessType: EmailKeychainAccessType?
+    var keychainAccessError: EmailKeychainAccessError?
+    
+    func emailManagerKeychainAccessFailed(accessType: EmailKeychainAccessType, error: EmailKeychainAccessError) {
+        keychainAccessErrorAccessType = accessType
+        keychainAccessError = error
+    }
 
     private func processMockAliasRequest(_ completion: @escaping (Data?, Error?) -> Void) {
         events.append(.aliasRequestMade)
@@ -695,6 +719,8 @@ class MockEmailManagerRequestDelegate: EmailManagerRequestDelegate {
 
 class MockEmailManagerStorage: EmailManagerStorage {
 
+    var mockError: EmailKeychainAccessError?
+    
     var mockUsername: String?
     var mockToken: String?
     var mockAlias: String?
@@ -703,6 +729,7 @@ class MockEmailManagerStorage: EmailManagerStorage {
     var mockWaitlistToken: String?
     var mockWaitlistTimestamp: Int?
     var mockWaitlistInviteCode: String?
+
     var storeTokenCallback: ((String, String, String?) -> Void)?
     var storeAliasCallback: ((String) -> Void)?
     var storeLastUseDateCallback: ((String) -> Void)?
@@ -713,23 +740,28 @@ class MockEmailManagerStorage: EmailManagerStorage {
     var storeWaitlistInviteCodeCallback: ((String) -> Void)?
     var deleteWaitlistStateCallback: (() -> Void)?
     
-    func getUsername() -> String? {
+    func getUsername() throws -> String? {
+        if let mockError = mockError { throw mockError }
         return mockUsername
     }
     
-    func getToken() -> String? {
+    func getToken() throws -> String? {
+        if let mockError = mockError { throw mockError }
         return mockToken
     }
     
-    func getAlias() -> String? {
+    func getAlias() throws -> String? {
+        if let mockError = mockError { throw mockError }
         return mockAlias
     }
 
-    func getCohort() -> String? {
+    func getCohort() throws -> String? {
+        if let mockError = mockError { throw mockError }
         return mockCohort
     }
 
-    func getLastUseDate() -> String? {
+    func getLastUseDate() throws -> String? {
+        if let mockError = mockError { throw mockError }
         return mockLastUseDate
     }
 

--- a/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
@@ -765,23 +765,23 @@ class MockEmailManagerStorage: EmailManagerStorage {
         return mockLastUseDate
     }
 
-    func store(token: String, username: String, cohort: String?) {
+    func store(token: String, username: String, cohort: String?) throws {
         storeTokenCallback?(token, username, cohort)
     }
     
-    func store(alias: String) {
+    func store(alias: String) throws {
         storeAliasCallback?(alias)
     }
 
-    func store(lastUseDate: String) {
+    func store(lastUseDate: String) throws {
         storeLastUseDateCallback?(lastUseDate)
     }
     
-    func deleteAlias() {
+    func deleteAlias() throws {
         deleteAliasCallback?()
     }
     
-    func deleteAuthenticationState() {
+    func deleteAuthenticationState() throws {
         deleteAuthenticationStateCallback?()
     }
 

--- a/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
@@ -647,7 +647,7 @@ class EmailManagerTests: XCTestCase {
 }
 
 class MockEmailManagerRequestDelegate: EmailManagerRequestDelegate {
-    
+
     var mockAliases: [String] = []
     var waitlistTimestamp: Int = 1
     
@@ -777,11 +777,11 @@ class MockEmailManagerStorage: EmailManagerStorage {
         storeLastUseDateCallback?(lastUseDate)
     }
     
-    func deleteAlias() throws {
+    func deleteAlias() {
         deleteAliasCallback?()
     }
     
-    func deleteAuthenticationState() throws {
+    func deleteAuthenticationState() {
         deleteAuthenticationStateCallback?()
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1202679436624547/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1258
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/662
What kind of version bump will this require?: Patch

**Description**:

This PR adds error reporting to the email manager's keychain access. It does this by adding a new delegate method to the email manager's request delegate, which then requests that the client codebase fire a pixel on BSK's behalf.

Errors are reported when data from the keychain cannot be read correctly, or if the keychain itself has an error, unless the error is `errSecItemNotFound` in which case the usual nil value is returned.

**Note:** This functionality was deliberately only added to non-waitlist functions.

**Extra Note:** There are SwiftLint failures that exist in the modified files that have been around for a long time, they're not worth fixing as a part of these changes.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check out this branch in a local copy of BSK
1. Add your local BSK checkout to your local copy of the iOS repo running this branch
1. Test all of the email waitlist functionality as usual – sign in, sign out, fill your Duck address, fill a random alias. I like to use https://nextdraft.com since it has an email field right on the home page.
1. Go into `EmailKeychainManager` and add a deliberate thrown error into one of the getter functions, like `getString(forField:)`
1. Run the app again and visit https://nextdraft.com, check that the console shows pixels being sent; on iOS this is `m_email_autofill_keychain_error`
1. Modify the deliberately thrown error to return a keychain error, like `throw EmailKeychainAccessError.keychainAccessFailure(errSecInvalidData)`
1. Run the app and once more visit https://nextdraft.com, check that the console shows the keychain pixel error being sent and **also includes the error status code**

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15
* [x] macOS 10.15
* [x] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
