### PR TITLE
Add 30-minute timeout to the unit tests GHA workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,6 +32,7 @@ jobs:
     name: Run unit tests
 
     runs-on: macos-12
+    timeout-minutes: 30
 
     steps:
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Task/Issue URL: https://app.asana.com/0/0/1203164850287658/f
iOS PR: N/A
macOS PR: N/A
What kind of version bump will this require?: None

**Description**:
Add a timeout to terminate workflows early in case they hang up unexpectedly.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Ensure that the unit tests workflow runs without a syntax error and finishes without unexpected errors

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
