### PR TITLE
URL Extension improvements

### DIFF
--- a/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/StringExtension.swift
@@ -60,17 +60,6 @@ public extension String {
     func droppingWwwPrefix() -> String {
         self.dropping(prefix: "www.")
     }
-
-    // Replaces plus symbols in a string with the space character encoding
-    // Space UTF-8 encoding is 0x20
-    func encodingPlusesAsSpaces() -> String {
-        return replacingOccurrences(of: "+", with: "%20")
-    }
-    
-    func removingCharacters(in set: CharacterSet) -> String {
-      let filtered = unicodeScalars.filter { !set.contains($0) }
-      return String(String.UnicodeScalarView(filtered))
-    }
     
     func autofillNormalized() -> String {
         let autofillCharacterSet = CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters).union(.symbols)
@@ -110,12 +99,33 @@ public extension String {
 
 }
 
-// MARK: - Punycode
-extension String {
-    public var punycodeEncodedHostname: String {
+public extension StringProtocol {
+
+    // Replaces plus symbols in a string with the space character encoding
+    // Space UTF-8 encoding is 0x20
+    func encodingPlusesAsSpaces() -> String {
+        return replacingOccurrences(of: "+", with: "%20")
+    }
+
+    func percentEncoded(withAllowedCharacters allowedCharacters: CharacterSet) -> String {
+        if let percentEncoded = self.addingPercentEncoding(withAllowedCharacters: allowedCharacters) {
+            return percentEncoded
+        }
+        assertionFailure("Unexpected failure")
+        return components(separatedBy: allowedCharacters.inverted).joined()
+    }
+
+    func removingCharacters(in set: CharacterSet) -> String {
+        let filtered = unicodeScalars.filter { !set.contains($0) }
+        return String(String.UnicodeScalarView(filtered))
+    }
+
+    // MARK: Punycode
+    var punycodeEncodedHostname: String {
         return self.split(separator: ".")
             .map { String($0) }
             .map { $0.idnaEncoded ?? $0 }
             .joined(separator: ".")
     }
+
 }

--- a/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
@@ -161,7 +161,6 @@ extension URL {
         }
 
         var query = ""
-        let allowedCharacters = CharacterSet(charactersIn: "%+").union(.urlQueryParameterAllowed)
         if urlAndQuery.count > 1 {
             // escape invalid characters with %20 in query values
             // keep already encoded characters and + sign in place
@@ -173,15 +172,17 @@ extension URL {
                         let isParameterName = (idx == 0)
                         guard !(isParameterName && component.contains(" ")) else { throw Throwable() }
 
-                        return component.percentEncoded(withAllowedCharacters: allowedCharacters)
+                        return component.percentEncoded(withAllowedCharacters: .urlQueryStringAllowed)
                     }.joined(separator: "=")
                 }.joined(separator: "&")
             } catch {
                 return nil
             }
+        } else if urlAndHash[0].hasSuffix("?") {
+            query = "?"
         }
         if urlAndHash.count > 1 {
-            query += "#" + urlAndHash[1].percentEncoded(withAllowedCharacters: allowedCharacters)
+            query += "#" + urlAndHash[1].percentEncoded(withAllowedCharacters: .urlQueryStringAllowed)
         } else if s.hasSuffix("#") {
             query += "#"
         }
@@ -314,6 +315,7 @@ fileprivate extension CharacterSet {
     static let urlQueryReserved = CharacterSet(charactersIn: ":/?#[]@!$&'()*+,;=")
 
     static let urlQueryParameterAllowed = CharacterSet.urlQueryAllowed.subtracting(Self.urlQueryReserved)
+    static let urlQueryStringAllowed = CharacterSet(charactersIn: "%+?").union(.urlQueryParameterAllowed)
 
 }
 

--- a/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
+++ b/Sources/BrowserServicesKit/Common/Extensions/URLExtension.swift
@@ -159,17 +159,17 @@ extension URL {
         var query = ""
         if urlAndQuery.count > 1 {
             // escape invalid characters with %20 in query values
+            // keep already encoded characters and + sign in place
+            let allowedCharacters = CharacterSet(charactersIn: "%+").union(.urlQueryParameterAllowed)
             do {
                 struct Throwable: Error {}
                 query = try "?" + urlAndQuery[1].split(separator: "&").map { component in
                     try component.split(separator: "=", maxSplits: 1).enumerated().map { idx, component -> String in
-                        // don't allow spaces in query names
-                        guard !(idx == 0 && component.contains(" ")),
-                              let encoded = component.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed)
-                        else {
-                            throw Throwable()
-                        }
-                        return encoded
+                        // don't allow spaces in parameter names
+                        let isParameterName = (idx == 0)
+                        guard !(isParameterName && component.contains(" ")) else { throw Throwable() }
+
+                        return component.percentEncoded(withAllowedCharacters: allowedCharacters)
                     }.joined(separator: "=")
                 }.joined(separator: "&")
             } catch {
@@ -186,7 +186,7 @@ extension URL {
 
         let encodedPath = componentsWithoutQuery
             .dropFirst()
-            .map { $0.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlPathAllowed) ?? $0 }
+            .map { $0.percentEncoded(withAllowedCharacters: .urlPathAllowed) }
             .joined(separator: "/")
 
         let hostPathSeparator = !encodedPath.isEmpty || urlAndQuery[0].hasSuffix("/") ? "/" : ""
@@ -229,51 +229,41 @@ extension URL {
 
     // MARK: - Parameters
 
-    public enum ParameterError: Error {
-        case parsingFailed
-        case encodingFailed
-        case creatingFailed
+    public func appendingParameters<C: Collection>(_ parameters: C, allowedReservedCharacters: CharacterSet? = nil) -> URL
+    where C.Element == (key: String, value: String) {
+
+        return parameters.reduce(self) { partialResult, parameter in
+            partialResult.appendingParameter(
+                name: parameter.key,
+                value: parameter.value,
+                allowedReservedCharacters: allowedReservedCharacters
+            )
+        }
     }
 
-    public func appendingParameters<C: Collection>(_ parameters: C) throws -> URL where C.Element == (key: String, value: String) {
-        var url = self
-
-        for parameter in parameters {
-            url = try url.appendingParameter(name: parameter.key, value: parameter.value)
-        }
-
-        return url
+    public func appendingParameter(name: String, value: String, allowedReservedCharacters: CharacterSet? = nil) -> URL {
+        let queryItem = URLQueryItem(percentEncodingName: name,
+                                     value: value,
+                                     withAllowedCharacters: allowedReservedCharacters)
+        return self.appending(percentEncodedQueryItem: queryItem)
     }
 
-    public func appendingParameter(name: String, value: String, allowedReservedCharacters: CharacterSet? = nil) throws -> URL {
-        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { throw ParameterError.parsingFailed }
-        
-        let allowedCharacters: CharacterSet = {
-            if let allowedReservedCharacters = allowedReservedCharacters {
-                return .urlQueryParameterAllowed.union(allowedReservedCharacters)
-            }
-            return .urlQueryParameterAllowed
-        }()
-        
-        guard let percentEncodedName = name.addingPercentEncoding(withAllowedCharacters: allowedCharacters),
-              let percentEncodedValue = value.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
-        else {
-            throw ParameterError.encodingFailed
-        }
-        
+    public func appending(percentEncodedQueryItem: URLQueryItem) -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else { return self }
+
         var percentEncodedQueryItems = components.percentEncodedQueryItems ?? [URLQueryItem]()
-        percentEncodedQueryItems.append(URLQueryItem(name: percentEncodedName, value: percentEncodedValue))
+        percentEncodedQueryItems.append(percentEncodedQueryItem)
         components.percentEncodedQueryItems = percentEncodedQueryItems
 
-        guard let newUrl = components.url else { throw ParameterError.creatingFailed }
-        return newUrl
+        return components.url ?? self
     }
 
-    public func getParameter(name: String) throws -> String? {
-        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { throw ParameterError.parsingFailed }
-        guard let encodedQuery = components.percentEncodedQuery else { throw ParameterError.encodingFailed }
+    public func getParameter(named name: String) -> String? {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false),
+              let encodedQuery = components.percentEncodedQuery
+        else { return nil }
         components.percentEncodedQuery = encodedQuery.encodingPlusesAsSpaces()
-        let queryItem = components.queryItems?.first(where: { (queryItem) -> Bool in
+        let queryItem = components.queryItems?.first(where: { queryItem -> Bool in
             queryItem.name == name
         })
         return queryItem?.value
@@ -294,13 +284,11 @@ extension URL {
 
     public func removingParameters(named parametersToRemove: Set<String>) -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return self }
-        guard let encodedQuery = components.percentEncodedQuery else { return self }
-        components.percentEncodedQuery = encodedQuery.encodingPlusesAsSpaces()
-        guard var query = components.queryItems else { return self }
 
-        query.removeAll { parametersToRemove.contains($0.name) }
+        var percentEncodedQueryItems = components.percentEncodedQueryItems ?? [URLQueryItem]()
+        percentEncodedQueryItems.removeAll { parametersToRemove.contains($0.name) }
+        components.percentEncodedQueryItems = percentEncodedQueryItems
 
-        components.queryItems = query
         return components.url ?? self
     }
 
@@ -315,7 +303,25 @@ fileprivate extension CharacterSet {
      * included in `CharacterSet.urlQueryAllowed` but still need to be percent-escaped.
      */
     static let urlQueryReserved = CharacterSet(charactersIn: ":/?#[]@!$&'()*+,;=")
-    
+
     static let urlQueryParameterAllowed = CharacterSet.urlQueryAllowed.subtracting(Self.urlQueryReserved)
+
+}
+
+extension URLQueryItem {
+
+    init(percentEncodingName name: String, value: String, withAllowedCharacters allowedReservedCharacters: CharacterSet? = nil) {
+        let allowedCharacters: CharacterSet = {
+            if let allowedReservedCharacters = allowedReservedCharacters {
+                return .urlQueryParameterAllowed.union(allowedReservedCharacters)
+            }
+            return .urlQueryParameterAllowed
+        }()
+
+        let percentEncodedName = name.percentEncoded(withAllowedCharacters: allowedCharacters)
+        let percentEncodedValue = value.percentEncoded(withAllowedCharacters: allowedCharacters)
+
+        self.init(name: percentEncodedName, value: percentEncodedValue)
+    }
 
 }

--- a/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionDetection.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionDetection.swift
@@ -67,7 +67,7 @@ public class AdClickAttributionDetection {
         var vendorDomain: String?
         if attributionFeature.isDomainDetectionEnabled,
            let adDomainParameterName = attributionFeature.attributionDomainParameterName(for: url),
-           let domainFromParameter = try? url.getParameter(name: adDomainParameterName),
+           let domainFromParameter = url.getParameter(named: adDomainParameterName),
            !domainFromParameter.isEmpty {
             
             if let eTLDp1 = tld.eTLDplus1(domainFromParameter)?.lowercased() {

--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/AdClickAttributionFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/AdClickAttributionFeature.swift
@@ -62,7 +62,7 @@ public class AdClickAttributionFeature: AdClickAttributing {
             for linkFormat in linkFormats[domain] ?? [] where linkFormat.url.host == domain && url.path == linkFormat.url.path {
 
                 if let parameterMatching = linkFormat.adDomainParameterName,
-                   (try? url.getParameter(name: parameterMatching)) != nil {
+                   url.getParameter(named: parameterMatching) != nil {
                     return linkFormat
                 } else if linkFormat.matcher?.matches(url) ?? false {
                     return linkFormat
@@ -71,7 +71,7 @@ public class AdClickAttributionFeature: AdClickAttributing {
             return nil
         }
     }
-    
+
     enum Constants {
         static let linkFormatsSettingsKey = "linkFormats"
         static let allowlistSettingsKey = "allowlist"
@@ -203,7 +203,7 @@ public class AdClickAttributionFeature: AdClickAttributing {
         }
         
         override func matches(_ url: URL) -> Bool {
-            return (try? url.getParameter(name: paramName)) != nil
+            return url.getParameter(named: paramName) != nil
         }
     }
     
@@ -217,7 +217,7 @@ public class AdClickAttributionFeature: AdClickAttributing {
         }
         
         override func matches(_ url: URL) -> Bool {
-            guard let value = (try? url.getParameter(name: paramName)) else {
+            guard let value = url.getParameter(named: paramName) else {
                 return false
             }
             return value == paramValue

--- a/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 @testable import BrowserServicesKit
 
+// swiftlint:disable line_length
 final class URLExtensionTests: XCTestCase {
 
     func test_external_urls_are_valid() {

--- a/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
@@ -65,42 +65,42 @@ final class URLExtensionTests: XCTestCase {
     }
 
     func testWhenAddParameterIsCalled_ThenItDoesNotChangeExistingURL() {
-        let url = URL(string: "https://duckduckgo.com/?q=Battlestar+Galactica")!
+        let url = URL(string: "https://duckduckgo.com/?q=Battle%20star+Galactica%25a")!
 
         XCTAssertEqual(
-            try url.appendingParameter(name: "ia", value: "web"),
-            URL(string: "https://duckduckgo.com/?q=Battlestar+Galactica&ia=web")!
+            url.appendingParameter(name: "ia", value: "web"),
+            URL(string: "https://duckduckgo.com/?q=Battle%20star+Galactica%25a&ia=web")!
         )
     }
 
     func testWhenAddParameterIsCalled_ThenItEncodesRFC3986QueryReservedCharactersInTheParameter() {
         let url = URL(string: "https://duck.com/")!
 
-        XCTAssertEqual(try url.appendingParameter(name: ":", value: ":"), URL(string: "https://duck.com/?%3A=%3A")!)
-        XCTAssertEqual(try url.appendingParameter(name: "/", value: "/"), URL(string: "https://duck.com/?%2F=%2F")!)
-        XCTAssertEqual(try url.appendingParameter(name: "?", value: "?"), URL(string: "https://duck.com/?%3F=%3F")!)
-        XCTAssertEqual(try url.appendingParameter(name: "#", value: "#"), URL(string: "https://duck.com/?%23=%23")!)
-        XCTAssertEqual(try url.appendingParameter(name: "[", value: "["), URL(string: "https://duck.com/?%5B=%5B")!)
-        XCTAssertEqual(try url.appendingParameter(name: "]", value: "]"), URL(string: "https://duck.com/?%5D=%5D")!)
-        XCTAssertEqual(try url.appendingParameter(name: "@", value: "@"), URL(string: "https://duck.com/?%40=%40")!)
-        XCTAssertEqual(try url.appendingParameter(name: "!", value: "!"), URL(string: "https://duck.com/?%21=%21")!)
-        XCTAssertEqual(try url.appendingParameter(name: "$", value: "$"), URL(string: "https://duck.com/?%24=%24")!)
-        XCTAssertEqual(try url.appendingParameter(name: "&", value: "&"), URL(string: "https://duck.com/?%26=%26")!)
-        XCTAssertEqual(try url.appendingParameter(name: "'", value: "'"), URL(string: "https://duck.com/?%27=%27")!)
-        XCTAssertEqual(try url.appendingParameter(name: "(", value: "("), URL(string: "https://duck.com/?%28=%28")!)
-        XCTAssertEqual(try url.appendingParameter(name: ")", value: ")"), URL(string: "https://duck.com/?%29=%29")!)
-        XCTAssertEqual(try url.appendingParameter(name: "*", value: "*"), URL(string: "https://duck.com/?%2A=%2A")!)
-        XCTAssertEqual(try url.appendingParameter(name: "+", value: "+"), URL(string: "https://duck.com/?%2B=%2B")!)
-        XCTAssertEqual(try url.appendingParameter(name: ",", value: ","), URL(string: "https://duck.com/?%2C=%2C")!)
-        XCTAssertEqual(try url.appendingParameter(name: ";", value: ";"), URL(string: "https://duck.com/?%3B=%3B")!)
-        XCTAssertEqual(try url.appendingParameter(name: "=", value: "="), URL(string: "https://duck.com/?%3D=%3D")!)
+        XCTAssertEqual(url.appendingParameter(name: ":", value: ":"), URL(string: "https://duck.com/?%3A=%3A")!)
+        XCTAssertEqual(url.appendingParameter(name: "/", value: "/"), URL(string: "https://duck.com/?%2F=%2F")!)
+        XCTAssertEqual(url.appendingParameter(name: "?", value: "?"), URL(string: "https://duck.com/?%3F=%3F")!)
+        XCTAssertEqual(url.appendingParameter(name: "#", value: "#"), URL(string: "https://duck.com/?%23=%23")!)
+        XCTAssertEqual(url.appendingParameter(name: "[", value: "["), URL(string: "https://duck.com/?%5B=%5B")!)
+        XCTAssertEqual(url.appendingParameter(name: "]", value: "]"), URL(string: "https://duck.com/?%5D=%5D")!)
+        XCTAssertEqual(url.appendingParameter(name: "@", value: "@"), URL(string: "https://duck.com/?%40=%40")!)
+        XCTAssertEqual(url.appendingParameter(name: "!", value: "!"), URL(string: "https://duck.com/?%21=%21")!)
+        XCTAssertEqual(url.appendingParameter(name: "$", value: "$"), URL(string: "https://duck.com/?%24=%24")!)
+        XCTAssertEqual(url.appendingParameter(name: "&", value: "&"), URL(string: "https://duck.com/?%26=%26")!)
+        XCTAssertEqual(url.appendingParameter(name: "'", value: "'"), URL(string: "https://duck.com/?%27=%27")!)
+        XCTAssertEqual(url.appendingParameter(name: "(", value: "("), URL(string: "https://duck.com/?%28=%28")!)
+        XCTAssertEqual(url.appendingParameter(name: ")", value: ")"), URL(string: "https://duck.com/?%29=%29")!)
+        XCTAssertEqual(url.appendingParameter(name: "*", value: "*"), URL(string: "https://duck.com/?%2A=%2A")!)
+        XCTAssertEqual(url.appendingParameter(name: "+", value: "+"), URL(string: "https://duck.com/?%2B=%2B")!)
+        XCTAssertEqual(url.appendingParameter(name: ",", value: ","), URL(string: "https://duck.com/?%2C=%2C")!)
+        XCTAssertEqual(url.appendingParameter(name: ";", value: ";"), URL(string: "https://duck.com/?%3B=%3B")!)
+        XCTAssertEqual(url.appendingParameter(name: "=", value: "="), URL(string: "https://duck.com/?%3D=%3D")!)
     }
 
     func testWhenAddParameterIsCalled_ThenItAllowsUnescapedReservedCharactersAsSpecified() {
         let url = URL(string: "https://duck.com/")!
 
         XCTAssertEqual(
-            try url.appendingParameter(
+            url.appendingParameter(
                 name: "domains",
                 value: "test.com,example.com/test,localhost:8000/api",
                 allowedReservedCharacters: .init(charactersIn: ",:")
@@ -167,6 +167,11 @@ final class URLExtensionTests: XCTestCase {
         }
     }
 
+    func testWhenURLParametersModifiedWithInvalidCharactersThenParametersArePercentEscaped() {
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://www.duckduckgo.com/html?q=a%20search with+space+and%25plus&ia=calculator")!.absoluteString,
+                       "https://www.duckduckgo.com/html?q=a%20search%20with+space+and%25plus&ia=calculator")
+    }
+
     func testWhenPunycodeUrlIsCalledWithEncodedUrlsThenUrlIsReturned() {
         XCTAssertEqual("http://xn--ls8h.la", "💩.la".decodedURL?.absoluteString)
         XCTAssertEqual("http://xn--ls8h.la/", "💩.la/".decodedURL?.absoluteString)
@@ -183,13 +188,13 @@ final class URLExtensionTests: XCTestCase {
     func testWhenParamExistsThengetParameterReturnsCorrectValue() throws {
         let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
         let expected = "secondValue"
-        let actual = try url?.getParameter(name: "secondParam")
+        let actual = url?.getParameter(named: "secondParam")
         XCTAssertEqual(actual, expected)
     }
 
     func testWhenParamDoesNotExistThengetParameterIsNil() throws {
         let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
-        let result = try url?.getParameter(name: "someOtherParam")
+        let result = url?.getParameter(named: "someOtherParam")
         XCTAssertNil(result)
     }
 
@@ -206,9 +211,9 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertEqual(actual, url)
     }
 
-    func testWhenRemovingAParamThenRemainingUrlWebPlusesAreEncodedToEnsureTheyAreMaintainedAsSpaces_bugFix() {
+    func testWhenRemovingAParamThenRemainingUrlWebPlusesAreEncodedToEnsureTheyAreMaintainedAsSpaces() {
         let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=45+%2B+5")
-        let expected = URL(string: "http://test.com?secondParam=45%20+%205")
+        let expected = URL(string: "http://test.com?secondParam=45+%2B+5")
         let actual = url?.removeParameter(name: "firstParam")
         XCTAssertEqual(actual, expected)
     }
@@ -232,38 +237,38 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertEqual(actual, url)
     }
 
-    func testWhenRemovingParamsThenRemainingUrlWebPlusesAreEncodedToEnsureTheyAreMaintainedAsSpaces_bugFix() {
+    func testWhenRemovingParamsThenRemainingUrlWebPlusesAreEncodedToEnsureTheyAreMaintainedAsSpaces() {
         let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=45+%2B+5")
-        let expected = URL(string: "http://test.com?secondParam=45%20+%205")
+        let expected = URL(string: "http://test.com?secondParam=45+%2B+5")
         let actual = url?.removingParameters(named: ["firstParam"])
         XCTAssertEqual(actual, expected)
     }
 
     func testWhenNoParamsThenAddingAppendsQuery() throws {
-        let url = URL(string: "http://test.com")
-        let expected = URL(string: "http://test.com?aParam=aValue")
-        let actual = try url?.appendingParameter(name: "aParam", value: "aValue")
+        let url = URL(string: "http://test.com")!
+        let expected = URL(string: "http://test.com?aParam=aValue")!
+        let actual = url.appendingParameter(name: "aParam", value: "aValue")
         XCTAssertEqual(actual, expected)
     }
 
     func testWhenParamDoesNotExistThenAddingParamAppendsItToExistingQuery() throws {
-        let url = URL(string: "http://test.com?firstParam=firstValue")
-        let expected = URL(string: "http://test.com?firstParam=firstValue&anotherParam=anotherValue")
-        let actual = try url?.appendingParameter(name: "anotherParam", value: "anotherValue")
+        let url = URL(string: "http://test.com?firstParam=firstValue")!
+        let expected = URL(string: "http://test.com?firstParam=firstValue&anotherParam=anotherValue")!
+        let actual = url.appendingParameter(name: "anotherParam", value: "anotherValue")
         XCTAssertEqual(actual, expected)
     }
 
     func testWhenParamHasInvalidCharactersThenAddingParamAppendsEncodedVersion() throws {
-        let url = URL(string: "http://test.com")
-        let expected = URL(string: "http://test.com?aParam=43%20%2B%205")
-        let actual = try url?.appendingParameter(name: "aParam", value: "43 + 5")
+        let url = URL(string: "http://test.com")!
+        let expected = URL(string: "http://test.com?aParam=43%20%2B%205")!
+        let actual = url.appendingParameter(name: "aParam", value: "43 + 5")
         XCTAssertEqual(actual, expected)
     }
 
     func testWhenParamExistsThenAddingNewValueAppendsParam() throws {
-        let url = URL(string: "http://test.com?firstParam=firstValue")
-        let expected = URL(string: "http://test.com?firstParam=firstValue&firstParam=newValue")
-        let actual = try url?.appendingParameter(name: "firstParam", value: "newValue")
+        let url = URL(string: "http://test.com?firstParam=firstValue")!
+        let expected = URL(string: "http://test.com?firstParam=firstValue&firstParam=newValue")!
+        let actual = url.appendingParameter(name: "firstParam", value: "newValue")
         XCTAssertEqual(actual, expected)
     }
 

--- a/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/Common/Extensions/URLExtensionTests.swift
@@ -168,8 +168,34 @@ final class URLExtensionTests: XCTestCase {
     }
 
     func testWhenURLParametersModifiedWithInvalidCharactersThenParametersArePercentEscaped() {
-        XCTAssertEqual(URL(trimmedAddressBarString: "https://www.duckduckgo.com/html?q=a%20search with+space+and%25plus&ia=calculator")!.absoluteString,
-                       "https://www.duckduckgo.com/html?q=a%20search%20with+space+and%25plus&ia=calculator")
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://www.duckduckgo.com/html?q=a%20search with+space?+and%25plus&ia=calculator")!.absoluteString,
+                       "https://www.duckduckgo.com/html?q=a%20search%20with+space?+and%25plus&ia=calculator")
+    }
+
+    func testWhenURLWithEmptyQueryIsFixedUpThenQuestionCharIsKept() {
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://duckduckgo.com/?")!.absoluteString,
+                       "https://duckduckgo.com/?")
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://duckduckgo.com?")!.absoluteString,
+                       "https://duckduckgo.com?")
+        XCTAssertEqual(URL(trimmedAddressBarString: "https:/duckduckgo.com/?")!.absoluteString,
+                       "https://duckduckgo.com/?")
+        XCTAssertEqual(URL(trimmedAddressBarString: "https:/duckduckgo.com?")!.absoluteString,
+                       "https://duckduckgo.com?")
+    }
+
+    func testWhenURLWithHashIsFixedUpThenHashIsCorrectlyEscaped() {
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://duckduckgo.com/#hash with #")!.absoluteString,
+                       "https://duckduckgo.com/#hash%20with%20%23")
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://duckduckgo.com/html?q=a b#hash with #")!.absoluteString,
+                       "https://duckduckgo.com/html?q=a%20b#hash%20with%20%23")
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://duckduckgo.com/html#hash with #")!.absoluteString,
+                       "https://duckduckgo.com/html#hash%20with%20%23")
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://duckduckgo.com/html?q#hash with #")!.absoluteString,
+                       "https://duckduckgo.com/html?q#hash%20with%20%23")
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://duckduckgo.com/html?#hash with? #")!.absoluteString,
+                       "https://duckduckgo.com/html?#hash%20with?%20%23")
+        XCTAssertEqual(URL(trimmedAddressBarString: "https://duckduckgo.com/html?q=a b#")!.absoluteString,
+                       "https://duckduckgo.com/html?q=a%20b#")
     }
 
     func testWhenPunycodeUrlIsCalledWithEncodedUrlsThenUrlIsReturned() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1202902953508711
iOS PR:  https://github.com/duckduckgo/iOS/pull/1301
macOS PR: 
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC: @miasma13 

**Description**:
- Fixes URL fixup (when non-URL-valid characters and spaces are added as parameter values)
- Added percent-escaping for #hashed part of a URL
- Fixed unexpected behaviour when removingParameters(named:) alters other parameters (replaces "+" with "%20")

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate search queries work with + sign and spaces
2. Modify search query, add "+" or other special characters and spaces, validate search query matches entered value
3. Modify search URL manually, adding spaces/"+"/special characters to the q=.. parameter, validate url fixup works correctly
4. add hash part to the url (e.g #r1-8); Validate hash part stays in place when url fixup is applied (when query parameters invalid characters are percent-escaped)
5. validate hash part of the url is percent-escaped (e.g. #r af+s -> #r%20af%25s)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
