### PR TITLE
Add MetricKit crash collection 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,6 @@ let package = Package(
                 "TrackerRadarKit",
                 "BloomFilterWrapper",
                 "Common",
-                "Crashes",
                 "UserScript"
             ],
             resources: [

--- a/Package.swift
+++ b/Package.swift
@@ -50,8 +50,9 @@ let package = Package(
             ]),
         .target(
             name: "Crashes",
-            dependencies: [ ],
-            linkerSettings: [.unsafeFlags(["-Xlinker", "-no_application_extension"])]),
+            dependencies: [ ]
+            // linkerSettings: [.unsafeFlags(["-Xlinker", "-no_application_extension"])]
+        ),
         .target(
             name: "BloomFilter",
             resources: [

--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -19,6 +19,7 @@
 import Foundation
 import MetricKit
 
+@available(iOSApplicationExtension, unavailable)
 @available(iOS 13, macOS 12, *)
 public struct CrashCollection {
 

--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -50,4 +50,29 @@ public struct CrashCollection {
 
     }
 
+    static let firstCrashKey = "CrashCollection.first"
+
+    static var firstCrash: Bool {
+        get {
+            UserDefaults().object(forKey: Self.firstCrashKey) as? Bool ?? true
+        }
+
+        set {
+            UserDefaults().set(newValue, forKey: Self.firstCrashKey)
+        }
+    }
+
+    public static func start(firePixel: @escaping ([String: String]) -> Void) {
+        let first = Self.firstCrash
+        CrashCollection.collectCrashesAsync { params in
+            var params = params
+            if first {
+                params["first"] = "1"
+            }
+            firePixel(params)
+        }
+        // Turn the flag off for next time
+        Self.firstCrash = false
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1203353338544857/f
iOS PR:  
macOS PR: 
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL:
CC:

**Description**:

Adds pixel based Crash Collection.

**Steps to test this PR**:
1. See iOS PR https://github.com/duckduckgo/iOS/pull/1381

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
