### PR TITLE
Update Privacy Dashboard's open settings API

### DIFF
--- a/Sources/PrivacyDashboard/PrivacyDashboardController.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardController.swift
@@ -21,11 +21,15 @@ import WebKit
 import Combine
 import PrivacyDashboardResources
 
+public enum PrivacyDashboardOpenSettingsTarget: String {
+    case general
+    case cookiePopupManagement = "cpm"
+}
+
 public protocol PrivacyDashboardControllerDelegate: AnyObject {
-    
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didChangeProtectionSwitch isEnabled: Bool)
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didRequestOpenUrlInNewTab url: URL)
-    func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didRequestOpenSettings target: String)
+    func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didRequestOpenSettings target: PrivacyDashboardOpenSettingsTarget)
 
 #if os(iOS)
     func privacyDashboardControllerDidTapClose(_ privacyDashboardController: PrivacyDashboardController)
@@ -224,7 +228,8 @@ extension PrivacyDashboardController: WKNavigationDelegate {
 extension PrivacyDashboardController: PrivacyDashboardUserScriptDelegate {
 
     func userScript(_ userScript: PrivacyDashboardUserScript, didRequestOpenSettings target: String) {
-        delegate?.privacyDashboardController(self, didRequestOpenSettings: target)
+        let settingsTarget = PrivacyDashboardOpenSettingsTarget(rawValue: target) ?? .general
+        delegate?.privacyDashboardController(self, didRequestOpenSettings: settingsTarget)
     }
 
     func userScript(_ userScript: PrivacyDashboardUserScript, didChangeProtectionStateTo isProtected: Bool) {

--- a/Sources/PrivacyDashboard/PrivacyDashboardController.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardController.swift
@@ -25,6 +25,7 @@ public protocol PrivacyDashboardControllerDelegate: AnyObject {
     
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didChangeProtectionSwitch isEnabled: Bool)
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didRequestOpenUrlInNewTab url: URL)
+    func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didRequestOpenSettings target: String)
 
 #if os(iOS)
     func privacyDashboardControllerDidTapClose(_ privacyDashboardController: PrivacyDashboardController)
@@ -36,7 +37,6 @@ public protocol PrivacyDashboardControllerDelegate: AnyObject {
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didRequestSubmitBrokenSiteReportWithCategory category: String, description: String)
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didSetPermission permissionName: String, to state: PermissionAuthorizationState)
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, setPermission permissionName: String, paused: Bool)
-    func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didRequestOpenSettings target: String)
 #endif
     
 }
@@ -224,9 +224,7 @@ extension PrivacyDashboardController: WKNavigationDelegate {
 extension PrivacyDashboardController: PrivacyDashboardUserScriptDelegate {
 
     func userScript(_ userScript: PrivacyDashboardUserScript, didRequestOpenSettings target: String) {
-#if os(macOS)
         delegate?.privacyDashboardController(self, didRequestOpenSettings: target)
-#endif
     }
 
     func userScript(_ userScript: PrivacyDashboardUserScript, didChangeProtectionStateTo isProtected: Bool) {


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/0/1203928853394760/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1475 (done as part of https://app.asana.com/0/715106103902962/1201892492219034/f)
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/972
What kind of version bump will this require?: Major

**Description**:
- make the delegate method a required for both platforms (instead of macOS only)
- transform the string parameter denoting settings sub-screen/pane into an enum

**Steps to test this PR**:
1. Open a website where cookies prompt is managed (notification shows in the address bar)
2. Open Privacy Dashboard
3. Open "Cookies managed" option
4. Tap open settings button/link to verify if it successfully navigates to Settings pane.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
