### PR TITLE
Add script execution guard for about:blank frames

### DIFF
--- a/Sources/BrowserServicesKit/UserScript/UserScript.swift
+++ b/Sources/BrowserServicesKit/UserScript/UserScript.swift
@@ -18,6 +18,7 @@
 //
 
 import WebKit
+import CryptoKit
 
 public protocol UserScript: WKScriptMessageHandler {
 
@@ -73,11 +74,23 @@ extension UserScript {
     static func makeWKUserScript(source: String, injectionTime: WKUserScriptInjectionTime,
                                  forMainFrameOnly: Bool,
                                  requiresRunInPageContentWorld: Bool = false) -> WKUserScript {
+        let hash = SHA256.hash(data: Data(source.utf8)).hashValue
+
+        // This prevents the script being executed twice which appears to be a WKWebKit issue for about:blank frames when the location changes
+        let sourceOut = """
+        (() => {
+            if (window.navigator._duckduckgoloader_ && window.navigator._duckduckgoloader_.includes('\(hash)')) {return}
+            \(source)
+            window.navigator._duckduckgoloader_ = window.navigator._duckduckgoloader_ || [];
+            window.navigator._duckduckgoloader_.push('\(hash)')
+        })()
+        """
+
         if #available(macOS 11.0, iOS 14.0, *) {
             let contentWorld = getContentWorld(requiresRunInPageContentWorld)
-            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: contentWorld)
+            return WKUserScript(source: sourceOut, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: contentWorld)
         } else {
-            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly)
+            return WKUserScript(source: sourceOut, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly)
         }
     }
 

--- a/Tests/BrowserServicesKitTests/UserScript/StaticUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/UserScript/StaticUserScriptTests.swift
@@ -40,7 +40,7 @@ class StaticUserScriptTests: XCTestCase {
         let src = "var val = 'Test';\n"
         let us = TestStaticUserScript()
         let script = us.makeWKUserScript()
-        XCTAssertEqual(script.source, src)
+        XCTAssertEqual(script.source, UserScriptTestHelper.getScriptOutput(src))
         XCTAssertEqual(script.injectionTime, .atDocumentEnd)
         XCTAssertEqual(script.isForMainFrameOnly, false)
     }

--- a/Tests/BrowserServicesKitTests/UserScript/UserScriptTestHelper.swift
+++ b/Tests/BrowserServicesKitTests/UserScript/UserScriptTestHelper.swift
@@ -1,0 +1,37 @@
+//
+//  UserScriptTestHelper.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import CryptoKit
+
+struct UserScriptTestHelper {
+    
+    static func getScriptOutput (_ src: String) -> String {
+        let hash = SHA256.hash(data: Data(src.utf8)).hashValue
+
+        return """
+        (() => {
+            if (window.navigator._duckduckgoloader_ && window.navigator._duckduckgoloader_.includes('\(hash)')) {return}
+            \(src)
+            window.navigator._duckduckgoloader_ = window.navigator._duckduckgoloader_ || [];
+            window.navigator._duckduckgoloader_.push('\(hash)')
+        })()
+        """
+    }
+}

--- a/Tests/BrowserServicesKitTests/UserScript/UserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/UserScript/UserScriptTests.swift
@@ -47,7 +47,7 @@ class UserScriptTests: XCTestCase {
         let src = "var val = 'Test';\n"
         let us = TestUserScript(val: "Test", injectionTime: .atDocumentStart, forMainFrameOnly: true, messageNames: [])
         let script = us.makeWKUserScript()
-        XCTAssertEqual(script.source, src)
+        XCTAssertEqual(script.source, UserScriptTestHelper.getScriptOutput(src))
         XCTAssertEqual(script.injectionTime, .atDocumentStart)
         XCTAssertEqual(script.isForMainFrameOnly, true)
     }
@@ -56,7 +56,7 @@ class UserScriptTests: XCTestCase {
         let src = "var val = 'test2';\n"
         let us = TestUserScript(val: "test2", injectionTime: .atDocumentEnd, forMainFrameOnly: false, messageNames: [])
         let script = us.makeWKUserScript()
-        XCTAssertEqual(script.source, src)
+        XCTAssertEqual(script.source, UserScriptTestHelper.getScriptOutput(src))
         XCTAssertEqual(script.injectionTime, .atDocumentEnd)
         XCTAssertEqual(script.isForMainFrameOnly, false)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200437802575119/1202155258470004/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1335
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/750
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

Visiting https://www.washingtonpost.com/ without this patch you'll see "TypeError: Attempting to change value of a readonly property." errors as we're creating a property called __firefox__.find (in the isolated world) and then trying to redeclare over it.

This is only a side effect of us executing all user scripts multiple times for about:blank frames; most of our code isn't idempotent so will be creating side effects.

The solution is a little hacky here but we create a guard that prevents the script from executing multiple times for the same execution context.

- Note when debugging this; we run some scripts in isolated and some in default worlds so the variable is created both times. The issue exists in both worlds but the array is created both times so you'll see different sized arrays as you step through etc (this is because isolated worlds have a totally different window global) the code works as expected for the isolated also.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Visiting https://www.washingtonpost.com/
2. There should be no error with the following text in the console: "TypeError: Attempting to change value of a readonly property."

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
