### PR TITLE
Update autofill to 6.1.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "b35f79da552b3b0e772c0f7582a8ff79f0e9cd29",
-          "version": "6.1.1"
+          "revision": "3a329ee47224295fd4e8e85d8674daa126145134",
+          "version": "6.1.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "PrivacyDashboard", targets: ["PrivacyDashboard"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.1.1")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.1.2")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("2.0.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203789390844836/1203789390844836
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.2


## Description
Updates Autofill to version [6.1.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.2).

### Autofill 6.1.2 release notes
## What's Changed
* Type consistency internally + when consumed by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/247
* Improve hybrid form UX by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/248


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.1.1...6.1.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).