### PR TITLE
fix about: scheme fragments dropping

### DIFF
--- a/Sources/Common/Extensions/StringExtension.swift
+++ b/Sources/Common/Extensions/StringExtension.swift
@@ -61,16 +61,24 @@ public extension String {
         self.dropping(prefix: "www.")
     }
 
-    var hashedSuffix: String? {
+    var hashedSuffixRange: PartialRangeFrom<String.Index>? {
         if let idx = self.firstIndex(of: "#") {
-            return String(self[idx...])
+            return idx...
+        } else if self.hasPrefix("about:"),
+                  let range = self.range(of: "%23") {
+            return range.lowerBound...
         }
         return nil
     }
 
+    var hashedSuffix: String? {
+        hashedSuffixRange.map { range in String(self[range]) }
+    }
+
     func droppingHashedSuffix() -> String {
-        if let idx = self.firstIndex(of: "#") {
-            return String(self[..<idx])
+        if let range = self.hashedSuffixRange {
+            guard range.lowerBound > self.startIndex else { return "" }
+            return String(self[..<range.lowerBound])
         }
         return self
     }

--- a/Tests/CommonTests/Extensions/StringExtensionTests.swift
+++ b/Tests/CommonTests/Extensions/StringExtensionTests.swift
@@ -83,6 +83,9 @@ final class StringExtensionTests: XCTestCase {
     func testDroppingHashedSuffix() {
         XCTAssertEqual("http://localhost:8084/#navlink".droppingHashedSuffix(), "http://localhost:8084/")
         XCTAssertEqual("http://localhost:8084/#navlink#1".droppingHashedSuffix(), "http://localhost:8084/")
+        XCTAssertEqual("about://blank/#navlink1".url!.absoluteString.droppingHashedSuffix(), "about://blank/")
+        XCTAssertEqual("about:blank/#navlink1".url!.absoluteString.droppingHashedSuffix(), "about:blank/")
+        XCTAssertEqual("about:blank#navlink1".url!.absoluteString.droppingHashedSuffix(), "about:blank")
     }
 
 }

--- a/Tests/CommonTests/Extensions/URLExtensionTests.swift
+++ b/Tests/CommonTests/Extensions/URLExtensionTests.swift
@@ -322,7 +322,7 @@ final class URLExtensionTests: XCTestCase {
 
 }
 
-private extension String {
+extension String {
     var url: URL? {
         return URL(trimmedAddressBarString: self)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1204067721102897/f
iOS PR:  - not affected
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1007
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
Fixes about: scheme with fragments URLs navigation asserting in DistributedNavigationDelegate

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open about:blank
2. navigate to about:blank#1 - validate no assertion is fired

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
