### PR TITLE
Add SPM cache

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,6 +41,24 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Set cache key hash
+      run: |
+         has_only_tags=$(jq '[ .object.pins[].state | has("version") ] | all' Package.resolved)
+         if [[ "$has_only_tags" == "true" ]]; then
+           echo "cache_key_hash=${{ hashFiles('Package.resolved') }}" >> $GITHUB_ENV
+         else
+           echo "Package.resolved contains dependencies specified by branch or commit, skipping cache."
+         fi
+
+    - name: Cache SPM
+      if: env.cache_key_hash
+      uses: actions/cache@v3
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ env.cache_key_hash }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
 


### PR DESCRIPTION
## Task
https://app.asana.com/0/1203301625297703/1204055987245578/f

## Description

Adds cache for the SPM packages to reduce build times.

The pictures show the reduced time in the `Run tests` step. In the after picture, you will see the Cache SPM step takes 3 minutes because it caches the packages the first time.

| Before | After |
| --- | --- |
|![Before cache](https://user-images.githubusercontent.com/7924732/223106420-2bb73679-9fd1-4b80-8a59-cd5136b3ee8f.png)|![After cache](https://user-images.githubusercontent.com/7924732/223106424-4c8ba2b2-2390-472b-8ad1-f902fd4c9140.png)|


