### PR TITLE
Checking whether domains of credential and requesting website mach

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -439,7 +439,10 @@ extension AutofillUserScript {
             guard let credential = $0,
                   let id = credential.account.id,
                   let password = String(data: credential.password, encoding: .utf8),
-                  credential.account.domain == requestingDomain else { return }
+                  credential.account.domain == requestingDomain else {
+                replyHandler("{}")
+                return
+            }
 
             let response = RequestVaultCredentialsForAccountResponse(success: .init(id: String(id),
                                                                     username: credential.account.username,

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -430,11 +430,13 @@ extension AutofillUserScript {
               let accountId = Int64(id) else {
             return
         }
+        let requestingDomain = hostForMessage(message)
 
         vaultDelegate?.autofillUserScript(self, didRequestCredentialsForAccount: Int64(accountId)) {
             guard let credential = $0,
                   let id = credential.account.id,
-                  let password = String(data: credential.password, encoding: .utf8) else { return }
+                  let password = String(data: credential.password, encoding: .utf8),
+                  credential.account.domain == requestingDomain else { return }
 
             let response = RequestVaultCredentialsForAccountResponse(success: .init(id: String(id),
                                                                     username: credential.account.username,

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -359,7 +359,10 @@ extension AutofillUserScript {
         }
 
         let domain = hostForMessage(message)
-        vaultDelegate?.autofillUserScript(self, didRequestCredentialsForDomain: domain, subType: request.subType, trigger: request.trigger) { credentials, action in
+        vaultDelegate?.autofillUserScript(self,
+                                          didRequestCredentialsForDomain: domain,
+                                          subType: request.subType,
+                                          trigger: request.trigger) { credentials, action in
             let response = RequestVaultCredentialsForDomainResponse.responseFromSecureVaultWebsiteCredentials(credentials, action: action)
 
             if let json = try? JSONEncoder().encode(response), let jsonString = String(data: json, encoding: .utf8) {

--- a/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
@@ -170,10 +170,11 @@ class AutofillVaultUserScriptTests: XCTestCase {
         let message = MockWKScriptMessage(name: "pmHandlerGetAutofillCredentials", body: body, webView: mockWebView)
 
         let expect = expectation(description: #function)
-        expect.isInverted = true
-        userScript.userContentController(userContentController, didReceive: message) { _,_ in
+        userScript.userContentController(userContentController, didReceive: message) {
+            XCTAssertEqual($0 as? String, "{}")
+            XCTAssertNil($1)
+
             expect.fulfill()
-            XCTFail()
         }
 
         waitForExpectations(timeout: 1.0)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203127424124512/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1362
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/803
What kind of version bump will this require?: Patch

**Description**:

This PR adds a security check that injects the credentials into the website only if domains match
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make sure autofill works for multiple items from your keychain
1. Verify you no longer can request the credentials for an arbitrary id and get it injected into a page.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
