### PR TITLE
Fix issue when symbolic link is being created at the source too

### DIFF
--- a/scripts/setup-new-file-template.sh
+++ b/scripts/setup-new-file-template.sh
@@ -7,8 +7,20 @@ script_dir=$(dirname "$(readlink -f "$0")")
 source="$script_dir/assets/Swift File For Package.xctemplate"
 destination="/Applications/Xcode.app/Contents/Developer/Library/Xcode/Templates/File Templates/MultiPlatform/Source/Swift File For Package.xctemplate"
 
-# Create a symbolic link
-ln -sF "$source" "$destination"
+# Store the current working directory
+original_dir=$(pwd)
+
+# Change the working directory to the assets directory to ensure that the symbolic
+# link is created with the correct relative paths and only in the intended destination directory.
+# Without this, the ln command would create the symbolic link in the current working directory 
+# as well as the destination directory.
+(
+  cd "$script_dir/assets" || exit
+  ln -sF "$source" "$destination"
+)
+
+# Restore the original working directory
+cd "$original_dir" || exit
 
 # Check if the symlink was created successfully
 if [[ ! -L "$destination" ]]; then

--- a/scripts/setup-new-file-template.sh
+++ b/scripts/setup-new-file-template.sh
@@ -7,20 +7,8 @@ script_dir=$(dirname "$(readlink -f "$0")")
 source="$script_dir/assets/Swift File For Package.xctemplate"
 destination="/Applications/Xcode.app/Contents/Developer/Library/Xcode/Templates/File Templates/MultiPlatform/Source/Swift File For Package.xctemplate"
 
-# Store the current working directory
-original_dir=$(pwd)
-
-# Change the working directory to the assets directory to ensure that the symbolic
-# link is created with the correct relative paths and only in the intended destination directory.
-# Without this, the ln command would create the symbolic link in the current working directory 
-# as well as the destination directory.
-(
-  cd "$script_dir/assets" || exit
-  ln -sF "$source" "$destination"
-)
-
-# Restore the original working directory
-cd "$original_dir" || exit
+# Create a symbolic link
+ln -sFn "$source" "$destination"
 
 # Check if the symlink was created successfully
 if [[ ! -L "$destination" ]]; then


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1203979634198817/f
iOS PR:  n/a
macOS PR: n/a
What kind of version bump will this require?: n/a

CC: @ayoy 

**Description**:

 Include the -n or --no-dereference option. This should prevent the creation of the duplicate symbolic link.

**Steps to test this PR**:
1. Remove the "Swift File For Package.xctemplate" under /Applications/Xcode.app/Contents/Developer/Library/Xcode/Templates/File Templates/MultiPlatform/Source/
1. Run the script - make sure the symbolic link works and appear **only** the destination.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
