### PR TITLE
Shane/webkit handler names [wip]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "BrowserServicesKit", targets: ["BrowserServicesKit"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.1.0")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.2.0")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -67,6 +67,7 @@ public class AutofillUserScript: NSObject, UserScript {
     public lazy var source: String = {
         var js = scriptSourceProvider.source
         js = js.replacingOccurrences(of: "PLACEHOLDER_SECRET", with: generatedSecret)
+        js = js.replacingOccurrences(of: "// INJECT webkitMessageHandlerNames HERE", with: "webkitMessageHandlerNames = \(messageNamesJson);")
         js = js.replacingOccurrences(of: "// INJECT isTopFrame HERE", with: "isTopFrame = \(isTopAutofillContext ? "true" : "false");")
         return js
     }()
@@ -84,6 +85,18 @@ public class AutofillUserScript: NSObject, UserScript {
     public var messageNames: [String] {
         return MessageName.allCases.map(\.rawValue)
     }
+
+    // communicate known message handler names to user scripts.
+    public lazy var messageNamesJson: String = {
+        // note: this doesn't include the messages from the overlay - only messages that can potentially be execute on macOS 10.x need
+        // to be communicated to the JavaScript layer.
+        let combinedMessages = MessageName.allCases.map(\.rawValue) + WebsiteAutofillUserScript.WebsiteAutofillMessageName.allCases.map(\.rawValue)
+        guard let json = try? JSONEncoder().encode(combinedMessages), let jsonString = String(data: json, encoding: .utf8) else {
+            assertionFailure("AutofillUserScript: could not encode message names into JSON")
+            return ""
+        }
+        return jsonString
+    }()
 
     // swiftlint:disable cyclomatic_complexity
     internal func messageHandlerFor(_ messageName: String) -> MessageHandler? {

--- a/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
@@ -41,7 +41,7 @@ public class WebsiteAutofillUserScript: AutofillUserScript {
         return WebsiteAutofillMessageName.allCases.map(\.rawValue) + super.messageNames
     }
 
-    private enum WebsiteAutofillMessageName: String, CaseIterable {
+    public enum WebsiteAutofillMessageName: String, CaseIterable {
         case closeAutofillParent
         case getSelectedCredentials
         case showAutofillParent


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: 
iOS PR:  https://github.com/duckduckgo/iOS/pull/1341
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/759
What kind of version bump will this require?: Major/Minor/Patch


**Description**:
Exposes webkit handler names to Autofill UserScripts

**Steps to test this PR**:

1. Autofill works as normal on macOS catalina
1. Autofill works as normal on macOS > catalina

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
