### PR TITLE
Fix platforms builds after adding unsafe flags

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/duckduckgo/GRDB.swift.git",
         "state": {
           "branch": null,
-          "revision": "f465dd5c0bf590cdb9bee4e96c53b1719ee30730",
-          "version": "1.2.0"
+          "revision": "830ddd161710ed7a80dcbeb4d4b62cf0ae4d8baf",
+          "version": "1.2.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -48,9 +48,6 @@ let package = Package(
             name: "BloomFilter",
             resources: [
                 .process("CMakeLists.txt")
-            ],
-            cxxSettings: [
-                .unsafeFlags(["-std=c++11"])
             ]),
         .target(
             name: "Common",
@@ -81,5 +78,6 @@ let package = Package(
                 "Common"
             ]
         )
-    ]
+    ],
+    cxxLanguageStandard: .cxx11
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.2.0")),
-        .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.0")),
+        .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.1")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),
         .package(url: "https://github.com/duckduckgo/content-scope-scripts", .exact("3.2.0"))

--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,9 @@ let package = Package(
             name: "BloomFilter",
             resources: [
                 .process("CMakeLists.txt")
+            ],
+            cxxSettings: [
+                .unsafeFlags(["-std=c++11"])
             ]),
         .target(
             name: "Common",


### PR DESCRIPTION
Required:

Previous PR: https://github.com/duckduckgo/BrowserServicesKit/pull/164
Task/Issue URL: https://app.asana.com/0/1200194497630846/1203329771832287/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1374
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/832
What kind of version bump will this require?: Patch

Description:
Previous [PR](https://github.com/duckduckgo/BrowserServicesKit/pull/164) has broken platform builds because of unsafe c++ flags; Changing it to safe flags