### PR TITLE
fix flaky testClientRedirectToSameDocument

### DIFF
--- a/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
+++ b/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
@@ -731,9 +731,6 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         }
         waitForExpectations(timeout: 5)
 
-        if case .didFail = responder(at: 0).history[5] {
-            responder(at: 0).history.insert(responder(at: 0).history.remove(at: 5), at: 6)
-        }
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(req(urls.testScheme), .other, src: main()),
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),

--- a/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
+++ b/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
@@ -386,10 +386,20 @@ extension DistributedNavigationDelegateTestsBase {
     // Event sequence checking
     func assertHistory(ofResponderAt responderIdx: Int, equalsTo rhs: [TestsNavigationEvent], file: StaticString = #file, line: UInt = #line, useEventLine: Bool = true) {
         let lhs = responder(at: responderIdx).history
+        var rhs = rhs
         var lastEventLine = line
         for idx in 0..<max(lhs.count, rhs.count) {
             let event1 = lhs.indices.contains(idx) ? lhs[idx] : nil
-            let event2 = rhs.indices.contains(idx) ? rhs[idx] : nil
+            var idx2: Int! = (event1 != nil ? rhs.firstIndex(where: { event2 in compare("", event1, event2) == nil }) : nil)
+            if let idx2 {
+                // events are equal
+                rhs.remove(at: idx2)
+                continue
+            } else {
+                idx2 = idx
+            }
+
+            let event2 = rhs.indices.contains(idx2) ? rhs.remove(at: idx2) : nil
             let line = useEventLine ? (event2?.line ?? lastEventLine) : line
             lastEventLine = line
 

--- a/Tests/NavigationTests/NavigationDownloadsTests.swift
+++ b/Tests/NavigationTests/NavigationDownloadsTests.swift
@@ -236,33 +236,6 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
         }
         waitForExpectations(timeout: 5)
 
-        // sort download events by url and event order
-        responder(at: 0).history
-            .replaceSubrange(5...13, with: responder(at: 0)
-                .history[5...13]
-                .sorted {
-                    func eventAndUrlIdx(from event: TestsNavigationEvent) -> (event: Int, idx: Int) {
-                        switch event {
-                        case .navigationAction(let navAction, _, _):
-                            return (0, Int(String(navAction.navigationAction.url.string.last!))!)
-                        case .navActionWillBecomeDownload(let navAction, _):
-                            return (1, Int(String(navAction.navigationAction.url.string.last!))!)
-                        case .navActionBecameDownload(let navAction, _, _):
-                            return (2, Int(String(navAction.navigationAction.url.string.last!))!)
-                        default:
-                            XCTFail("unexpected \(event)")
-                            return (0, 0)
-                        }
-                    }
-                    let lhs = eventAndUrlIdx(from: $0)
-                    let rhs = eventAndUrlIdx(from: $1)
-                    if lhs.idx == rhs.idx {
-                        return lhs.event < rhs.event
-                    } else {
-                        return lhs.idx < rhs.idx
-                    }
-                })
-
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(req(urls.local), .other, src: main()),
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
@@ -322,33 +295,6 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
             _=webView.load(req(urls.local))
         }
         waitForExpectations(timeout: 5)
-
-        // sort download events by url and event order
-        responder(at: 0).history
-            .replaceSubrange(8...16, with: responder(at: 0)
-                .history[8...16]
-                .sorted {
-                    func eventAndUrlIdx(from event: TestsNavigationEvent) -> (event: Int, idx: Int) {
-                        switch event {
-                        case .navigationResponse(.response(let response, _), _):
-                            return (0, Int(String(response.response.url.string.last!))!)
-                        case .navResponseWillBecomeDownload(let idx, _):
-                            return (1, idx + 1)
-                        case .navResponseBecameDownload(_, let url, _):
-                            return (2, Int(String(url.string.last!))!)
-                        default:
-                            XCTFail("unexpected \(event)")
-                            return (0, 0)
-                        }
-                    }
-                    let lhs = eventAndUrlIdx(from: $0)
-                    let rhs = eventAndUrlIdx(from: $1)
-                    if lhs.idx == rhs.idx {
-                        return lhs.event < rhs.event
-                    } else {
-                        return lhs.idx < rhs.idx
-                    }
-                })
 
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(req(urls.local), .other, src: main()),

--- a/Tests/NavigationTests/NavigationRedirectsTests.swift
+++ b/Tests/NavigationTests/NavigationRedirectsTests.swift
@@ -58,6 +58,9 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
         }
         waitForExpectations(timeout: 5)
 
+        if case .didCommit = responder(at: 0).history[5] {
+            responder(at: 0).history.insert(responder(at: 0).history[5], at: 4)
+        }
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(req(urls.local), .other, src: main()),
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),

--- a/Tests/NavigationTests/NavigationRedirectsTests.swift
+++ b/Tests/NavigationTests/NavigationRedirectsTests.swift
@@ -1032,9 +1032,6 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             return false
         })
 
-        if case .didFail = responder(at: 0).history[3] {
-            responder(at: 0).history.insert(responder(at: 0).history.remove(at: 3), at: 1)
-        }
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(NavAction(req(urls.local), .other, from: history[2], src: main(urls.local2))),
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1204022321706940/f
What kind of version bump will this require?: Patch

**Steps to test this PR**:
1. Validate tests pass
