### PR TITLE
Add xcbeautify to unit tests reports

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,13 +44,12 @@ jobs:
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
 
+    - name: Install xcbeautify
+      continue-on-error: true
+      run: brew install xcbeautify
+
     - name: Run tests
-      # BSK does not support running tests in parallel, but the flag is required
-      # to make XUnit output work. Making it parallel with 1 worker then.
-      # https://stackoverflow.com/a/70040836
-      run: |
-        swift test --parallel --num-workers=1 \
-          --xunit-output tests.xml
+      run: swift test | xcbeautify --report junit --report-path . --junit-report-filename tests.xml
 
     - name: Publish Unit Tests Report
       uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,7 +49,7 @@ jobs:
       run: brew install xcbeautify
 
     - name: Run tests
-      run: swift test | xcbeautify --report junit --report-path . --junit-report-filename tests.xml
+      run: set -o pipefail && swift test | xcbeautify --report junit --report-path . --junit-report-filename tests.xml
 
     - name: Publish Unit Tests Report
       uses: mikepenz/action-junit-report@v3
@@ -57,3 +57,4 @@ jobs:
       with:
         check_name: Test Report
         report_paths: tests.xml
+        require_tests: true


### PR DESCRIPTION
# Task issue

https://app.asana.com/0/1203301625297703/1203998658300743/f

## Description

Add [xcbeautify](https://github.com/tuist/xcbeautify) to our unit tests report.

I also removed the need to add the --parellel flag because now we use the xcbeautify report instead of the swift test one