### PR TITLE
Update autofill to 6.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "b16d363471003b39973b0f5418d3af2d37e657ae",
-          "version": "6.0.0"
+          "revision": "971a9cd907f99d5ffda7872edf50b1a9aabb8cc3",
+          "version": "6.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "PrivacyDashboard", targets: ["PrivacyDashboard"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.0.0")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.1.0")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.1")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203655296097097/1203655296097097
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.0


## Description
Updates Autofill to version [6.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.0).

### Autofill 6.1.0 release notes
## What's Changed
* Fix types for ID by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/239
* Email Protection sign-up tooltip by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/240
* Autofill pixels by @sixers in https://github.com/duckduckgo/duckduckgo-autofill/pull/242
* More minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/244

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.0.0...6.0.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).