### PR TITLE
Add api to reset compilation start time from clients

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -201,6 +201,12 @@ public class ContentBlockerRulesManager: CompiledRuleListsSource {
         }
         return token
     }
+    
+    public func resetCompilationTime() {
+        lock.lock()
+        compilationStartTime = nil
+        lock.unlock()
+    }
 
     /// Returns true if the compilation should be executed immediately
     private func updateCompilationState(token: CompletionToken) -> Bool {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200194497630846/1203569850690831/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1439
macOS:
It doesn't seem to be an issue on macOS since app won't be backgrounded as much as on iOS.

What kind of version bump will this require?: Patch
