### PR TITLE
WKFrameInfo nullable request property

### DIFF
--- a/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
+++ b/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
@@ -1,5 +1,5 @@
 //
-//  WKNavigationActionExtension.swift
+//  WKFrameInfoExtension.swift
 //
 //  Copyright © 2023 DuckDuckGo. All rights reserved.
 //

--- a/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
+++ b/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
@@ -1,0 +1,110 @@
+//
+//  WKNavigationActionExtension.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import WebKit
+import os.log
+
+public extension WKFrameInfo {
+
+    internal static var defaultMainFrameHandle = "4"
+
+    // prevent exception if private API keys go missing
+    override func value(forUndefinedKey key: String) -> Any? {
+        assertionFailure("valueForUndefinedKey: \(key)")
+        return nil
+    }
+
+    @nonobjc var handle: String {
+#if DEBUG
+        String(describing: (self.value(forKey: "handle") as? NSObject)!.value(forKey: "frameID")!)
+#else
+        self.isMainFrame ? Self.defaultMainFrameHandle : "iframe"
+#endif
+    }
+
+    /// Safe Optional `request: URLRequest` getter:
+    /// .request of a new Frame can be `null`, see https://app.asana.com/0/0/1203965979591356/f
+    var safeRequest: URLRequest? {
+        _=WKFrameInfo.addSafetyCheckForSafeRequestUsageOnce
+        return self.perform(#selector(getter: request))?.takeUnretainedValue() as? URLRequest
+    }
+
+#if DEBUG
+    private static var ignoredRequestUsageSymbols = Set<String>()
+
+    // ensure `.safeRequest` is used and not `.request`
+    static var addSafetyCheckForSafeRequestUsageOnce: Void = {
+        let originalRequestMethod = class_getInstanceMethod(WKFrameInfo.self, #selector(getter: WKFrameInfo.request))!
+        let swizzledRequestMethod = class_getInstanceMethod(WKFrameInfo.self, #selector(WKFrameInfo.swizzledRequest))!
+        method_exchangeImplementations(originalRequestMethod, swizzledRequestMethod)
+
+        // ignore `request` selector calls from `safeRequest` itself
+        ignoredRequestUsageSymbols.insert(callingSymbol())
+    }()
+
+    // get symbol from stack trace for a caller of a calling method
+    static private func callingSymbol() -> String {
+        let stackTrace = Thread.callStackSymbols
+        // find `callingSymbol` itself or dispatch_once_callout
+        var callingSymbolIdx = stackTrace.firstIndex(where: { $0.contains("_dispatch_once_callout") })
+            ?? stackTrace.firstIndex(where: { $0.contains("callingSymbol") })!
+        // procedure calling `callingSymbol`
+        callingSymbolIdx += 1
+
+        var symbolName: String
+        repeat {
+            // caller for the procedure
+            callingSymbolIdx += 1
+            symbolName = String(stackTrace[callingSymbolIdx].split(separator: " ")[3])
+        } while stackTrace[callingSymbolIdx - 1].contains(symbolName.dropping(suffix: "To")) // skip objc wrappers
+
+        return symbolName
+    }
+
+    @objc dynamic private func swizzledRequest() -> URLRequest? {
+        func fileLine(file: StaticString = #file, line: Int = #line) -> String {
+            return "\(("\(file)" as NSString).lastPathComponent):\(line + 1)"
+        }
+
+        // don‘t break twice
+        if Self.ignoredRequestUsageSymbols.insert(Self.callingSymbol()).inserted {
+            os_log("""
+
+
+            ------------------------------------------------------------------------------------------------------
+                BREAK at %s:
+            ------------------------------------------------------------------------------------------------------
+                Don‘t use `WKFrameInfo.request` as it has incorrect nullability
+                Use `WKFrameInfo.safeRequest` instead
+
+                Hit Continue (^⌘Y) to continue program execution
+            ------------------------------------------------------------------------------------------------------
+
+            """, type: .debug, fileLine())
+            raise(SIGINT)
+        }
+        
+        return self.swizzledRequest() // call the original
+    }
+
+#else
+    static var addSafetyCheckForSafeRequestUsageOnce: Void { () }
+#endif
+
+}
+

--- a/Sources/Navigation/FrameInfo.swift
+++ b/Sources/Navigation/FrameInfo.swift
@@ -33,7 +33,7 @@ public struct FrameInfo: Equatable {
     }
 
     public init(frame: WKFrameInfo) {
-        self.init(frameIdentity: FrameIdentity(frame), url: frame.request.url ?? .empty, securityOrigin: SecurityOrigin(frame.securityOrigin))
+        self.init(frameIdentity: FrameIdentity(frame), url: frame.safeRequest?.url ?? .empty, securityOrigin: SecurityOrigin(frame.securityOrigin))
     }
 
     public static func mainFrame(for webView: WKWebView) -> FrameInfo {
@@ -98,23 +98,4 @@ extension FrameIdentity: CustomDebugStringConvertible {
     public var debugDescription: String {
         "\(webView?.pointerValue?.debugDescription.replacing(regex: "^0x0*", with: "0x") ?? "<nil>")_\(handle)\(isMainFrame ? ": Main" : "")"
     }
-}
-
-public extension WKFrameInfo {
-    internal static var defaultMainFrameHandle = "4"
-
-    // prevent exception if private API keys go missing
-    override func value(forUndefinedKey key: String) -> Any? {
-        assertionFailure("valueForUndefinedKey: \(key)")
-        return nil
-    }
-
-    @nonobjc var handle: String {
-#if DEBUG
-        String(describing: (self.value(forKey: "handle") as? NSObject)!.value(forKey: "frameID")!)
-#else
-        self.isMainFrame ? Self.defaultMainFrameHandle : "iframe"
-#endif
-    }
-
 }

--- a/Sources/Navigation/NavigationAction.swift
+++ b/Sources/Navigation/NavigationAction.swift
@@ -105,7 +105,7 @@ public struct NavigationAction {
            redirectHistory == nil,
            navigationAction.safeSourceFrame == nil,
            navigationAction.targetFrame?.isMainFrame == true,
-           navigationAction.targetFrame?.request.url?.isEmpty == true,
+           navigationAction.targetFrame?.safeRequest?.url?.isEmpty == true,
            webView.backForwardList.currentItem != nil {
 
             // go back after failing session restoration has `other` Navigation Type


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199230911884351/1203965979591356/f
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/981
What kind of version bump will this require?: Minor/Patch

CC: @tomasstrba 

**Description**:
Added WKFrameInfo.safeRequest property instead of wrongly-non-nullable .request
Added runtime checks for WKFrameInfo.safeRequest and WKNavigationAction.sourceFrame usage in Debug config

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

Steps to test this PR:
0. Validate both Debug&Release builds
1. Go to https://www.seriouseats.com/ask-the-food-lab-do-i-need-to-use-kosher-salt
2. Click through the "Buy on ..." product links, validate there‘s no crash when WKFrameInfo.request is accessed
3. Validate microphone permission works on https://permission.site/

