### PR TITLE
Change the visibility of DecodableHelper.decode to `public`

### DIFF
--- a/Sources/BrowserServicesKit/Common/DecodableHelper.swift
+++ b/Sources/BrowserServicesKit/Common/DecodableHelper.swift
@@ -19,8 +19,8 @@
 import Foundation
 import os
 
-struct DecodableHelper {
-    static func decode<Input: Any, Target: Decodable>(from input: Input) -> Target? {
+public struct DecodableHelper {
+    public static func decode<Input: Any, Target: Decodable>(from input: Input) -> Target? {
         do {
             let json = try JSONSerialization.data(withJSONObject: input)
             return try JSONDecoder().decode(Target.self, from: json)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: n/a
iOS PR:  n/a
macOS PR: n/a
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
n/a

**Description**:

Just making DecodableHelper usable to consumers of BrowserServicesKit
