### PR TITLE
Don't return referrers that are the same

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/duckduckgo/content-scope-scripts",
         "state": {
           "branch": null,
-          "revision": "430ad3879cc49fbdb3f62bd73e13f2dea58ed1df",
-          "version": "2.4.1"
+          "revision": "b06512e7e757ae8cdba5a538b0dae13adc61b50d",
+          "version": "2.3.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/duckduckgo/content-scope-scripts",
         "state": {
           "branch": null,
-          "revision": "b06512e7e757ae8cdba5a538b0dae13adc61b50d",
-          "version": "2.3.0"
+          "revision": "430ad3879cc49fbdb3f62bd73e13f2dea58ed1df",
+          "version": "2.4.1"
         }
       },
       {

--- a/Sources/BrowserServicesKit/ReferrerTrimming/ReferrerTrimming.swift
+++ b/Sources/BrowserServicesKit/ReferrerTrimming/ReferrerTrimming.swift
@@ -103,6 +103,10 @@ public class ReferrerTrimming {
             newReferrer = "\(referrerScheme)://\(tld.eTLDplus1(referrerHost) ?? referrerHost)/"
         }
         
+        if newReferrer == referrerUrl.absoluteString {
+            return nil
+        }
+        
         return newReferrer
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: 
iOS PR: https://github.com/duckduckgo/iOS/pull/1296
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/712
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC: @samsymons @bwaresiak 

**Description**:
Don't return a new referrer if its the same as the old one

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
(See platform PRs)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15
* [x] macOS 10.15
* [x] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
