### PR TITLE
Update autofill to 6.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "49c5e80e44306937cb3eaa7afb690b7889de3895",
-          "version": "6.2.0"
+          "revision": "9f0c2eab4223f1f28cced4eac73e4381a8daa35e",
+          "version": "6.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "PrivacyDashboard", targets: ["PrivacyDashboard"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.2.0")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.3.0")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("2.0.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203937331479729/1203937331479729
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.3.0


## Description
Updates Autofill to version [6.3.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.3.0).

### Autofill 6.3.0 release notes
## What's Changed
* Email protection in-context signup for extensions by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/243


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.2.0...6.3.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203937331479733