### PR TITLE
Update autofill to 6.1.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "b16d363471003b39973b0f5418d3af2d37e657ae",
-          "version": "6.0.0"
+          "revision": "b35f79da552b3b0e772c0f7582a8ff79f0e9cd29",
+          "version": "6.1.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "PrivacyDashboard", targets: ["PrivacyDashboard"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.0.0")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.1.1")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.2.1")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203674907697561/1203674907697561
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.1


## Description
Updates Autofill to version [6.1.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.1).

### Autofill 6.1.1 release notes
## What's Changed
* Fix types for ID by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/239
* Email Protection sign-up tooltip by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/240
* Autofill pixels by @sixers in https://github.com/duckduckgo/duckduckgo-autofill/pull/242
* More minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/244
* Fix schema issue in extension repo by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/245
* Remove form frontend validation by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/246


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.0.0...6.1.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).