### PR TITLE
Sort domains before returning Unprotected Domains data set to guarantee consistency.

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -36,7 +36,7 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
     }
 
     public var userUnprotectedDomains: [String] {
-        return Array(locallyUnprotected.unprotectedDomains).normalizedDomainsForContentBlocking()
+        return Array(locallyUnprotected.unprotectedDomains).normalizedDomainsForContentBlocking().sorted()
     }
     
     public var tempUnprotectedDomains: [String] {

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
@@ -226,6 +226,28 @@ class AppPrivacyConfigurationTests: XCTestCase {
         config.userDisabledProtection(forDomain: "enabled2.com")
         XCTAssertTrue(config.isUserUnprotected(domain: "enabled2.com"))
     }
+    
+    func testWhenRequestingUnprotectedSites_ThenTheyAreConsistentlyOrdered() {
+        let mockEmbeddedData = MockEmbeddedDataProvider(data: embeddedConfig, etag: embeddedConfigETag)
+
+        let mockProtectionStore = MockDomainsProtectionStore()
+
+        let manager = PrivacyConfigurationManager(fetchedETag: corruptedConfigETag,
+                                                  fetchedData: corruptedConfig,
+                                                  embeddedDataProvider: mockEmbeddedData,
+                                                  localProtection: mockProtectionStore)
+
+        XCTAssertEqual(manager.embeddedConfigData.etag, mockEmbeddedData.embeddedDataEtag)
+        XCTAssertNil(manager.fetchedConfigData)
+
+        let config = manager.privacyConfig
+        
+        mockProtectionStore.unprotectedDomains = ["first.com", "second.com"]
+        XCTAssertEqual(config.userUnprotectedDomains, ["first.com", "second.com"])
+        
+        mockProtectionStore.unprotectedDomains = ["second.com", "first.com"]
+        XCTAssertEqual(config.userUnprotectedDomains, ["first.com", "second.com"])
+    }
 
     let exampleConfig =
     """


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**: 

Task/Issue URL: https://app.asana.com/0/414709148257752/1203476561077750
iOS PR:  n/a - drop as it to develop
macOS PR: n/a - drop as is to develop
What kind of version bump will this require?: Patch

**Description**:

Sort domains before returning data set to guarantee consistency.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

On old version :Break in DefaultContentBlockerRulesExceptionsSource:116 to see how User Unprotected domains were returned in random order (set). This should not happen with this change.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 
* [ ] macOS 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
