### PR TITLE
Address macOS keychain permission failures

### DIFF
--- a/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
@@ -361,7 +361,7 @@ class EmailManagerTests: XCTestCase {
     func testWhenGettingUsername_AndKeychainAccessFails_ThenRequestDelegateIsCalled() {
         let username = "dax"
         let storage = MockEmailManagerStorage()
-        storage.mockError = .keychainAccessFailure(errSecInternalError)
+        storage.mockError = .keychainLookupFailure(errSecInternalError)
         storage.mockUsername = username
         let emailManager = EmailManager(storage: storage)
         
@@ -370,7 +370,7 @@ class EmailManagerTests: XCTestCase {
 
         XCTAssertNil(emailManager.userEmail)
         XCTAssertEqual(requestDelegate.keychainAccessErrorAccessType, .getUsername)
-        XCTAssertEqual(requestDelegate.keychainAccessError, .keychainAccessFailure(errSecInternalError))
+        XCTAssertEqual(requestDelegate.keychainAccessError, .keychainLookupFailure(errSecInternalError))
     }
     
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202974804358541/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1316
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/721
What kind of version bump will this require?: Major

**Optional**:

Tech Design URL:
CC:

**Description**:

This PR updates the email protection keychain class to use the data protection keychain on macOS. This is to fix an issue where users found themselves unable to sign out sometimes - swapping to the data protection keychain should prevent this going forward.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

To test the data protection keychain:

1. Before checking out this branch, run the develop branch and sign into email protection. Then, open Keychain Access and search for `debug.email`. You should see 4 entries which exist in the **login** keychain.
1. Check this branch out and run it. Search again in Keychain Access for `debug.email` and you should see the same entries, but now in the **iCloud** keychain. If so, then the migration worked - if not, let me know.
1. Try to sign out of Email Protection and verify that it works
1. Sign back in, and test that generating aliases etc works. After signing in, check that the values were added to the **iCloud** keychain.

To test the pixel additions:

1. Turn pixel logging on in Logging.swift if you're on macOS
2. Add a hardcoded failure into one of the keychain access functions that throw
3. Test whichever email protection feature calls the function you added the failure to, and verify that a pixel shows up in the console logs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
