### PR TITLE
Update autofill to 0.0.0_test

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "516209f9a0252c9795b51ca3c815cfbbf34ad0a0",
-          "version": "5.2.0"
+          "revision": "45a10b5247d12cbd7f1438bd764d4270f21b3344",
+          "version": "0.0.0_test"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "Common", targets: ["Common"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.2.0")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("0.0.0_test")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
**Reviewer:** 
**Asana:** https://app.asana.com/0/1203252997537724/1203252997537724
**Autofill Release:** https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.0_test


## Description
Updates Autofill to version [0.0.0_test](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.0_test).

### Autofill 0.0.0_test release notes
More complex release notes with titles. Last time I tried this, it failed. Let's see if Asana is smarter now with API v1.

## What's Changed
* Another round of fixes and improvements by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/225
* feat: support Windows by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/215
* [WIP] Improve release workflow by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/205


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/5.2.0...0.0.0_test

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).