### PR TITLE
fix assertion for popup about:blank navigations without WKNavigation

### DIFF
--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -413,7 +413,11 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
     @MainActor
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation wkNavigation: WKNavigation?) {
         let navigation: Navigation
-        if let expectedNavigation = navigationExpectedToStart, wkNavigation != nil || expectedNavigation.navigationAction.navigationType == .sessionRestoration {
+        if let expectedNavigation = navigationExpectedToStart,
+           wkNavigation != nil
+            || expectedNavigation.navigationAction.navigationType == .sessionRestoration
+            || expectedNavigation.navigationAction.url.scheme.map(URL.NavigationalScheme.init) == .about {
+
             // regular flow: start .expected navigation
             navigation = expectedNavigation
         } else if webView.url?.isEmpty == false {

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -416,10 +416,12 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
         if let expectedNavigation = navigationExpectedToStart, wkNavigation != nil || expectedNavigation.navigationAction.navigationType == .sessionRestoration {
             // regular flow: start .expected navigation
             navigation = expectedNavigation
-        } else {
+        } else if webView.url?.isEmpty == false {
             assertionFailure("session restoration happening without NavigationAction")
             navigation = Navigation(identity: NavigationIdentity(wkNavigation), responders: responders, state: .expected(nil), isCurrent: true)
             navigation.navigationActionReceived(.sessionRestoreNavigation(webView: webView, mainFrameNavigation: navigation))
+        } else {
+            return
         }
 
         navigation.started(wkNavigation)
@@ -696,7 +698,7 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
     @MainActor
     public func webView(_ webView: WKWebView, didCommit wkNavigation: WKNavigation?) {
         guard let navigation = wkNavigation?.navigation ?? startedNavigation else {
-            assertionFailure("Unexpected didCommitNavigation")
+            assert(wkNavigation == nil, "Unexpected didCommitNavigation without preceding didStart")
             return
         }
         updateCurrentHistoryItemIdentity(webView.backForwardList.currentItem)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1204065038916789/f
iOS PR:  - not affected
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1008
What kind of version bump will this require?: Patch

**Optional**:

**Steps to test this PR**:
1. window.open("") from js console, validate no assertion is raised
