### PR TITLE
Fix content blocking tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     name: Run unit tests
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,18 +31,7 @@ jobs:
 
     name: Run unit tests
 
-    strategy:
-      matrix:
-        os: [macos-11, macos-12]
-        include:
-          # Skipping tests that are known to be failing on MacOS 12
-          - skipped_tests: |
-              --skip 'BrowserServicesKitTests.TrackerAllowlistReferenceTests' \
-              --skip 'BrowserServicesKitTests.SurrogatesUserScriptsTests' \
-              --skip 'BrowserServicesKitTests.ContentBlockerRulesUserScriptsTests' \
-            os: macos-12
-
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
 
     steps:
 
@@ -57,12 +46,11 @@ jobs:
       # https://stackoverflow.com/a/70040836
       run: |
         swift test --parallel --num-workers=1 \
-          ${{ matrix.skipped_tests }} \
-          --xunit-output tests-${{ matrix.os }}.xml
+          --xunit-output tests.xml
 
     - name: Publish Unit Tests Report
       uses: mikepenz/action-junit-report@v3
       if: always()
       with:
-        check_name: Test Report (${{ matrix.os }})
-        report_paths: tests-${{ matrix.os }}.xml
+        check_name: Test Report
+        report_paths: tests.xml

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesUserScriptsTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesUserScriptsTests.swift
@@ -268,7 +268,7 @@ class ContentBlockerRulesUserScriptsTests: XCTestCase {
                                                                   exceptions: [])
 
         let websiteLoaded = self.expectation(description: "Website Loaded")
