### PR TITLE
Bump autofill to 5.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/duckduckgo/content-scope-scripts",
         "state": {
           "branch": null,
-          "revision": "b06512e7e757ae8cdba5a538b0dae13adc61b50d",
-          "version": "2.3.0"
+          "revision": "430ad3879cc49fbdb3f62bd73e13f2dea58ed1df",
+          "version": "2.4.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "d29c5abc7f473b69f3d81d8a15e137ed3aab029d",
-          "version": "5.0.1"
+          "revision": "48fa29dc6a01930e5fb79fa1f67a9a5d1eb788b9",
+          "version": "5.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "BrowserServicesKit", targets: ["BrowserServicesKit"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.0.1")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.1.0")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1203115049860112/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1329
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/743
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
- Bump json-schema-to-typescript from 10.1.5 to 11.0.2 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/203
- Fix incorrect schema by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/211
- Bump ts-to-zod from 1.10.0 to 1.13.1 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/210
- Update Asana token name by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/218
- More fixes and improvements by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/222

**Steps to test this PR**:
- Specific changes tested during the autofill release
- Instructions for smoke tests in the Asana task

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 11

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
