### PR TITLE
fix breaking on WKFrameInfo.safeRequest

### DIFF
--- a/Sources/Common/Extensions/BundleExtension.swift
+++ b/Sources/Common/Extensions/BundleExtension.swift
@@ -20,12 +20,18 @@
 import Foundation
 
 extension Bundle {
-    
+
     struct Keys {
+        static let name = kCFBundleNameKey as String
         static let versionNumber = "CFBundleShortVersionString"
     }
-    
+
     public var releaseVersionNumber: String? {
         return infoDictionary?[Keys.versionNumber] as? String
     }
+
+    public var name: String? {
+        object(forInfoDictionaryKey: Keys.name) as? String
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: 
What kind of version bump will this require?: Patch

**Optional**:

**Description**:
 fix breakpoint on WKFrameInfo.safeRequest when running App Store scheme
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate no break is happening when running App Store scheme
