### PR TITLE
[WIP] Add credentialsProvider feature flag

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "7f30dbe8fe0f248e8fc0c4830ecb7f0c829e1502",
+          "revision": "c043911786c2657d039e306adfd3849b163ed6af",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "516209f9a0252c9795b51ca3c815cfbbf34ad0a0",
-          "version": "5.2.0"
+          "revision": "d0d090fc93f92cbab4c5b31279b316ebeb86b718",
+          "version": null
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "c043911786c2657d039e306adfd3849b163ed6af",
+          "revision": "d45ed0e11cc73467b980221d36b975abe82d78c4",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "7f8e8cbe54ee581f33cc82eca8c9f96135d8ef0e",
+          "revision": "ba289980a6a2377f5af6e1fe97600290d4121b5a",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "d0d090fc93f92cbab4c5b31279b316ebeb86b718",
+          "revision": "7f8e8cbe54ee581f33cc82eca8c9f96135d8ef0e",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "ba289980a6a2377f5af6e1fe97600290d4121b5a",
+          "revision": "7f30dbe8fe0f248e8fc0c4830ecb7f0c829e1502",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "Common", targets: ["Common"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("c043911786c2657d039e306adfd3849b163ed6af")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("d45ed0e11cc73467b980221d36b975abe82d78c4")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "Common", targets: ["Common"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("d0d090fc93f92cbab4c5b31279b316ebeb86b718")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("7f8e8cbe54ee581f33cc82eca8c9f96135d8ef0e")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "Common", targets: ["Common"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("7f30dbe8fe0f248e8fc0c4830ecb7f0c829e1502")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("c043911786c2657d039e306adfd3849b163ed6af")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "Common", targets: ["Common"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.2.0")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("d0d090fc93f92cbab4c5b31279b316ebeb86b718")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "Common", targets: ["Common"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("ba289980a6a2377f5af6e1fe97600290d4121b5a")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("7f30dbe8fe0f248e8fc0c4830ecb7f0c829e1502")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "Common", targets: ["Common"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("7f8e8cbe54ee581f33cc82eca8c9f96135d8ef0e")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .revision("ba289980a6a2377f5af6e1fe97600290d4121b5a")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -229,7 +229,7 @@ extension AutofillUserScript {
 
     struct RequestAvailableInputTypesResponse: Codable {
 
-        // GetAvailableInputTypesResponse: https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/deviceApiCalls/schemas/getAvailableInputTypes.result.json
+        // GetAvailableInputTypesResponse: https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/deviceApiCalls/schemas/availableInputTypes.json
         // TODO: change the type
         struct AvailableInputTypesSuccess: Codable {
             let email: Bool

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -142,8 +142,9 @@ extension AutofillUserScript {
     }
 
     struct CredentialObject: Codable {
-        let id: Int64
+        let id: String
         let username: String
+        let credentialsProvider: String? // TODO: use enum "bitwarden" | "duckduckgo"
     }
     
     // MARK: - Requests
@@ -228,6 +229,8 @@ extension AutofillUserScript {
 
     struct RequestAvailableInputTypesResponse: Codable {
 
+        // GetAvailableInputTypesResponse: https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/deviceApiCalls/schemas/getAvailableInputTypes.result.json
+        // TODO: change the type
         struct AvailableInputTypesSuccess: Codable {
             let email: Bool
             let credentials: Bool
@@ -265,9 +268,10 @@ extension AutofillUserScript {
     }
     
     struct CredentialResponse: Codable {
-        let id: String
+        let id: String // <- TODO: when bitwarden is locked use id = "provider_locked"
         let username: String
         let password: String
+        let credentialsProvider: String? // TODO: <- use enum "bitwarden" | "duckduckgo"
     }
 
     // GetAutofillDataResponse: https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/deviceApiCalls/schemas/getAutofillData.result.json
@@ -285,7 +289,8 @@ extension AutofillUserScript {
                                                               action: RequestVaultCredentialsAction) -> Self {
             let credential: CredentialResponse?
             if let credentials = credentials, let id = credentials.account.id, let password = String(data: credentials.password, encoding: .utf8) {
-                credential = CredentialResponse(id: String(id), username: credentials.account.username, password: password)
+                // TODO: use dynamic value for credentialsProvider
+                credential = CredentialResponse(id: String(id), username: credentials.account.username, password: password, credentialsProvider: "bitwarden")
             } else {
                 credential = nil
             }
@@ -303,17 +308,26 @@ extension AutofillUserScript {
     // MARK: - Message Handlers
     
     func getAvailableInputTypes(_ message: AutofillMessage, _ replyHandler: @escaping MessageReplyHandler) {
+    
+        guard let request: GetAvailableInputTypesRequest = DecodableHelper.decode(from: message.messageBody) else {
+            return
+        }
+        
+        let mainType = request.mainType
         let domain = hostForMessage(message)
         let email = emailDelegate?.autofillUserScriptDidRequestSignedInStatus(self) ?? false
         vaultDelegate?.autofillUserScript(self, didRequestAutoFillInitDataForDomain: domain) { accounts, identities, cards in
+            // TODO: here we should check if we have at least one username and one password in any of the credential items
             let credentials: [CredentialObject] = accounts.compactMap {
                 guard let id = $0.id else { return nil }
-                return .init(id: id, username: $0.username)
+                return .init(id: String(id), username: $0.username, credentialsProvider: "bitwarden")
             }
 
+            // TODO: same for these items. We must return an object as described in the schema (see line 231 above) where every input type is true if we have at least 1 value across all items
             let identities: [IdentityObject] = identities.compactMap(IdentityObject.from(identity:))
             let cards: [CreditCardObject] = cards.compactMap(CreditCardObject.autofillInitializationValueFrom(card:))
 
+            // TODO: this must conform to the new type to be defined in line 231 above
             let success = RequestAvailableInputTypesResponse.AvailableInputTypesSuccess(
                     email: email,
                     credentials: credentials.count > 0,
@@ -322,9 +336,25 @@ extension AutofillUserScript {
             )
             let response = RequestAvailableInputTypesResponse(success: success, error: nil)
             if let json = try? JSONEncoder().encode(response), let jsonString = String(data: json, encoding: .utf8) {
-                replyHandler(jsonString)
+                // TODO: use dynamic values. Instead of "credentials" it should be the mainType passed as a parameter above
+                // IMPORTANT: when bitwarden is locked the credentials should always be both true!
+                replyHandler("""
+                {
+                    "success": {
+                        "credentials": {
+                            "username": true,
+                            "password": true
+                        }
+                    }
+                }
+                """)
             }
         }
+    }
+    
+    // https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/deviceApiCalls/schemas/getAvailableInputTypes.params.json
+    struct GetAvailableInputTypesRequest: Codable {
+        let mainType: GetAutofillDataMainType
     }
 
     // https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/deviceApiCalls/schemas/getAutofillData.params.json
@@ -336,8 +366,9 @@ extension AutofillUserScript {
 
     // https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/deviceApiCalls/schemas/getAutofillData.params.json
     public enum GetAutofillDataMainType: String, Codable {
-        // only 'credentials' is currently supported
         case credentials
+        case identities
+        case creditCards
     }
 
     // https://github.com/duckduckgo/duckduckgo-autofill/blob/main/src/deviceApiCalls/schemas/getAutofillData.params.json
@@ -373,7 +404,8 @@ extension AutofillUserScript {
         vaultDelegate?.autofillUserScript(self, didRequestAutoFillInitDataForDomain: domain) { accounts, identities, cards in
             let credentials: [CredentialObject] = accounts.compactMap {
                 guard let id = $0.id else { return nil }
-                return .init(id: id, username: $0.username)
+                // TODO: When bitwarden is locked pass "provider_locked" as the id, and empty string as username
+                return .init(id: String(id), username: $0.username, credentialsProvider: "bitwarden")
             }
 
             let identities: [IdentityObject] = identities.compactMap(IdentityObject.from(identity:))
@@ -412,7 +444,8 @@ extension AutofillUserScript {
         vaultDelegate?.autofillUserScript(self, didRequestAccountsForDomain: hostForMessage(message)) { credentials in
             let credentials: [CredentialObject] = credentials.compactMap {
                 guard let id = $0.id else { return nil }
-                return .init(id: id, username: $0.username)
+                // TODO: use dynamic value for credentialsProvider
+                return .init(id: String(id), username: $0.username, credentialsProvider: "bitwarden")
             }
 
             let response = RequestVaultAccountsResponse(success: credentials)
@@ -438,7 +471,9 @@ extension AutofillUserScript {
 
             let response = RequestVaultCredentialsForAccountResponse(success: .init(id: String(id),
                                                                     username: credential.account.username,
-                                                                    password: password))
+                                                                    password: password,
+                                                                    // TODO: use dynamic value
+                                                                    credentialsProvider: "bitwarden"))
             if let json = try? JSONEncoder().encode(response), let jsonString = String(data: json, encoding: .utf8) {
                 replyHandler(jsonString)
             }

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SourceProvider.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SourceProvider.swift
@@ -58,7 +58,39 @@ public class DefaultAutofillSourceProvider: AutofillUserScriptSourceProvider {
         replacements["// INJECT contentScope HERE"] = "contentScope = " + privacyConfigJson + ";"
         replacements["// INJECT userUnprotectedDomains HERE"] = "userUnprotectedDomains = " + userUnprotectedDomainsString + ";"
         replacements["// INJECT userPreferences HERE"] = "userPreferences = " + jsonPropertiesString + ";"
+        // TODO: use dynamic values
+        let availableInputTypes = """
+            {
+                credentials: undefined,
+                identities: {
+                    firstName: true,
+                    middleName: true,
+                    lastName: true,
+                    birthdayDay: true,
+                    birthdayMonth: true,
+                    birthdayYear: true,
+                    addressStreet: true,
+                    addressStreet2: true,
+                    addressCity: true,
+                    addressProvince: true,
+                    addressPostalCode: true,
+                    addressCountryCode: true,
+                    phone: true,
+                    emailAddress: true         // <- this is true if we have an address in identities OR if email protection is enabled
+                },
+                creditCards: {
+                    cardName: true,
+                    cardSecurityCode: true,
+                    expirationMonth: true,
+                    expirationYear: true,
+                    cardNumber: true
+                },
+                email: true                    // <- this is specific for email protection
+            }
+        """
+        replacements["// INJECT availableInputTypes HERE"] = "availableInputTypes = " + availableInputTypes + ";"
 
-        sourceStr = AutofillUserScript.loadJS("assets/autofill", from: Autofill.bundle, withReplacements: replacements)
+        // TODO: revert to "assets/autofill" once the integration is complete
+        sourceStr = AutofillUserScript.loadJS("assets/autofill-debug", from: Autofill.bundle, withReplacements: replacements)
     }
 }

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -51,6 +51,9 @@ public class AutofillUserScript: NSObject, UserScript {
         case getAvailableInputTypes
         case getAutofillData
         case storeFormData
+        
+        case askToUnlockProvider
+        case checkCredentialsProviderStatus
     }
 
     /// Represents if the autofill is loaded into the top autofill context.
@@ -132,6 +135,9 @@ public class AutofillUserScript: NSObject, UserScript {
         case .pmHandlerOpenManageCreditCards: return pmOpenManageCreditCards
         case .pmHandlerOpenManageIdentities: return pmOpenManageIdentities
         case .pmHandlerOpenManagePasswords: return pmOpenManagePasswords
+            
+        case .askToUnlockProvider: return askToUnlockProvider
+        case .checkCredentialsProviderStatus: return checkCredentialsProviderStatus
         }
     }
     // swiftlint:enable cyclomatic_complexity

--- a/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
@@ -58,8 +58,7 @@ public struct ContentScopeFeatureToggles: Encodable {
     public let passwordGeneration: Bool
     
     public let inlineIconCredentials: Bool
-    // TODO: use an enum as mentioned in Asana
-    public let credentialsProvider: String
+    public let thirdPartyCredentialsProvider: Bool
     
     // Explicitly defined memberwise init only so it can be public
     public init(emailProtection: Bool,
@@ -69,7 +68,7 @@ public struct ContentScopeFeatureToggles: Encodable {
                 credentialsSaving: Bool,
                 passwordGeneration: Bool,
                 inlineIconCredentials: Bool,
-                credentialsProvider: String) {
+                thirdPartyCredentialsProvider: Bool) {
         
         self.emailProtection = emailProtection
         self.credentialsAutofill = credentialsAutofill
@@ -78,7 +77,7 @@ public struct ContentScopeFeatureToggles: Encodable {
         self.credentialsSaving = credentialsSaving
         self.passwordGeneration = passwordGeneration
         self.inlineIconCredentials = inlineIconCredentials
-        self.credentialsProvider = credentialsProvider
+        self.thirdPartyCredentialsProvider = thirdPartyCredentialsProvider
     }
     
     enum CodingKeys: String, CodingKey {
@@ -93,7 +92,7 @@ public struct ContentScopeFeatureToggles: Encodable {
         case passwordGeneration = "password_generation"
         
         case inlineIconCredentials = "inlineIcon_credentials"
-        case credentialsProvider = "credentials_provider"
+        case thirdPartyCredentialsProvider = "third_party_credentials_provider"
     }
 }
 

--- a/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift
@@ -58,6 +58,8 @@ public struct ContentScopeFeatureToggles: Encodable {
     public let passwordGeneration: Bool
     
     public let inlineIconCredentials: Bool
+    // TODO: use an enum as mentioned in Asana
+    public let credentialsProvider: String
     
     // Explicitly defined memberwise init only so it can be public
     public init(emailProtection: Bool,
@@ -66,7 +68,8 @@ public struct ContentScopeFeatureToggles: Encodable {
                 creditCardsAutofill: Bool,
                 credentialsSaving: Bool,
                 passwordGeneration: Bool,
-                inlineIconCredentials: Bool) {
+                inlineIconCredentials: Bool,
+                credentialsProvider: String) {
         
         self.emailProtection = emailProtection
         self.credentialsAutofill = credentialsAutofill
@@ -75,6 +78,7 @@ public struct ContentScopeFeatureToggles: Encodable {
         self.credentialsSaving = credentialsSaving
         self.passwordGeneration = passwordGeneration
         self.inlineIconCredentials = inlineIconCredentials
+        self.credentialsProvider = credentialsProvider
     }
     
     enum CodingKeys: String, CodingKey {
@@ -89,6 +93,7 @@ public struct ContentScopeFeatureToggles: Encodable {
         case passwordGeneration = "password_generation"
         
         case inlineIconCredentials = "inlineIcon_credentials"
+        case credentialsProvider = "credentials_provider"
     }
 }
 

--- a/Tests/BrowserServicesKitTests/UserScript/ContentScopePropertiesMocks.swift
+++ b/Tests/BrowserServicesKitTests/UserScript/ContentScopePropertiesMocks.swift
@@ -15,5 +15,6 @@ extension ContentScopeFeatureToggles {
                                                          creditCardsAutofill: true,
                                                          credentialsSaving: true,
                                                          passwordGeneration: true,
-                                                         inlineIconCredentials: true)
+                                                         inlineIconCredentials: true,
+                                                         credentialsProvider: "duckduckgo")
 }

--- a/Tests/BrowserServicesKitTests/UserScript/ContentScopePropertiesMocks.swift
+++ b/Tests/BrowserServicesKitTests/UserScript/ContentScopePropertiesMocks.swift
@@ -16,5 +16,5 @@ extension ContentScopeFeatureToggles {
                                                          credentialsSaving: true,
                                                          passwordGeneration: true,
                                                          inlineIconCredentials: true,
-                                                         credentialsProvider: "duckduckgo")
+                                                         thirdPartyCredentialsProvider: false)
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1202852141087806/f
iOS PR: TBD
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/710
What kind of version bump will this require?: **Major**

**Optional**:

Tech Design URL: https://app.asana.com/0/481882893211075/1203035091319598/f
CC: @tomasstrba @samsymons 

**Description**:
This branch demonstrates a bunch of API changes needed for the native/js communication for the Bitwarden integration. I've added `TODO`s on every spot that needs to be changed so they're easy to spot and you guys have a clear guidance into what is needed right inline. Do let me know if you need more info.
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Compile it with the [appropriate macOS branch](https://github.com/more-duckduckgo-org/macos-browser/pull/710).
1. Open a page where you have credentials (e.g.: https://privacy-test-pages.glitch.me/autofill/autoprompt/1-standard-login-form.html).
1. The autofill tooltip should show the Bitwarden logo.


To check the Bitwarden Locked UI:

1. Change the value of the `id` to `provider_locked` [here](https://github.com/duckduckgo/BrowserServicesKit/pull/136/files#diff-e3a6f8439dda8c6e33174e39d592d5dad70242d03c6801acebc0ef5f49106c3eR407).
1. Check the same page. You should now see the Bitwarden Locked tooltip UI.
1. NOTE: clicking on it will send the usual `pmGetAutofillCredentials` call but with the `id: provider_locked`. You can plug in your logic so that it triggers Bitwarden. This is not done in this PR.

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [ ] macOS 10.15
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