-        let websiteURL = URL(string: "test://example.com")!
+        let websiteURL = URL(string: "test://example.com/index.html")!
 
         navigationDelegateMock.onDidFinishNavigation = {
             websiteLoaded.fulfill()
@@ -384,7 +384,7 @@ class ContentBlockerRulesUserScriptsTests: XCTestCase {
                                                                   exceptions: [])
 
         let websiteLoaded = self.expectation(description: "Website Loaded")
-        let websiteURL = URL(string: "test://example.com")!
+        let websiteURL = URL(string: "test://example.com/index.html")!
 
         navigationDelegateMock.onDidFinishNavigation = {
             websiteLoaded.fulfill()
@@ -414,7 +414,7 @@ class ContentBlockerRulesUserScriptsTests: XCTestCase {
                                                                   exceptions: [])
 
         let websiteLoaded = self.expectation(description: "Website Loaded")
-        let websiteURL = URL(string: "test://sub.example.com")!
+        let websiteURL = URL(string: "test://sub.example.com/index.html")!
 
         navigationDelegateMock.onDidFinishNavigation = {
             websiteLoaded.fulfill()
@@ -471,7 +471,7 @@ class ContentBlockerRulesUserScriptsTests: XCTestCase {
                                                                   exceptions: ["example.com"])
 
         let websiteLoaded = self.expectation(description: "Website Loaded")
-        let websiteURL = URL(string: "test://example.com")!
+        let websiteURL = URL(string: "test://example.com/index.html")!
 
         navigationDelegateMock.onDidFinishNavigation = {
             websiteLoaded.fulfill()
@@ -501,7 +501,7 @@ class ContentBlockerRulesUserScriptsTests: XCTestCase {
                                                                   exceptions: ["example.com"])
 
         let websiteLoaded = self.expectation(description: "Website Loaded")
-        let websiteURL = URL(string: "test://sub.example.com")!
+        let websiteURL = URL(string: "test://sub.example.com/index.html")!
 
         navigationDelegateMock.onDidFinishNavigation = {
             websiteLoaded.fulfill()

--- a/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesUserScriptTests.swift
@@ -245,7 +245,7 @@ class SurrogatesUserScriptsTests: XCTestCase {
 
     func testWhenSiteIsLocallyUnprotectedThenSurrogatesAreNotInjected() {
 
-        let websiteURL = URL(string: "test://example.com")!
+        let websiteURL = URL(string: "test://example.com/index.html")!
 
         let privacyConfig = WebKitTestHelper.preparePrivacyConfig(locallyUnprotected: ["example.com"],
                                                                   tempUnprotected: [],
@@ -313,7 +313,7 @@ class SurrogatesUserScriptsTests: XCTestCase {
 
     func testWhenSiteIsTempUnprotectedThenSurrogatesAreNotInjected() {
 
-        let websiteURL = URL(string: "test://example.com")!
+        let websiteURL = URL(string: "test://example.com/index.html")!
 
         let privacyConfig = WebKitTestHelper.preparePrivacyConfig(locallyUnprotected: [],
                                                                   tempUnprotected: ["example.com"],
@@ -345,7 +345,7 @@ class SurrogatesUserScriptsTests: XCTestCase {
 
     func testWhenSiteIsSubdomainOfTempUnprotectedThenSurrogatesAreNotInjected() {
 
-        let websiteURL = URL(string: "test://sub.example.com")!
+        let websiteURL = URL(string: "test://sub.example.com/index.html")!
 
         let privacyConfig = WebKitTestHelper.preparePrivacyConfig(locallyUnprotected: [],
                                                                   tempUnprotected: ["example.com"],
@@ -377,7 +377,7 @@ class SurrogatesUserScriptsTests: XCTestCase {
 
     func testWhenSiteIsInExceptionListThenSurrogatesAreNotInjected() {
 
-        let websiteURL = URL(string: "test://example.com")!
+        let websiteURL = URL(string: "test://example.com/index.html")!
 
         let allowlist = ["tracker.com": [PrivacyConfigurationData.TrackerAllowlist.Entry(rule: "tracker.com/", domains: ["example.com"])]]
 
@@ -445,7 +445,7 @@ class SurrogatesUserScriptsTests: XCTestCase {
 
     func testWhenTrackerIsInAllowListThenSurrogatesAreNotInjected() {
 
-        let websiteURL = URL(string: "test://example.com")!
+        let websiteURL = URL(string: "test://example.com/index.html")!
 
         let privacyConfig = WebKitTestHelper.preparePrivacyConfig(locallyUnprotected: [],
                                                                   tempUnprotected: [],
@@ -477,7 +477,7 @@ class SurrogatesUserScriptsTests: XCTestCase {
 
     func testWhenSiteIsSubdomainOfExceptionListThenSurrogatesAreNotInjected() {
 
-        let websiteURL = URL(string: "test://sub.example.com")!
+        let websiteURL = URL(string: "test://sub.example.com/index.html")!
 
         let privacyConfig = WebKitTestHelper.preparePrivacyConfig(locallyUnprotected: [],
                                                                   tempUnprotected: [],

--- a/Tests/BrowserServicesKitTests/ContentBlocker/TrackerAllowlistReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/TrackerAllowlistReferenceTests.swift
@@ -147,7 +147,10 @@ class TrackerAllowlistReferenceTests: XCTestCase {
 
         os_log("TEST: %s", test.description)
 
-        let siteURL = URL(string: normalizeScheme(urlString: test.site))!
+        var siteURL = URL(string: normalizeScheme(urlString: test.site))!
+        if siteURL.absoluteString.hasSuffix(".com") {
+            siteURL = siteURL.appendingPathComponent("index.html")
+        }
         let requestURL = URL(string: normalizeScheme(urlString: test.request))!
 
         let resource = MockWebsite.EmbeddedResource(type: .script,
@@ -166,7 +169,8 @@ class TrackerAllowlistReferenceTests: XCTestCase {
         let request = URLRequest(url: siteURL)
 
         WKWebsiteDataStore.default().removeData(ofTypes: [WKWebsiteDataTypeDiskCache,
-                                                          WKWebsiteDataTypeMemoryCache],
+                                                          WKWebsiteDataTypeMemoryCache,
+                                                          WKWebsiteDataTypeOfflineWebApplicationCache],
                                                 modifiedSince: Date(timeIntervalSince1970: 0),
                                                 completionHandler: {
             self.webView.load(request)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1202179326307010
iOS PR:  n/a
macOS PR: n/a
What kind of version bump will this require?: None (only tests affected)

**Description**:

Workaround for WebKit bug that has been introduced in macOS 12 release. This also updates github actions to remove macOS 11 test job and enable all tests on macOS 12.

See https://bugs.webkit.org/show_bug.cgi?id=245236

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Run tests, see that everything passes.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
