### PR TITLE
Autofill changes how URLs are stored and match suggestions

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/Matchers/AutofillUrlMatcher.swift
+++ b/Sources/BrowserServicesKit/Autofill/Matchers/AutofillUrlMatcher.swift
@@ -55,11 +55,7 @@ public struct AutofillDomainNameUrlMatcher: AutofillUrlMatcher {
         }
 
         if currentUrlComponents.eTLDplus1(tld: tld) == savedUrlComponents.eTLDplus1(tld: tld) {
-            if currentUrlComponents.subdomain(tld: tld) == savedUrlComponents.subdomain(tld: tld) ||
-               subdomainsAreTheSameIgnoringWWW(currentSite: currentUrlComponents, savedSite: savedUrlComponents, tld: tld) ||
-               (savedUrlComponents.subdomain(tld: tld) ?? "").isEmpty {
-                return true
-            }
+            return true
         }
 
         return false
@@ -75,17 +71,6 @@ public struct AutofillDomainNameUrlMatcher: AutofillUrlMatcher {
 
         let noScheme = rawUrl.dropping(prefix: URL.URLProtocol.https.scheme).dropping(prefix: URL.URLProtocol.http.scheme)
         return URLComponents(string: "\(URL.URLProtocol.https.scheme)\(noScheme)")
-    }
-
-    private func subdomainsAreTheSameIgnoringWWW(currentSite: URLComponents, savedSite: URLComponents, tld: TLD) -> Bool {
-        let currentSiteSubdomain = currentSite.subdomain(tld: tld)?.replacingOccurrences(of: Constants.www, with: "") ?? ""
-        let savedSiteSubdomain = savedSite.subdomain(tld: tld)?.replacingOccurrences(of: Constants.www, with: "") ?? ""
-
-        return currentSiteSubdomain == savedSiteSubdomain
-    }
-
-    private enum Constants {
-        static let www = "www"
     }
 
 }

