### PR TITLE
fix bloom filter crash

### DIFF
--- a/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgrade.swift
+++ b/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgrade.swift
@@ -36,7 +36,8 @@ public final class HTTPSUpgrade {
         self.store = store
         self.privacyManager = privacyManager
     }
-    
+
+    @MainActor
     public func upgrade(url: URL) async -> Result<URL, HTTPSUpgradeError> {
         guard url.isHttp,
               let host = url.host,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200541656900018/1204105120334404/f
iOS PR:  
macOS PR: 
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
Fixes crash caused by bloom filter being called from background thread (non-main-actor)
