### PR TITLE
strip www from both sides during domain check

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -440,7 +440,7 @@ extension AutofillUserScript {
             guard let credential = $0,
                   let id = credential.account.id,
                   let password = String(data: credential.password, encoding: .utf8),
-                  credential.account.domain == requestingDomain.droppingWwwPrefix() else {
+                  credential.account.domain.droppingWwwPrefix() == requestingDomain.droppingWwwPrefix() else {
                 replyHandler("{}")
                 return
             }


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1203127424124512/f
iOS PR: n/a - will follow up
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/858
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

Strips WWW from both side when checking domains for autofill

**Steps to test this PR**:
1. Go to https://www.rei.com/YourAccountLoginView and enter some bogus credentials and save them
1. Reload the page and ensure the credentials are filled

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