--- a/Sources/BrowserServicesKit/Autofill/Matchers/AutofillUrlMatcher.swift
+++ b/Sources/BrowserServicesKit/Autofill/Matchers/AutofillUrlMatcher.swift
@@ -1,0 +1,91 @@
+//
+//  AutofillUrlMatcher.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Common
+
+public protocol AutofillUrlMatcher {
+    func cleanRawUrl(_ rawUrl: String) -> String
+    func isMatchingForAutofill(currentSite: String, savedSite: String, tld: TLD) -> Bool
+}
+
+public struct AutofillDomainNameUrlMatcher: AutofillUrlMatcher {
+
+    public init() {}
+
+    public func cleanRawUrl(_ rawUrl: String) -> String {
+        let trimmedUrl = rawUrl.trimmingWhitespace()
+
+        guard let urlComponents = normalizeSchemeForAutofill(trimmedUrl), let host = urlComponents.host else {
+            return rawUrl
+        }
+
+        if let port = urlComponents.port {
+            return "\(host):\(port)"
+        } else {
+            return host
+        }
+    }
+
+    public func isMatchingForAutofill(currentSite: String, savedSite: String, tld: TLD) -> Bool {
+
+        guard let currentUrlComponents = normalizeSchemeForAutofill(currentSite),
+              let savedUrlComponents = normalizeSchemeForAutofill(savedSite) else {
+            return false
+        }
+
+        if currentUrlComponents.port != savedUrlComponents.port {
+            return false
+        }
+
+        if currentUrlComponents.eTLDplus1(tld: tld) == savedUrlComponents.eTLDplus1(tld: tld) {
+            if currentUrlComponents.subdomain(tld: tld) == savedUrlComponents.subdomain(tld: tld) ||
+               subdomainsAreTheSameIgnoringWWW(currentSite: currentUrlComponents, savedSite: savedUrlComponents, tld: tld) ||
+               (savedUrlComponents.subdomain(tld: tld) ?? "").isEmpty {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func normalizeSchemeForAutofill(_ rawUrl: String) -> URLComponents? {
+        if !rawUrl.starts(with: URL.URLProtocol.https.scheme) &&
+           !rawUrl.starts(with: URL.URLProtocol.http.scheme) &&
+           rawUrl.contains("://") {
+            // Contains some other protocol, so don't mess with it
+            return nil
+        }
+
+        let noScheme = rawUrl.dropping(prefix: URL.URLProtocol.https.scheme).dropping(prefix: URL.URLProtocol.http.scheme)
+        return URLComponents(string: "\(URL.URLProtocol.https.scheme)\(noScheme)")
+    }
+
+    private func subdomainsAreTheSameIgnoringWWW(currentSite: URLComponents, savedSite: URLComponents, tld: TLD) -> Bool {
+        let currentSiteSubdomain = currentSite.subdomain(tld: tld)?.replacingOccurrences(of: Constants.www, with: "") ?? ""
+        let savedSiteSubdomain = savedSite.subdomain(tld: tld)?.replacingOccurrences(of: Constants.www, with: "") ?? ""
+
+        return currentSiteSubdomain == savedSiteSubdomain
+    }
+
+    private enum Constants {
+        static let www = "www"
+    }
+
+}

--- a/Sources/Common/Extensions/URLComponentsExtension.swift
+++ b/Sources/Common/Extensions/URLComponentsExtension.swift
@@ -1,0 +1,32 @@
+//
+//  URLComponentsExtension.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension URLComponents {
+
+    public func eTLDplus1(tld: TLD) -> String? {
+        return tld.eTLDplus1(self.host?.lowercased())
+    }
+
+    public func subdomain(tld: TLD) -> String? {
+        return tld.extractSubdomain(from: self.host?.lowercased())
+    }
+
+
+}

--- a/Sources/Common/TLD/TLD.swift
+++ b/Sources/Common/TLD/TLD.swift
@@ -89,5 +89,13 @@ public class TLD {
         guard let host = URL(string: escapedStringURL)?.host else { return nil }
         return eTLDplus1(host)
     }
-    
+
+    public func extractSubdomain(from host: String?) -> String? {
+        guard let host = host, let eTLDPlus1 = eTLDplus1(host) else {
+            return nil
+        }
+
+        let subdomain = host.replacingOccurrences(of: eTLDPlus1, with: "").dropping(suffix: ".")
+        return subdomain.isEmpty ? nil : subdomain
+    }
 }

--- a/Sources/UserScript/UserScriptMessage.swift
+++ b/Sources/UserScript/UserScriptMessage.swift
@@ -37,7 +37,11 @@ extension WKScriptMessage: UserScriptMessage {
     }
     
     public var messageHost: String {
-        return frameInfo.securityOrigin.host
+        return "\(frameInfo.securityOrigin.host)\(messagePort)"
+    }
+
+    public var messagePort: String {
+        return frameInfo.securityOrigin.port == 0 ? "" : ":\(frameInfo.securityOrigin.port)"
     }
 
     public var isMainFrame: Bool {

--- a/Tests/BrowserServicesKitTests/Autofill/Matchers/AutofillDomainNameUrlMatcherTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/Matchers/AutofillDomainNameUrlMatcherTests.swift
@@ -81,10 +81,10 @@ final class AutofillDomainNameUrlMatcherTests: XCTestCase {
         XCTAssertTrue(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
     }
 
-    func testWhenSavedSiteContainsSubdomainAndVisitedSiteDoesNotThenNoMatchingForAutofill() {
+    func testWhenSavedSiteContainsSubdomainAndVisitedSiteDoesNotThenMatchingForAutofill() {
         let currentUrl = "example.com"
         let savedUrl = "login.example.com"
-        XCTAssertFalse(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
+        XCTAssertTrue(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
     }
 
     func testWhenSavedSiteDoesNotContainSubdomainAndVisitedSiteDoesThenMatchingForAutofill() {
@@ -93,10 +93,10 @@ final class AutofillDomainNameUrlMatcherTests: XCTestCase {
         XCTAssertTrue(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
     }
 
-    func testWhenUrlsHaveDifferentSubdomainsThenNoMatchingForAutofill() {
+    func testWhenUrlsHaveDifferentSubdomainsThenMatchingForAutofill() {
         let currentUrl = "login.example.com"
         let savedUrl = "test.example.com"
-        XCTAssertFalse(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
+        XCTAssertTrue(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
     }
 
     func testWhenSavedSiteContainsWwwSubdomainAndVisitedSiteDoesNotThenMatchingForAutofill() {
@@ -147,16 +147,16 @@ final class AutofillDomainNameUrlMatcherTests: XCTestCase {
         XCTAssertTrue(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
     }
 
-    func testWhenSavedSiteContainNestedSubdomainsAndVisitedSiteContainsMatchingRootSubdomainThenNotMatchingForAutofill() {
+    func testWhenSavedSiteContainNestedSubdomainsAndVisitedSiteContainsMatchingRootSubdomainThenMatchingForAutofill() {
         let currentUrl = "a.example.com"
         let savedUrl = "login.a.example.com"
-        XCTAssertFalse(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
+        XCTAssertTrue(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
     }
 
-    func testWhenSavedSiteContainSubdomainAndVisitedSiteContainsNestedSubdomainsThenNotMatchingForAutofill() {
+    func testWhenSavedSiteContainSubdomainAndVisitedSiteContainsNestedSubdomainsThenMatchingForAutofill() {
         let currentUrl = "login.a.example.com"
         let savedUrl = "a.example.com"
-        XCTAssertFalse(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
+        XCTAssertTrue(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
     }
 
     func testWhenSavedSiteHasNoSubdomainAndVisitedMaliciousSitePartiallyContainSavedSiteThenNoMatchingForAutofill() {

--- a/Tests/BrowserServicesKitTests/Autofill/Matchers/AutofillDomainNameUrlMatcherTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/Matchers/AutofillDomainNameUrlMatcherTests.swift
@@ -1,5 +1,5 @@
 //
-//  AutofillUrlMatcherTests.swift
+//  AutofillDomainNameUrlMatcherTests.swift
 //  DuckDuckGo
 //
 //  Copyright © 2023 DuckDuckGo. All rights reserved.
@@ -21,7 +21,7 @@ import XCTest
 import BrowserServicesKit
 import Common
 
-final class AutofillUrlMatcherTests: XCTestCase {
+final class AutofillDomainNameUrlMatcherTests: XCTestCase {
 
     private let tld = TLD()
     private let autofillDomainNameUrlMatcher = AutofillDomainNameUrlMatcher()
@@ -51,13 +51,13 @@ final class AutofillUrlMatcherTests: XCTestCase {
         XCTAssertEqual("RandomText", autofillDomainNameUrlMatcher.cleanRawUrl("thisIs@RandomText"))
     }
 
-    func testwhenUrlsAreIdenticalThenMatchingForAutofill() {
+    func testWhenUrlsAreIdenticalThenMatchingForAutofill() {
         let currentUrl = "https://example.com"
         let savedUrl = "https://example.com"
         XCTAssertTrue(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))
     }
 
-    func testwhenUrlsAreIdenticalExceptForUppercaseVisitedSiteThenMatchingForAutofill() {
+    func testWhenUrlsAreIdenticalExceptForUppercaseVisitedSiteThenMatchingForAutofill() {
         let currentUrl = "https://example.com"
         let savedUrl = "https://EXAMPLE.COM"
         XCTAssertTrue(autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl, savedSite: savedUrl, tld: tld))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL:  https://app.asana.com/0/488551667048375/1203927830097159/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1510
macOS PR: https://github.com/more-duckduckgo-org/macos-browser/pull/991
What kind of version bump will this require?: Minor

**Description**:

- Autofill URLs normalized to store only host:port
- Subdomains and ports taken into consideration for Autofill suggestion matching

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See iOS PR for test steps

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
