### PR TITLE
Add dependabot config for git submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 


### PR DESCRIPTION
**Required**:

Task/Issue URL:  https://app.asana.com/0/0/1203414149510266/f
iOS PR:  N/A
macOS PR: N/A
What kind of version bump will this require?: N/A (Infrastructure change)

**Description**:
Add dependabot config to auto generate PRs when privacy-reference-tests are updated

**Steps to test this PR**:
1. I don't think this can be testes in PR form. We need to merge it and then update the privacy reference tests repo and see if we get an automatic PR

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
