### PR TITLE
Surrogate + Privacy configuration privacy reference tests

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
@@ -47,17 +47,17 @@ public protocol PrivacyConfiguration {
     /// Check the protection status of given domain.
     ///
     /// Returns true if all below is true:
-    ///  - Site is not user unprotected.
-    ///  - Site is not in temp list.
-    ///  - Site is not in an exception list for content blocking feature.
+    ///  - Domain is not user unprotected.
+    ///  - Domain is not in temp list.
+    ///  - Domain is not in an exception list for content blocking feature.
     func isFeature(_ feature: PrivacyFeature, enabledForDomain: String?) -> Bool
 
     /// Check the protection status of given domain.
     ///
     /// Returns true if all below is true:
-    ///  - Site is not user unprotected.
-    ///  - Site is not in temp list.
-    ///  - Site is not in an exception list for content blocking feature.
+    ///  - Domain is not user unprotected.
+    ///  - Domain is not in temp list.
+    ///  - Domain is not in an exception list for content blocking feature.
     func isProtected(domain: String?) -> Bool
 
     /// Check if given domain is locally unprotected.

--- a/Tests/BrowserServicesKitTests/ContentBlocker/DomainMatchingTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/DomainMatchingTests.swift
@@ -30,7 +30,7 @@ struct RefTests: Decodable {
         let siteURL: String
         let requestURL: String
         let requestType: String
-        let expectAction: String?
+        let expectAction, expectExpression: String?
         let exceptPlatforms: [String]?
         
     }
@@ -43,7 +43,7 @@ struct RefTests: Decodable {
         
     }
     
-    let domainTests: DomainTests
+    let domainTests, surrogateTests: DomainTests
 }
 
 class DomainMatchingTests: XCTestCase {

--- a/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesReferenceTests.swift
@@ -41,14 +41,14 @@ final class SurrogatesReferenceTests: XCTestCase {
     }
     
     func testSurrogates() throws {
-        let data = JsonTestDataLoader()
+        let dataLoader = JsonTestDataLoader()
         
-        let trackerRadarJSONData = data.fromJsonFile(Resource.trackerRadar)
-        let testsData = data.fromJsonFile(Resource.tests)
-        let surrogatesData = data.fromJsonFile(Resource.surrogates)
+        let trackerRadarJSONData = dataLoader.fromJsonFile(Resource.trackerRadar)
+        let testsData = dataLoader.fromJsonFile(Resource.tests)
+        let surrogatesData = dataLoader.fromJsonFile(Resource.surrogates)
         
-        let refTests = try JSONDecoder().decode(RefTests.self, from: testsData)
-        let surrogateTests = refTests.surrogateTests.tests
+        let referenceTests = try JSONDecoder().decode(RefTests.self, from: testsData)
+        let surrogateTests = referenceTests.surrogateTests.tests
         
         let surrogateString = String(data: surrogatesData, encoding: .utf8)!
         

--- a/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesReferenceTests.swift
@@ -1,0 +1,222 @@
+//
+//  TrackerAllowlistReferenceTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import XCTest
+@testable import TrackerRadarKit
+import os.log
+import WebKit
+import BrowserServicesKit
+import Common
+
+final class SurrogatesReferenceTests: XCTestCase {
+    private let schemeHandler = TestSchemeHandler()
+    private var mockWebsite: MockWebsite!
+    private let userScriptDelegateMock = MockSurrogatesUserScriptDelegate()
+    private let navigationDelegateMock = MockNavigationDelegate()
+    private let tld = TLD()
+    private var redirectTests = [RefTests.Test]()
+    private var webView: WKWebView!
+    
+    private enum Resource {
+        static let trackerRadar = "Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json"
+        static let tests = "Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json"
+        static let surrogates = "Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/surrogates.txt"
+    }
+    
+    func testSurrogates() throws {
+        let data = JsonTestDataLoader()
+        
+        let trackerRadarJSONData = data.fromJsonFile(Resource.trackerRadar)
+        let testsData = data.fromJsonFile(Resource.tests)
+        let surrogatesData = data.fromJsonFile(Resource.surrogates)
+        
+        let refTests = try JSONDecoder().decode(RefTests.self, from: testsData)
+        let surrogateTests = refTests.surrogateTests.tests
+        
+        let surrogateString = String(data: surrogatesData, encoding: .utf8)!
+        
+        let trackerData = try JSONDecoder().decode(TrackerData.self, from: trackerRadarJSONData)
+        let encodedData = try? JSONEncoder().encode(trackerData)
+        let encodedTrackerData = String(data: encodedData!, encoding: .utf8)!
+        
+        let rules = ContentBlockerRulesBuilder(trackerData: trackerData).buildRules(withExceptions: [],
+                                                                                    andTemporaryUnprotectedDomains: [])
+        
+        let privacyConfig = WebKitTestHelper.preparePrivacyConfig(locallyUnprotected: [],
+                                                                  tempUnprotected: [],
+                                                                  trackerAllowlist: [:],
+                                                                  contentBlockingEnabled: true,
+                                                                  exceptions: [])
+        
+        let platformTests = surrogateTests.filter {
+            let skip = $0.exceptPlatforms?.contains("ios-browser")
+            return skip == false || skip == nil
+        }
+        
+        /*
+         We need to split redirect tests from the rest
+         redirect surrogates have to be injected in webview and then validated against an expression
+         */
+        redirectTests = platformTests.filter {
+            $0.expectAction == "redirect"
+        }
+        
+        let notRedirectTests = platformTests.filter {
+            $0.expectAction != "redirect"
+        }
+        
+        for test in notRedirectTests {
+            os_log("TEST: %s", test.name)
+            let requestURL = URL(string: test.requestURL)!
+            let siteURL = URL(string: test.siteURL)!
+            let requestType = ContentBlockerRulesBuilder.resourceMapping[test.requestType]
+            let rule = rules.matchURL(url: requestURL, topLevel: siteURL, resourceType: requestType!)
+            let result = rule?.action
+            
+            if test.expectAction == "block" {
+                XCTAssertEqual(result, .block())
+            } else if test.expectAction == "ignore" {
+                XCTAssertTrue(result == nil || result == .ignorePreviousRules())
+            }
+        }
+        
+        let testsExecuted = expectation(description: "tests executed")
+        testsExecuted.expectedFulfillmentCount = redirectTests.count
+        
+        createWebViewForUserScripTests(trackerData: trackerData,
+                                       encodedTrackerData: encodedTrackerData,
+                                       surrogates: surrogateString,
+                                       privacyConfig: privacyConfig) { webview in
+            
+            self.webView = webview
+            self.runTestForRedirect(onTestExecuted: testsExecuted)
+        }
+        
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    private func runTestForRedirect(onTestExecuted: XCTestExpectation) {
+        
+        guard let test = redirectTests.popLast(),
+              let expectExpression = test.expectExpression else {
+            return
+        }
+        
+        os_log("TEST: %s", test.name)
+        
+        let requestURL = URL(string: test.requestURL.testSchemeNormalized)!
+        let siteURL = URL(string: test.siteURL.testSchemeNormalized)!
+        
+        let resource = MockWebsite.EmbeddedResource(type: .script,
+                                                    url: requestURL)
+        
+        mockWebsite = MockWebsite(resources: [resource])
+        
+        schemeHandler.reset()
+        schemeHandler.requestHandlers[siteURL] = { _ in
+            return self.mockWebsite.htmlRepresentation.data(using: .utf8)!
+        }
+        
+        let request = URLRequest(url: siteURL)
+        
+        WKWebsiteDataStore.default().removeData(ofTypes: [WKWebsiteDataTypeDiskCache,
+                                                          WKWebsiteDataTypeMemoryCache,
+                                                          WKWebsiteDataTypeOfflineWebApplicationCache],
+                                                modifiedSince: Date(timeIntervalSince1970: 0),
+                                                completionHandler: {
+            self.webView.load(request)
+        })
+        
+        navigationDelegateMock.onDidFinishNavigation = {
+            
+            XCTAssertEqual(self.userScriptDelegateMock.detectedSurrogates.count, 1)
+            
+            if let request = self.userScriptDelegateMock.detectedSurrogates.first {
+                XCTAssertTrue(request.isBlocked, "Surrogate should block request \(requestURL)")
+                XCTAssertEqual(request.url, requestURL.absoluteString)
+            }
+            
+            self.userScriptDelegateMock.reset()
+            
+            self.webView?.evaluateJavaScript(expectExpression, completionHandler: { result, err in
+                XCTAssertNil(err)
+                
+                if let result = result as? Bool {
+                    XCTAssertTrue(result, "Expression \(expectExpression) should return true")
+                    onTestExecuted.fulfill()
+                    
+                    DispatchQueue.main.async {
+                        self.runTestForRedirect(onTestExecuted: onTestExecuted)
+                    }
+                }
+            })
+        }
+    }
+    
+    private func createWebViewForUserScripTests(trackerData: TrackerData,
+                                                encodedTrackerData: String,
+                                                surrogates: String,
+                                                privacyConfig: PrivacyConfiguration,
+                                                completion: @escaping (WKWebView) -> Void) {
+        
+        var tempUnprotected = privacyConfig.tempUnprotectedDomains.filter { !$0.trimmingWhitespace().isEmpty }
+        tempUnprotected.append(contentsOf: privacyConfig.exceptionsList(forFeature: .contentBlocking))
+        
+        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist)
+        
+        WebKitTestHelper.prepareContentBlockingRules(trackerData: trackerData,
+                                                     exceptions: privacyConfig.userUnprotectedDomains,
+                                                     tempUnprotected: tempUnprotected,
+                                                     trackerExceptions: exceptions) { rules in
+            guard let rules = rules else {
+                XCTFail("Rules were not compiled properly")
+                return
+            }
+            
+            let configuration = WKWebViewConfiguration()
+            configuration.setURLSchemeHandler(self.schemeHandler, forURLScheme: self.schemeHandler.scheme)
+            
+            let webView = WKWebView(frame: .init(origin: .zero, size: .init(width: 500, height: 1000)),
+                                    configuration: configuration)
+            webView.navigationDelegate = self.navigationDelegateMock
+            
+            let config = TestSchemeSurrogatesUserScriptConfig(privacyConfig: privacyConfig,
+                                                              surrogates: surrogates,
+                                                              trackerData: trackerData,
+                                                              encodedSurrogateTrackerData: encodedTrackerData,
+                                                              tld: self.tld,
+                                                              isDebugBuild: true)
+            
+            let userScript = SurrogatesUserScript(configuration: config)
+            userScript.delegate = self.userScriptDelegateMock
+            
+            for messageName in userScript.messageNames {
+                configuration.userContentController.add(userScript, name: messageName)
+            }
+            
+            configuration.userContentController.addUserScript(WKUserScript(source: userScript.source,
+                                                                           injectionTime: .atDocumentStart,
+                                                                           forMainFrameOnly: false))
+            configuration.userContentController.add(rules)
+            
+            completion(webView)
+        }
+    }
+}

--- a/Tests/BrowserServicesKitTests/ContentBlocker/TrackerAllowlistReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/TrackerAllowlistReferenceTests.swift
@@ -137,10 +137,6 @@ class TrackerAllowlistReferenceTests: XCTestCase {
         waitForExpectations(timeout: 30, handler: nil)
     }
 
-    private func normalizeScheme(urlString: String) -> String {
-        return urlString.replacingOccurrences(of: "https://", with: "test://").replacingOccurrences(of: "http://", with: "test://")
-    }
-
     // swiftlint:disable function_body_length
     private func popTestAndExecute(onTestExecuted: XCTestExpectation) {
 
@@ -150,11 +146,11 @@ class TrackerAllowlistReferenceTests: XCTestCase {
 
         os_log("TEST: %s", test.description)
 
-        var siteURL = URL(string: normalizeScheme(urlString: test.site))!
+        var siteURL = URL(string: test.site.testSchemeNormalized)!
         if siteURL.absoluteString.hasSuffix(".com") {
             siteURL = siteURL.appendingPathComponent("index.html")
         }
-        let requestURL = URL(string: normalizeScheme(urlString: test.request))!
+        let requestURL = URL(string: test.request.testSchemeNormalized)!
 
         let resource = MockWebsite.EmbeddedResource(type: .script,
                                                     url: requestURL)

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/PrivacyConfigurationReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/PrivacyConfigurationReferenceTests.swift
@@ -1,0 +1,114 @@
+//
+//  PrivacyConfigurationReferenceTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import os.log
+import BrowserServicesKit
+
+final class PrivacyConfigurationReferenceTests: XCTestCase {
+
+    private enum Resource {
+        static let configRootPath = "Resources/privacy-reference-tests/privacy-configuration"
+        static let tests = "Resources/privacy-reference-tests/privacy-configuration/tests.json"
+    }
+    
+    func testPrivacyConfiguration() throws {
+        let dataLoader = JsonTestDataLoader()
+        let testsData = dataLoader.fromJsonFile(Resource.tests)
+
+        let referenceTests = try JSONDecoder().decode(TestData.self, from: testsData)
+
+        for testConfig in referenceTests.testConfigs {
+            let path = "\(Resource.configRootPath)/\(testConfig.referenceConfig)"
+            
+            let configData = dataLoader.fromJsonFile(path)
+            let configJSON = try JSONSerialization.jsonObject(with: configData, options: []) as! [String: Any]
+            let privacyConfigurationData = PrivacyConfigurationData(json: configJSON)
+            
+            let privacyConfiguration = AppPrivacyConfiguration(data: privacyConfigurationData,
+                                                               identifier: UUID().uuidString,
+                                                               localProtection: MockDomainsProtectionStore())
+            for test in testConfig.tests {
+                if test.exceptPlatforms.contains(.macosBrowser) || test.exceptPlatforms.contains(.iosBrowser) {
+                    os_log("Skipping test %@", test.name)
+                    continue
+                }
+                
+                let testInfo = "\nName: \(test.name)\nFeature: \(test.featureName)\nsiteURL: \(test.siteURL)\nConfig: \(testConfig.referenceConfig)"
+  
+                guard let url = URL(string: test.siteURL),
+                      let siteDomain = url.host else {
+                    XCTFail("Can't get domain \(testInfo)")
+                    continue
+                }
+                
+                if let feature = PrivacyFeature(rawValue: test.featureName) {
+                    let isEnabled = privacyConfiguration.isFeature(feature, enabledForDomain: siteDomain)
+                    XCTAssertEqual(isEnabled, test.expectFeatureEnabled, testInfo)
+                    
+                } else if test.featureName == "trackerAllowlist" {
+                    let isEnabled = privacyConfigurationData.trackerAllowlist.state == "enabled"
+                    XCTAssertEqual(isEnabled, test.expectFeatureEnabled, testInfo)
+                    
+                } else {
+                    XCTFail("Can't create feature \(testInfo)")
+                    continue
+                }
+            }
+        }
+    }
+}
+
+// MARK: - TestData
+private struct TestData: Codable {
+    let testConfigs: [TestConfig]
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dict = try container.decode([String: TestConfig].self)
+        testConfigs = dict.compactMap { _, values in values }
+    }
+}
+
+// MARK: - TestConfig
+private struct TestConfig: Codable {
+    let name, desc, referenceConfig: String
+    let tests: [Test]
+    
+}
+
+// MARK: - Test
+private struct Test: Codable {
+    let name, featureName: String
+    let siteURL: String
+    let frameURL: String?
+    let expectFeatureEnabled: Bool
+    let exceptPlatforms: [ExceptPlatform]
+    let scriptURL: String?
+}
+
+// MARK: - ExceptPlatform
+private enum ExceptPlatform: String, Codable {
+    case androidBrowser = "android-browser"
+    case iosBrowser = "ios-browser"
+    case macosBrowser = "macos-browser"
+    case safariExtension = "safari-extension"
+    case webExtension = "web-extension"
+    case windowsBrowser = "windows-browser"
+}

--- a/Tests/BrowserServicesKitTests/Utils/StringExtension.swift
+++ b/Tests/BrowserServicesKitTests/Utils/StringExtension.swift
@@ -1,0 +1,27 @@
+//
+//  StringExtension.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension String {
+    var testSchemeNormalized: String {
+        self.replacingOccurrences(of: "https://", with: "test://").replacingOccurrences(of: "http://", with: "test://")
+
+    }
+}


### PR DESCRIPTION
**Required**:

Task/Issue URL:  https://app.asana.com/0/0/1203391706352063/f & https://app.asana.com/0/0/1203391706352067/f
iOS PR:  N/A
macOS PR: N/A
What kind of version bump will this require?: N/A (Only tests are being added)

**Description**:

Add privacy reference tests for surrogates and privacy configuration

**Steps to test this PR**:
1. Make sure this was merged https://github.com/duckduckgo/privacy-reference-tests/pull/62 first
1. Run tests :) 


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
