### PR TITLE
Ensure link protection webview is created on main thread 

### DIFF
--- a/Sources/BrowserServicesKit/LinkProtection/AMPCanonicalExtractor.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/AMPCanonicalExtractor.swift
@@ -167,7 +167,8 @@ public class AMPCanonicalExtractor: NSObject {
         }
         
         completionHandler.setCompletionHandler(completion: completion)
-        
+
+        assert(Thread.isMainThread)
         webView = WKWebView(frame: .zero, configuration: makeConfiguration())
         webView?.navigationDelegate = self
         webView?.load(URLRequest(url: url))

--- a/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
@@ -64,7 +64,8 @@ public struct LinkProtection {
             completion(urlToLoad)
         }
     }
-    
+
+    @MainActor
     public func getCleanURL(from url: URL, onStartExtracting: () -> Void, onFinishExtracting: @escaping () -> Void) async -> URL {
         await withCheckedContinuation { continuation in
             getCleanURL(from: url, onStartExtracting: onStartExtracting, onFinishExtracting: onFinishExtracting) { url in
@@ -116,7 +117,8 @@ public struct LinkProtection {
         return didRewriteLink
     }
     // swiftlint:enable function_parameter_count
-    
+
+    @MainActor
     public func requestTrackingLinkRewrite(initiatingURL: URL?,
                                            navigationAction: WKNavigationAction,
                                            onStartExtracting: () -> Void,


### PR DESCRIPTION
**Required**:

Task/Issue URL:  https://app.asana.com/0/1201037661562251/1203289244240949/f
iOS PR:  n/a - no changes required
macOS PR: n/a - no changes required
What kind of version bump will this require: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

Adds `@MainActor` requirements to async link protection functions. and `assert` to check that WKWebView is created on the main thread.

No changes to iOS / macOS required.

Requires Xcode 14.x to test.

**Steps to test this PR**:
1. Drop BSK into iOS and macOS (drag in to Xcode)
1. Visit https://privacy-test-pages.glitch.me/privacy-protections/amp/ and check each link does not trigger the assert.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
