### PR TITLE
drop www prefix when checking domain

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -440,7 +440,7 @@ extension AutofillUserScript {
             guard let credential = $0,
                   let id = credential.account.id,
                   let password = String(data: credential.password, encoding: .utf8),
-                  credential.account.domain == requestingDomain else {
+                  credential.account.domain == requestingDomain.droppingWwwPrefix() else {
                 replyHandler("{}")
                 return
             }

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -149,7 +149,7 @@ public class AutofillUserScript: NSObject, UserScript, UserScriptMessageEncrypti
 
     init(scriptSourceProvider: AutofillUserScriptSourceProvider,
          encrypter: UserScriptEncrypter = AESGCMUserScriptEncrypter(),
-         hostProvider: SecurityOriginHostProvider = SecurityOriginHostProvider()) {
+         hostProvider: UserScriptHostProvider = SecurityOriginHostProvider()) {
         self.scriptSourceProvider = scriptSourceProvider
         self.hostProvider = hostProvider
         self.encrypter = encrypter

--- a/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
@@ -28,8 +28,10 @@ import UserScript
 // swiftlint:disable file_length
 
 class AutofillVaultUserScriptTests: XCTestCase {
-    
-    let userScript: AutofillUserScript = {
+
+    lazy var hostProvider: UserScriptHostProvider = SecurityOriginHostProvider()
+
+    lazy var userScript: AutofillUserScript = {
         let embeddedConfig =
         """
         {
@@ -46,8 +48,9 @@ class AutofillVaultUserScriptTests: XCTestCase {
         let properties = ContentScopeProperties(gpcEnabled: false, sessionKey: "1234", featureToggles: ContentScopeFeatureToggles.allTogglesOn)
         let sourceProvider = DefaultAutofillSourceProvider(privacyConfigurationManager: privacyConfig,
                                                            properties: properties)
-        return AutofillUserScript(scriptSourceProvider: sourceProvider)
+        return AutofillUserScript(scriptSourceProvider: sourceProvider, hostProvider: hostProvider)
     }()
+
     let userContentController = WKUserContentController()
 
     var encryptedMessagingParams: [String: Any] {
@@ -96,7 +99,7 @@ class AutofillVaultUserScriptTests: XCTestCase {
    }
 
     @available(macOS 11, iOS 14, *)
-    func testWhenCredentialForAccountRequested_ThenDelegateCalled() {
+    func testWhenCredentialForAccountRequestedFromMatchingDomain_ThenDelegateCalled() {
         class GetCredentialsDelegate: MockSecureVaultDelegate {
 
             override func autofillUserScript(_: AutofillUserScript,
@@ -105,7 +108,7 @@ class AutofillVaultUserScriptTests: XCTestCase {
 
                 completionHandler(.init(account: .init(id: accountId,
                                                        username: "1@example.com",
-                                                       domain: "",
+                                                       domain: "domain1.com",
                                                        created: Date(),
                                                        lastUpdated: Date()),
                                         password: "password".data(using: .utf8)!))
@@ -115,6 +118,8 @@ class AutofillVaultUserScriptTests: XCTestCase {
         }
 
         let randomAccountId = Int.random(in: 0 ..< Int.max) // JS will come through as a Int rather than Int64
+
+        hostProvider = MockHostProvider(host: "domain1.com")
 
         let delegate = GetCredentialsDelegate()
         userScript.vaultDelegate = delegate
@@ -133,6 +138,51 @@ class AutofillVaultUserScriptTests: XCTestCase {
             let data = ($0 as? String)?.data(using: .utf8)
             let response = try? JSONDecoder().decode(AutofillUserScript.RequestVaultCredentialsForAccountResponse.self, from: data!)
             XCTAssertEqual(Int64(response!.success.id), Int64(randomAccountId))
+
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    @available(macOS 11, iOS 14, *)
+    func testWhenCredentialForAccountRequestedAndRequestedDomainMatchesAfterRemovingWWWPrefix_ThenCredentialsReturned() {
+        class GetCredentialsDelegate: MockSecureVaultDelegate {
+
+            override func autofillUserScript(_: AutofillUserScript,
+                                             didRequestCredentialsForAccount accountId: Int64,
+                                             completionHandler: @escaping (SecureVaultModels.WebsiteCredentials?) -> Void) {
+
+                completionHandler(.init(account: .init(id: accountId,
+                                                       username: "1@example.com",
+                                                       domain: "domain1.com",
+                                                       created: Date(),
+                                                       lastUpdated: Date()),
+                                        password: "password".data(using: .utf8)!))
+
+            }
+
+        }
+
+        let randomAccountId = Int.random(in: 0 ..< Int.max) // JS will come through as a Int rather than Int64
+
+        hostProvider = MockHostProvider(host: "www.domain1.com")
+        
+        let delegate = GetCredentialsDelegate()
+        userScript.vaultDelegate = delegate
+
+        var body = encryptedMessagingParams
+        body["id"] = "\(randomAccountId)"
+
+        let mockWebView = MockWebView()
+        let message = MockWKScriptMessage(name: "pmHandlerGetAutofillCredentials",
+                                          body: body,
+                                          webView: mockWebView)
+
+        let expect = expectation(description: #function)
+        userScript.userContentController(userContentController, didReceive: message) {
+            XCTAssertNotEqual($0 as? String, "{}")
+            XCTAssertNil($1)
 
             expect.fulfill()
         }
@@ -523,6 +573,15 @@ struct NoneEncryptingEncrypter: UserScriptEncrypter {
         return (reply.data(using: .utf8)!, Data())
     }
 
+}
+
+struct MockHostProvider: UserScriptHostProvider {
+
+    let host: String
+
+    func hostForMessage(_ message: UserScriptMessage) -> String {
+        return host
+    }
 }
 
 // swiftlint:enable type_body_length


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1203127424124512/f
iOS PR:  to follow
macOS PR: to follow
What kind of version bump will this require?: Patch

**Optional**:

CC: @GioSensation, @tomasstrba, @shakyShane 

**Description**:

Drops www prefix when checking domain requesting credentials.

**Steps to test this PR**:
1. Drop BSK into iOS and macOS app 
1. Check autofill works as expected 
  * add an account in autofill for netflix.com then go to www.netflix.com and ensure credentials are presented
  * add an account in autofill for dunoon.scot then visit dunoon.scot and ensure credentials are presented

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [x] iOS 14
* [x] iOS 15
* [x] iOS 16
* [x] macOS 10.15
* [x] macOS 11
* [x] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
