### PR TITLE
Update autofill to 6.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "7ddea0cc34cc4d2695c1d490fcbb1cb2fde641d6",
-          "version": "5.3.1"
+          "revision": "b16d363471003b39973b0f5418d3af2d37e657ae",
+          "version": "6.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .library(name: "PrivacyDashboard", targets: ["PrivacyDashboard"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.3.1")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.0.0")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.1")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203479831798123/1203479831798123
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.0.0


## Description
Updates Autofill to version [6.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.0.0).

### Autofill 6.0.0 release notes
## What's Changed

**⚠️ This is a breaking change for Android and Windows. We will get in touch with details. ⚠️**

* Add support for Bitwarden integration
* Make Asana release script more resilient by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/234
* Reuse webkit messaging by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/226
* Send js pixels by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/237
* Further bitwarden js changes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/238


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/5.3.1...6.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).