### PR TITLE
Fix not loading any CBRs if cache files missing

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -226,19 +226,22 @@ public class ContentBlockerRulesManager: CompiledRuleListsSource {
         let initialCompilationTask = InitialCompilationTask(sourceRules: rulesSource.contentBlockerRulesLists,
                                                             lastCompiledRules: lastCompiledRules)
         let mutex = DispatchSemaphore(value: 0)
-        var result = [InitialCompilationTask.CachedRulesList]()
+        var result: [InitialCompilationTask.CachedRulesList]?
         withUnsafeMutablePointer(to: &result) { pointer in
             Task {
-                pointer.pointee = await initialCompilationTask.start()
-                // Leave context of current thread (most likely Main Thread, cause of await above) as soon as possible.
+                pointer.pointee = try? await initialCompilationTask.lookupCachedRulesLists()
                 mutex.signal()
             }
             // We want to confine Compilation work to WorkQueue, so we wait to come back from async Task
             mutex.wait()
         }
-        
-        let rules = generateRules(from: result)
-        applyRules(rules)
+
+        if let result = result {
+            let rules = generateRules(from: result)
+            applyRules(rules)
+        } else {
+            state = .idle
+        }
         scheduleCompilation()
     }
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1203344021820506/f
iOS PR:  
macOS PR: 
What kind of version bump will this require?: Patch

**Description**:
 - Fixes waiting for Content Blocking Rules to be applied on startup when WebKit cache files are missing
 
**Steps to test this PR**:
- Delete Content Blocking Rules cache files on the file system
    - ~/Library/Developer/CoreSimulator/Devices/DEVICE-ID/data/Containers/Data/Application/APPLICATION-ID/Library/WebKit/com.duckduckgo.mobile.ios - for iOS Simulator
    - ~/Library/WebKit/com.duckduckgo.macos.browser - for macOS
- Run the app and load a website
- Validate ContentBlockingRules are compiled before navigation

**OS Testing**:

* [ ] iOS
* [ ] macOS
