### PR TITLE
Update autofill to 6.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "3a329ee47224295fd4e8e85d8674daa126145134",
-          "version": "6.1.2"
+          "revision": "49c5e80e44306937cb3eaa7afb690b7889de3895",
+          "version": "6.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "PrivacyDashboard", targets: ["PrivacyDashboard"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.1.2")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.2.0")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("2.0.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203845335740047/1203845335740047
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.2.0


## Description
Updates Autofill to version [6.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.2.0).

### Autofill 6.2.0 release notes
## What's Changed
* Send autofill pixels on macOS by @sixers in https://github.com/duckduckgo/duckduckgo-autofill/pull/249


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.1.2...6.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).