### PR TITLE
[WIP] Fire pixel when autoprompt is dismissed

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "27a4cff621893ef9d1b96ec62c99b137a3a73450",
-          "version": "4.7.1"
+          "revision": "5e0cc08f3bf16fcbce7b5ecde09ea85734b1fdbc",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "BrowserServicesKit", targets: ["BrowserServicesKit"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("4.7.1")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("5e0cc08f3bf16fcbce7b5ecde09ea85734b1fdbc")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.1.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.0.4")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -41,6 +41,7 @@ public protocol AutofillSecureVaultDelegate: AnyObject {
                             completionHandler: @escaping ([SecureVaultModels.WebsiteAccount]) -> Void)
     func autofillUserScript(_: AutofillUserScript, didRequestCredentialsForDomain: String,
                             subType: AutofillUserScript.GetAutofillDataSubType,
+                            isAutoprompt: Bool,
                             completionHandler: @escaping (SecureVaultModels.WebsiteCredentials?, RequestVaultCredentialsAction) -> Void)
     
     func autofillUserScript(_: AutofillUserScript, didRequestCredentialsForAccount accountId: Int64,
@@ -329,6 +330,7 @@ extension AutofillUserScript {
     struct GetAutofillDataRequest: Codable {
         let mainType: GetAutofillDataMainType
         let subType: GetAutofillDataSubType
+        let isAutoprompt: Bool
     }
 
     // https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/deviceApiCalls/schemas/getAutofillData.params.json
@@ -350,7 +352,7 @@ extension AutofillUserScript {
         }
 
         let domain = hostForMessage(message)
-        vaultDelegate?.autofillUserScript(self, didRequestCredentialsForDomain: domain, subType: request.subType) { credentials, action in
+        vaultDelegate?.autofillUserScript(self, didRequestCredentialsForDomain: domain, subType: request.subType, isAutoprompt: request.isAutoprompt) { credentials, action in
             let response = RequestVaultCredentialsForDomainResponse.responseFromSecureVaultWebsiteCredentials(credentials, action: action)
 
             if let json = try? JSONEncoder().encode(response), let jsonString = String(data: json, encoding: .utf8) {

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -41,6 +41,7 @@ public protocol SecureVaultManagerDelegate: SecureVaultErrorReporting {
     func secureVaultManager(_: SecureVaultManager,
                             promptUserToAutofillCredentialsForDomain domain: String,
                             withAccounts accounts: [SecureVaultModels.WebsiteAccount],
+                            withIsAutoprompt isAutoprompt: Bool,
                             completionHandler: @escaping (SecureVaultModels.WebsiteAccount?) -> Void)
 
     func secureVaultManagerShouldAutomaticallyUpdateCredentialsWithoutUsername(_: SecureVaultManager) -> Bool
@@ -127,6 +128,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
     public func autofillUserScript(_: AutofillUserScript,
                                    didRequestCredentialsForDomain domain: String,
                                    subType: AutofillUserScript.GetAutofillDataSubType,
+                                   isAutoprompt: Bool,
                                    completionHandler: @escaping (SecureVaultModels.WebsiteCredentials?, RequestVaultCredentialsAction) -> Void) {
         do {
             let vault = try self.vault ?? SecureVaultFactory.default.makeVault(errorReporter: self.delegate)
@@ -146,7 +148,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                 return
             }
 
-            delegate?.secureVaultManager(self, promptUserToAutofillCredentialsForDomain: domain, withAccounts: accounts) { account  in
+            delegate?.secureVaultManager(self, promptUserToAutofillCredentialsForDomain: domain, withAccounts: accounts, withIsAutoprompt: isAutoprompt) { account  in
                 
                 guard let accountID = account?.id else {
                     completionHandler(nil, .none)


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1202674424656875/f
iOS PR: WIP
macOS PR: WIP
What kind of version bump will this require?: Minor

**Description**:
This fires a pixel when autoprompt is dismissed.

**Steps to test this PR**:
**Pixel fired on iOS**
1. On iOS, visit a login page where you have credentials. For example, https://privacy-test-pages.glitch.me/autofill/autoprompt/case-1.html (save credentials for this page if you haven't yet).
2. Provided the form is front and center and not covered on pageload you should be prompted to autofill your credentials automatically (this is the case on the page linked above).
3. Dismiss the prompt and look at the Xcode console. You should see a pixel called `m_autofill_logins_autoprompt_dismissed`.

**No pixel on iOS**
1. On iOS, visit a login page where you have credentials but the form does not trigger autoprompt. For example, https://privacy-test-pages.glitch.me/autofill/autoprompt/case-2.html.2. 
2. Dismiss the prompt and look at the Xcode console. You should **not** see a pixel called `m_autofill_logins_autoprompt_dismissed`.

**No pixel on macOS**
1. On macOS, visit https://privacy-test-pages.glitch.me/autofill/autoprompt/case-1.html (you may have to save credentials for this page).
2. The autofill prompt should be open.
3. Dismiss the prompt by hitting Escape or clicking anywhere on the page.
4. You should **not** see the pixel `m_autofill_logins_autoprompt_dismissed`.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
