### PR TITLE
Replace PrivacyConfigurationData.init(json:) with throwable .init(data:)

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
@@ -40,7 +40,14 @@ public struct PrivacyConfigurationData {
     public let trackerAllowlist: TrackerAllowlist
     public let unprotectedTemporary: [ExceptionEntry]
 
-    public init(json: [String: Any]) {
+    public init(data: Data) throws {
+        guard let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+            throw PrivacyConfigurationManager.ParsingError.dataMismatch
+        }
+        self = .init(json: json)
+    }
+
+    internal init(json: [String: Any]) {
 
         if let tempListData = json[CodingKeys.unprotectedTemporary.rawValue] as? [[String: String]] {
             unprotectedTemporary = tempListData.compactMap({ ExceptionEntry(json: $0) })

--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationManager.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationManager.swift
@@ -85,8 +85,7 @@ public class PrivacyConfigurationManager: PrivacyConfigurationManaging {
                 data = embedded
             } else {
                 let jsonData = embeddedDataProvider.embeddedData
-                let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any]
-                let configData = PrivacyConfigurationData(json: json!)
+                let configData = try! PrivacyConfigurationData(data: jsonData)
                 _embeddedConfigData = (jsonData, configData, embeddedDataProvider.embeddedDataEtag)
                 data = _embeddedConfigData
             }
@@ -145,12 +144,8 @@ public class PrivacyConfigurationManager: PrivacyConfigurationManaging {
             
             do {
                 // This might fail if the downloaded data is corrupt or format has changed unexpectedly
-                if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                    let configData = PrivacyConfigurationData(json: json)
-                    fetchedConfigData = (data, configData, etag)
-                } else {
-                    throw ParsingError.dataMismatch
-                }
+                let configData = try PrivacyConfigurationData(data: data)
+                fetchedConfigData = (data, configData, etag)
             } catch {
                 errorReporting?.fire(.privacyConfigurationParseFailed, error: error)
                 fetchedConfigData = nil

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/PrivacyConfigurationDataTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/PrivacyConfigurationDataTests.swift
@@ -25,11 +25,9 @@ class PrivacyConfigurationDataTests: XCTestCase {
 
     private var data = JsonTestDataLoader()
 
-    func testJSONParsing() {
+    func testJSONParsing() throws {
         let jsonData = data.fromJsonFile("Resources/privacy-config-example.json")
-        let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any]
-
-        let configData = PrivacyConfigurationData(json: json!)
+        let configData = try PrivacyConfigurationData(data: jsonData)
 
         XCTAssertEqual(configData.unprotectedTemporary.count, 1)
         XCTAssertEqual(configData.unprotectedTemporary.first?.domain, "example.com")

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/PrivacyConfigurationReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/PrivacyConfigurationReferenceTests.swift
@@ -38,8 +38,7 @@ final class PrivacyConfigurationReferenceTests: XCTestCase {
             let path = "\(Resource.configRootPath)/\(testConfig.referenceConfig)"
             
             let configData = dataLoader.fromJsonFile(path)
-            let configJSON = try JSONSerialization.jsonObject(with: configData, options: []) as! [String: Any]
-            let privacyConfigurationData = PrivacyConfigurationData(json: configJSON)
+            let privacyConfigurationData = try PrivacyConfigurationData(data: configData)
             
             let privacyConfiguration = AppPrivacyConfiguration(data: privacyConfigurationData,
                                                                identifier: UUID().uuidString,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203216978682724/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1429
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/906
What kind of version bump will this require?: Major

**Description**:
Add a throwable initializer for PrivacyConfigurationData to be used in Config Validator in the macOS app.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Follow steps to reproduce in the macOS PR.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
