### PR TITLE
Opt-outable private API usage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -109,6 +109,8 @@ let package = Package(
                 .define("WILLPERFORMCLIENTREDIRECT_ENABLED", .when(platforms: [.macOS])),
                 .define("_IS_REDIRECT_ENABLED", .when(platforms: [.macOS])),
                 .define("_MAIN_FRAME_NAVIGATION_ENABLED", .when(platforms: [.macOS])),
+                .define("_FRAME_HANDLE_ENABLED", .when(platforms: [.macOS])),
+                .define("PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED", .when(platforms: [.macOS])),
                 .define("TERMINATE_WITH_REASON_ENABLED", .when(platforms: [.macOS])),
             ]),
         .target(
@@ -169,8 +171,13 @@ let package = Package(
                 "Navigation",
                 .product(name: "Swifter", package: "swifter")
             ],
+            resources: [
+                .copy("Resources")
+            ],
             swiftSettings: [
                 .define("_IS_USER_INITIATED_ENABLED", .when(platforms: [.macOS])),
+                .define("_FRAME_HANDLE_ENABLED", .when(platforms: [.macOS])),
+                .define("PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED", .when(platforms: [.macOS])),
             ]),
         .testTarget(
             name: "UserScriptTests",

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -65,6 +65,7 @@ public final class DistributedNavigationDelegate: NSObject {
         self.currentNavigation = currentNavigation
     }
 
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
     /// last BackForwardList item committed into WebView
     @Published public private(set) var currentHistoryItemIdentity: HistoryItemIdentity?
     private func updateCurrentHistoryItemIdentity(_ currentItem: WKBackForwardListItem?) {
@@ -74,10 +75,17 @@ public final class DistributedNavigationDelegate: NSObject {
 
         currentHistoryItemIdentity = identity
     }
+#else
+    private var currentHistoryItemIdentity: HistoryItemIdentity? { nil }
+#endif
 
     public init(logger: OSLog) {
         dispatchPrecondition(condition: .onQueue(.main))
         self.logger = logger
+
+#if !_MAIN_FRAME_NAVIGATION_ENABLED
+        _=WKWebView.swizzleLoadMethodOnce
+#endif
     }
 
     /** set responder chain for Navigation Events with defined ownership and nullability:
@@ -176,13 +184,27 @@ private extension DistributedNavigationDelegate {
         // only handled for main-frame navigations:
         // get WKNavigation associated with the WKNavigationAction
         // it is not `current` yet, unless it‘s a server-redirect
+#if _MAIN_FRAME_NAVIGATION_ENABLED
         let wkNavigation = wkNavigationAction.mainFrameNavigation
+#else
+        let wkNavigation = webView.expectedMainFrameNavigation(for: wkNavigationAction)
+#endif
         let navigation: Navigation = {
             if let navigation = wkNavigation?.navigation,
                // same-document NavigationActions have a previous WKNavigation mainFrameNavigation
                !wkNavigationAction.isSameDocumentNavigation {
                 // it‘s a server-redirect or a developer-initiated navigation, so the WKNavigation already has an associated Navigation object
                 return navigation
+
+            // server-redirected navigation continues with the same WKNavigation identity
+            } else if let startedNavigation,
+                      case .started = startedNavigation.state,
+                      // redirect Navigation Action should always have sourceFrame set:
+                      // https://github.com/WebKit/WebKit/blob/c39358705b79ccf2da3b76a8be6334e7e3dfcfa6/Source/WebKit/UIProcess/WebPageProxy.cpp#L5675
+                      wkNavigationAction.safeSourceFrame != nil,
+                      wkNavigationAction.isRedirect != false {
+
+                return startedNavigation
             }
             return Navigation(identity: NavigationIdentity(wkNavigation), responders: responders, state: .expected(nil), isCurrent: false)
         }()
@@ -194,19 +216,12 @@ private extension DistributedNavigationDelegate {
         // custom NavigationType for navigations with developer-set NavigationType
         var navigationType: NavigationType? = navigation.state.expectedNavigationType
         var redirectHistory: [NavigationAction]?
-        if let startedNavigation,
-           // server-redirected navigation continues with the same WKNavigation identity
-           startedNavigation === navigation || navigation.identity == .expected,
-           case .started = startedNavigation.state,
-           // redirect Navigation Action should always have sourceFrame set:
-           // https://github.com/WebKit/WebKit/blob/c39358705b79ccf2da3b76a8be6334e7e3dfcfa6/Source/WebKit/UIProcess/WebPageProxy.cpp#L5675
-           wkNavigationAction.safeSourceFrame != nil,
-           wkNavigationAction.isRedirect != false {
 
+        // server redirect received
+        if startedNavigation === navigation {
             assert(navigationType == nil)
-            // server redirect received
             navigationType = .redirect(.server)
-            redirectHistory = startedNavigation.navigationActions
+            redirectHistory = navigation.navigationActions
 
         // client redirect
         } else if let startedNavigation,
@@ -254,11 +269,11 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
         if (navigationAction.url.scheme.map(URL.NavigationalScheme.init) == .about
             && (webView.backForwardList.currentItem == nil || navigationAction.navigationType == .sessionRestoration))
             // same-document navigations do the same
-            || wkNavigationAction.isSameDocumentNavigation {
+            || wkNavigationAction.isSameDocumentNavigation && navigationAction.navigationType != .redirect(.server) {
 
             // allow them right away
             decisionHandler(.allow, wkPreferences)
-            if let mainFrameNavigation {
+            if let mainFrameNavigation, !mainFrameNavigation.isCurrent {
                 self.willStart(mainFrameNavigation)
             }
             return
@@ -393,22 +408,6 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
     }
 
     // MARK: Navigation
-
-    @MainActor
-    @objc(_webView:navigation:didSameDocumentNavigation:)
-    public func webView(_ webView: WKWebView, wkNavigation: WKNavigation?, didSameDocumentNavigation navigationType: Int) {
-        os_log("didSameDocumentNavigation %s: %d", log: logger, type: .default, wkNavigation.debugDescription, navigationType)
-
-        // currentHistoryItemIdentity should only change for completed navigation, not while in progress
-        let navigationType = WKSameDocumentNavigationType(rawValue: navigationType)
-        if case .anchorNavigation = navigationType {
-            updateCurrentHistoryItemIdentity(webView.backForwardList.currentItem)
-        }
-
-        for responder in responders {
-            responder.navigation(wkNavigation?.navigation, didSameDocumentNavigationOf: navigationType)
-        }
-    }
 
     @MainActor
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation wkNavigation: WKNavigation?) {
@@ -605,7 +604,9 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
             return
         }
 
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
         updateCurrentHistoryItemIdentity(webView.backForwardList.currentItem)
+#endif
         navigation.didFinish(wkNavigation)
         os_log("didFinish: %s", log: logger, type: .default, navigation.debugDescription)
 
@@ -642,7 +643,9 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
             return
         }
 
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
         updateCurrentHistoryItemIdentity(webView.backForwardList.currentItem)
+#endif
 
         if navigation.isCurrent && !isProvisional {
             navigation.didResignCurrent()
@@ -660,6 +663,23 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
                 return
             }
             self.startedNavigation = nil
+        }
+    }
+
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
+    @MainActor
+    @objc(_webView:navigation:didSameDocumentNavigation:)
+    public func webView(_ webView: WKWebView, wkNavigation: WKNavigation?, didSameDocumentNavigation navigationType: Int) {
+        os_log("didSameDocumentNavigation %s: %d", log: logger, type: .default, wkNavigation.debugDescription, navigationType)
+
+        // currentHistoryItemIdentity should only change for completed navigation, not while in progress
+        let navigationType = WKSameDocumentNavigationType(rawValue: navigationType)
+        if case .anchorNavigation = navigationType {
+            updateCurrentHistoryItemIdentity(webView.backForwardList.currentItem)
+        }
+
+        for responder in responders {
+            responder.navigation(wkNavigation?.navigation, didSameDocumentNavigationOf: navigationType)
         }
     }
 
@@ -682,6 +702,7 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
             responder.didFailProvisionalLoad(with: request, in: frame, with: error)
         }
     }
+#endif
 
     // MARK: Downloads
 
@@ -699,7 +720,9 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
             assertionFailure("Unexpected didCommitNavigation")
             return
         }
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
         updateCurrentHistoryItemIdentity(webView.backForwardList.currentItem)
+#endif
         navigation.committed(wkNavigation)
         os_log("didCommit: %s", log: logger, type: .default, navigation.debugDescription)
 

--- a/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
+++ b/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
@@ -31,6 +31,7 @@ public extension WKFrameInfo {
         return nil
     }
 
+#if _FRAME_HANDLE_ENABLED
     @nonobjc var handle: FrameHandle {
         guard let handle = self.value(forKey: "handle") as? FrameHandle else {
             assertionFailure("WKFrameInfo.handle is missing")
@@ -38,6 +39,7 @@ public extension WKFrameInfo {
         }
         return handle
     }
+#endif
 
     /// Safe Optional `request: URLRequest` getter:
     /// .request of a new Frame can be `null`, see https://app.asana.com/0/0/1203965979591356/f

--- a/Sources/Navigation/Extensions/WKNavigationActionExtension.swift
+++ b/Sources/Navigation/Extensions/WKNavigationActionExtension.swift
@@ -123,6 +123,7 @@ extension WKNavigationAction: WebViewNavigationAction {
         }
     }
 
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
     /// returns navigation distance from current BackForwardList item for back/forward navigations
     /// -1-based, negative for back navigations; 1-based, positive for forward navigations
     public func getDistance(from historyItemIdentity: HistoryItemIdentity?) -> Int? {
@@ -142,6 +143,7 @@ extension WKNavigationAction: WebViewNavigationAction {
         }
         return nil
     }
+#endif
 
     public var isSameDocumentNavigation: Bool {
         guard let currentURL = targetFrame?.safeRequest?.url?.absoluteString,

--- a/Sources/Navigation/Extensions/WKWebViewExtension.swift
+++ b/Sources/Navigation/Extensions/WKWebViewExtension.swift
@@ -20,8 +20,10 @@ import WebKit
 
 extension WKWebView {
 
+#if _FRAME_HANDLE_ENABLED
+
     private static let mainFrameKey = "mainFrame"
-    var mainFrameHandle: FrameHandle {
+    public var mainFrameHandle: FrameHandle {
         guard self.responds(to: NSSelectorFromString("_" + Self.mainFrameKey))
                 || self.responds(to: NSSelectorFromString(Self.mainFrameKey)) else {
             return .fallbackMainFrameHandle
@@ -29,4 +31,129 @@ extension WKWebView {
         return value(forKey: Self.mainFrameKey) as? FrameHandle ?? .fallbackMainFrameHandle
     }
 
+#endif
+
+#if !_MAIN_FRAME_NAVIGATION_ENABLED
+
+    static let swizzleLoadMethodOnce: Void = {
+        var selectors = [
+            #selector(load(_:)): #selector(navigation_load(_:)),
+            #selector(loadFileURL): #selector(navigation_loadFileURL),
+            #selector(loadHTMLString): #selector(navigation_loadHTMLString),
+            #selector(load(_:mimeType:characterEncodingName:baseURL:)): #selector(navigation_load(_:mimeType:characterEncodingName:baseURL:)),
+            #selector(go(to:)): #selector(navigation_go(to:)),
+            NSSelectorFromString("goBack"): #selector(navigation_goBack),
+            NSSelectorFromString("goForward"): #selector(navigation_goForward),
+            NSSelectorFromString("reload"): #selector(navigation_reload),
+            NSSelectorFromString("reloadFromOrigin"): #selector(navigation_reloadFromOrigin),
+        ]
+        if #available(macOS 12.0, *) {
+            selectors.merge([
+                #selector(loadFileRequest(_:allowingReadAccessTo:)): #selector(navigation_loadFileRequest(_:allowingReadAccessTo:)),
+                #selector(loadSimulatedRequest(_:response:responseData:)): #selector(navigation_loadSimulatedRequest(_:response:responseData:)),
+                #selector(loadSimulatedRequest(_:responseHTML:)): #selector(navigation_loadSimulatedRequest(_:responseHTML:)),
+            ]) { _, _ in fatalError() }
+        }
+        for (selector, swizzledSelector) in selectors {
+            let originalMethod = class_getInstanceMethod(WKWebView.self, selector)!
+            let swizzledMethod = class_getInstanceMethod(WKWebView.self, swizzledSelector)!
+            method_exchangeImplementations(originalMethod, swizzledMethod)
+        }
+    }()
+
+    private static let expectedMainFrameNavigationsKey = UnsafeRawPointer(bitPattern: "expectedMainFrameNavigations".hashValue)!
+    private var expectedMainFrameNavigations: [HashableURLRequest: WeakWKNavigationBox] {
+        get {
+            objc_getAssociatedObject(self, Self.expectedMainFrameNavigationsKey) as? [HashableURLRequest: WeakWKNavigationBox] ?? [:]
+        }
+        set {
+            objc_setAssociatedObject(self, Self.expectedMainFrameNavigationsKey, newValue.filter { $0.value.ref != nil }, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+
+    fileprivate func addExpectedNavigation(_ navigation: WKNavigation, matching request: URLRequest) {
+        expectedMainFrameNavigations[.init(request)] = WeakWKNavigationBox(ref: navigation)
+    }
+
+    internal func expectedMainFrameNavigation(for navigationAction: WKNavigationAction) -> WKNavigation? {
+        // return and nullify the same dict record
+        withUnsafeMutablePointer(to: &expectedMainFrameNavigations[.init(navigationAction.request)]) { ptr in
+            defer {
+                ptr.pointee = nil
+            }
+            return ptr.pointee?.ref
+        }
+    }
+
+    @objc dynamic private func navigation_load(_ request: URLRequest) -> WKNavigation? {
+        navigation_load(request)?.appendingToExpectedNavigations(in: self, matching: request)
+    }
+    @objc dynamic private func navigation_loadFileURL(_ url: URL, allowingReadAccessTo readAccessURL: URL) -> WKNavigation? {
+        navigation_loadFileURL(url, allowingReadAccessTo: readAccessURL)?.appendingToExpectedNavigations(in: self, matching: URLRequest(url: url))
+    }
+    @objc dynamic private func navigation_loadHTMLString(_ string: String, baseURL: URL?) -> WKNavigation? {
+        navigation_loadHTMLString(string, baseURL: baseURL)?.appendingToExpectedNavigations(in: self, matching: URLRequest(url: baseURL ?? url ?? .empty))
+    }
+    @objc dynamic private func navigation_load(_ data: Data, mimeType MIMEType: String, characterEncodingName: String, baseURL: URL) -> WKNavigation? {
+        navigation_load(data, mimeType: MIMEType, characterEncodingName: characterEncodingName, baseURL: baseURL)?.appendingToExpectedNavigations(in: self, matching: URLRequest(url: baseURL))
+    }
+    @objc dynamic private func navigation_go(to item: WKBackForwardListItem) -> WKNavigation? {
+        navigation_go(to: item)?.appendingToExpectedNavigations(in: self, matching: URLRequest(url: item.url, cachePolicy: .returnCacheDataElseLoad))
+    }
+    @objc dynamic private func navigation_goBack() -> WKNavigation? {
+        navigation_goBack()?.appendingToExpectedNavigations(in: self, matching: URLRequest(url: backForwardList.backItem?.url ?? .empty, cachePolicy: .returnCacheDataElseLoad))
+    }
+    @objc dynamic private func navigation_goForward() -> WKNavigation? {
+        navigation_goForward()?.appendingToExpectedNavigations(in: self, matching: URLRequest(url: backForwardList.forwardItem?.url ?? .empty, cachePolicy: .returnCacheDataElseLoad))
+    }
+    @objc dynamic private func navigation_reload() -> WKNavigation? {
+        navigation_reload()?.appendingToExpectedNavigations(in: self, matching: URLRequest(url: url ?? .empty, cachePolicy: .reloadIgnoringLocalCacheData))
+    }
+    @objc dynamic private func navigation_reloadFromOrigin() -> WKNavigation? {
+        navigation_reloadFromOrigin()?.appendingToExpectedNavigations(in: self, matching: URLRequest(url: url ?? .empty, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData))
+    }
+
+    @objc dynamic private func navigation_loadFileRequest(_ request: URLRequest, allowingReadAccessTo readAccessURL: URL) -> WKNavigation {
+        navigation_loadFileRequest(request, allowingReadAccessTo: readAccessURL).appendingToExpectedNavigations(in: self, matching: request)
+    }
+
+    @objc dynamic private func navigation_loadSimulatedRequest(_ request: URLRequest, response: URLResponse, responseData data: Data) -> WKNavigation {
+        navigation_loadSimulatedRequest(request, response: response, responseData: data).appendingToExpectedNavigations(in: self, matching: request)
+    }
+
+    @objc dynamic private func navigation_loadSimulatedRequest(_ request: URLRequest, responseHTML string: String) -> WKNavigation {
+        navigation_loadSimulatedRequest(request, responseHTML: string).appendingToExpectedNavigations(in: self, matching: request)
+    }
+
+#endif
+
 }
+
+#if !_MAIN_FRAME_NAVIGATION_ENABLED
+struct WeakWKNavigationBox {
+    weak var ref: WKNavigation?
+}
+
+struct HashableURLRequest: Hashable {
+    var url: String?
+    var cachePolicy: URLRequest.CachePolicy
+    var timeoutInterval: TimeInterval
+
+    init(url: URL? = nil, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 60) {
+        self.url = url?.absoluteString.dropping(suffix: "/")
+        self.cachePolicy = cachePolicy
+        self.timeoutInterval = timeoutInterval
+    }
+
+    init(_ request: URLRequest) {
+        self.init(url: request.url, cachePolicy: request.cachePolicy, timeoutInterval: request.timeoutInterval)
+    }
+}
+
+extension WKNavigation {
+    func appendingToExpectedNavigations(in webView: WKWebView, matching request: URLRequest) -> WKNavigation {
+        webView.addExpectedNavigation(self, matching: request)
+        return self
+    }
+}
+#endif

--- a/Sources/Navigation/Extensions/WKWebViewExtension.swift
+++ b/Sources/Navigation/Extensions/WKWebViewExtension.swift
@@ -47,7 +47,7 @@ extension WKWebView {
             NSSelectorFromString("reload"): #selector(navigation_reload),
             NSSelectorFromString("reloadFromOrigin"): #selector(navigation_reloadFromOrigin),
         ]
-        if #available(macOS 12.0, *) {
+        if #available(macOS 12.0, iOS 15.0, *) {
             selectors.merge([
                 #selector(loadFileRequest(_:allowingReadAccessTo:)): #selector(navigation_loadFileRequest(_:allowingReadAccessTo:)),
                 #selector(loadSimulatedRequest(_:response:responseData:)): #selector(navigation_loadSimulatedRequest(_:response:responseData:)),

--- a/Sources/Navigation/FrameHandle.swift
+++ b/Sources/Navigation/FrameHandle.swift
@@ -18,6 +18,7 @@
 
 import WebKit
 
+#if _FRAME_HANDLE_ENABLED
 public struct FrameHandle: Hashable, _ObjectiveCBridgeable {
     private let rawValue: Any
 
@@ -95,3 +96,4 @@ extension FrameHandle: CustomDebugStringConvertible {
         "\(frameID)"
     }
 }
+#endif

--- a/Sources/Navigation/FrameInfo.swift
+++ b/Sources/Navigation/FrameInfo.swift
@@ -21,14 +21,16 @@ import Foundation
 import WebKit
 
 // swiftlint:disable line_length
-public struct FrameInfo: Equatable {
+public struct FrameInfo {
 
     public weak var webView: WKWebView?
-    public let handle: FrameHandle
 
     public let isMainFrame: Bool
     public let url: URL
     public let securityOrigin: SecurityOrigin
+
+#if _FRAME_HANDLE_ENABLED
+    public let handle: FrameHandle
 
     public init(webView: WKWebView?, handle: FrameHandle, isMainFrame: Bool, url: URL, securityOrigin: SecurityOrigin) {
         self.webView = webView
@@ -50,11 +52,36 @@ public struct FrameInfo: Equatable {
                   securityOrigin: webView.url?.securityOrigin ?? .empty)
     }
 
+#else
+
+    public init(webView: WKWebView?, isMainFrame: Bool, url: URL, securityOrigin: SecurityOrigin) {
+        self.webView = webView
+        self.isMainFrame = isMainFrame
+        self.url = url
+        self.securityOrigin = securityOrigin
+    }
+
+    public init(frame: WKFrameInfo) {
+        self.init(webView: frame.webView, isMainFrame: frame.isMainFrame, url: frame.safeRequest?.url ?? .empty, securityOrigin: SecurityOrigin(frame.securityOrigin))
+    }
+
+    public static func mainFrame(for webView: WKWebView) -> FrameInfo {
+        FrameInfo(webView: webView,
+                  isMainFrame: true,
+                  url: webView.url ?? .empty,
+                  securityOrigin: webView.url?.securityOrigin ?? .empty)
+    }
+
+#endif
+}
+
+#if _FRAME_HANDLE_ENABLED
+extension FrameInfo: Equatable {
     public static func == (lhs: FrameInfo, rhs: FrameInfo) -> Bool {
         return lhs.handle == rhs.handle && lhs.webView == rhs.webView && lhs.isMainFrame == rhs.isMainFrame && lhs.url.matches(rhs.url) && lhs.securityOrigin == rhs.securityOrigin
     }
-
 }
+#endif
 
 extension SecurityOrigin {
     public init(_ securityOrigin: WKSecurityOrigin) {
@@ -65,6 +92,11 @@ extension SecurityOrigin {
 extension FrameInfo: CustomDebugStringConvertible {
     public var debugDescription: String {
         let webViewPtr = webView.map(NSValue.init(nonretainedObject:))?.pointerValue?.debugDescription.replacing(regex: "^0x0*", with: "0x") ?? "<nil>"
-        return "<Frame \(webViewPtr)_\(handle.debugDescription) \(isMainFrame ? ": Main" : ""); current url: \(url.absoluteString.isEmpty ? "empty" : url.absoluteString)>"
+#if _FRAME_HANDLE_ENABLED
+        let handle = handle.debugDescription + " "
+#else
+        let handle = ""
+#endif
+        return "<Frame \(webViewPtr)_\(handle)\(isMainFrame ? ": Main" : ""); current url: \(url.absoluteString.isEmpty ? "empty" : url.absoluteString)>"
     }
 }

--- a/Sources/Navigation/NavigationResponder.swift
+++ b/Sources/Navigation/NavigationResponder.swift
@@ -90,6 +90,7 @@ public protocol NavigationResponder {
     func webContentProcessDidTerminate(with reason: WKProcessTerminationReason?)
 
     // MARK: - Private
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
     @MainActor
     func navigation(_ navigation: Navigation?, didSameDocumentNavigationOf navigationType: WKSameDocumentNavigationType?)
 
@@ -104,6 +105,7 @@ public protocol NavigationResponder {
 
     @MainActor
     func didFailProvisionalLoad(with request: URLRequest, in frame: WKFrameInfo, with error: Error)
+#endif
 
     /// Return true to disable stop on decidePolicyForNavigationAction taking longer than 4 secoinds
     @MainActor
@@ -140,8 +142,6 @@ public extension NavigationResponder {
 
     func webContentProcessDidTerminate(with reason: WKProcessTerminationReason?) {}
 
-    @MainActor
-    func navigation(_ navigation: Navigation?, didSameDocumentNavigationOf navigationType: WKSameDocumentNavigationType?) {}
 
     @MainActor
     func webViewWillPerformClientRedirect(to url: URL, withDelay delay: TimeInterval) {}
@@ -149,11 +149,16 @@ public extension NavigationResponder {
     @MainActor
     func webViewDidCancelClientRedirect(currentNavigation: Navigation?) {}
 
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
+    @MainActor
+    func navigation(_ navigation: Navigation?, didSameDocumentNavigationOf navigationType: WKSameDocumentNavigationType?) {}
+
     @MainActor
     func didFinishLoad(with request: URLRequest, in frame: WKFrameInfo) {}
 
     @MainActor
     func didFailProvisionalLoad(with request: URLRequest, in frame: WKFrameInfo, with error: Error) {}
+#endif
 
     var shouldDisableLongDecisionMakingChecks: Bool { false }
 

--- a/Sources/Navigation/NavigationType.swift
+++ b/Sources/Navigation/NavigationType.swift
@@ -30,7 +30,11 @@ public enum NavigationType: Equatable {
     case formSubmitted
     case formResubmitted
 
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
     case backForward(distance: Int)
+#else
+    case backForward
+#endif
     case reload
 
     case redirect(RedirectType)
@@ -55,7 +59,11 @@ public enum NavigationType: Equatable {
             self = .linkActivated
 #endif
         case .backForward:
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
             self = .backForward(distance: navigationAction.getDistance(from: currentHistoryItemIdentity) ?? 0)
+#else
+            self = .backForward
+#endif
         case .reload:
             self = .reload
         case .formSubmitted:
@@ -108,6 +116,7 @@ public extension NavigationType {
         return false
     }
 
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
     var backForwardDistance: Int? {
         if case .backForward(distance: let distance) = self, distance != 0 { return distance }
         return nil
@@ -120,6 +129,7 @@ public extension NavigationType {
     var isGoingForward: Bool {
         (backForwardDistance ?? 0) > 0
     }
+#endif
 
     var isSessionRestoration: Bool {
         if case .sessionRestoration = self { return true }
@@ -132,7 +142,9 @@ public protocol WebViewNavigationAction {
     var navigationType: WKNavigationType { get }
     var isSameDocumentNavigation: Bool { get }
 
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
     func getDistance(from historyItemIdentity: HistoryItemIdentity?) -> Int?
+#endif
 #if os(macOS)
     var isMiddleClick: Bool { get }
 #endif
@@ -166,7 +178,11 @@ extension NavigationType: CustomDebugStringConvertible {
         switch self {
         case .linkActivated: return "linkActivated"
         case .formSubmitted: return "formSubmitted"
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
         case .backForward(let distance): return "backForward" + (distance != 0 ? "[\(distance)]" : "")
+#else
+        case .backForward: return "backForward"
+#endif
         case .reload: return "reload"
         case .formResubmitted: return "formResubmitted"
         case .sessionRestoration: return "sessionRestoration"

--- a/Tests/NavigationTests/ClosureNavigationResponderTests.swift
+++ b/Tests/NavigationTests/ClosureNavigationResponderTests.swift
@@ -69,7 +69,7 @@ class ClosureNavigationResponderTests: DistributedNavigationDelegateTestsBase {
                 guard navigationActionCounter == 2 else { return .next }
                 eNavAction.fulfill()
                 return .allow
-            }  willStart: { _ in
+            } willStart: { _ in
                 eWillStart.fulfill()
             } didStart: { _ in
                 eDidStart.fulfill()

--- a/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
+++ b/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
@@ -304,9 +304,11 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
             if navAction.url.path == urls.local2.path {
                 XCTAssertTrue(navAction.isTargetingNewWindow)
                 newFrameIdentity = navAction.targetFrame?.handle
+#if _FRAME_HANDLE_ENABLED
                 XCTAssertNotEqual(newFrameIdentity, webView.mainFrameHandle)
-                XCTAssertTrue(navAction.targetFrame?.isMainFrame == true)
                 XCTAssertNotEqual(newFrameIdentity.frameID, WKFrameInfo.defaultMainFrameHandle)
+#endif
+                XCTAssertTrue(navAction.targetFrame?.isMainFrame == true)
             }
             return .next
         }
@@ -417,6 +419,38 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         eDidFinish = expectation(description: "didReload")
         withWebView { webView in
             _=webView.reload()
+        }
+        waitForExpectations(timeout: 5)
+
+        assertHistory(ofResponderAt: 0, equalsTo: [
+            .navigationAction(req(urls.local, defaultHeaders + ["Upgrade-Insecure-Requests": "1"], cachePolicy: .reloadIgnoringLocalCacheData), .reload, from: history[1], src: main(urls.local)),
+            .willStart(Nav(action: navAct(2), .approved, isCurrent: false)),
+            .didStart( Nav(action: navAct(2), .started)),
+            .response(Nav(action: navAct(2), .responseReceived, resp: .resp(urls.local, data.html.count, headers: .default + ["Content-Type": "text/html"]))),
+            .didCommit(Nav(action: navAct(2), .responseReceived, resp: resp(0), .committed)),
+            .didFinish(Nav(action: navAct(2), .finished, resp: resp(0), .committed))
+        ])
+    }
+
+    func testReloadFromOrigin() throws {
+        navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
+
+        server.middleware = [{ [data] request in
+            return .ok(.html(data.html.string()!))
+        }]
+        try server.start(8084)
+
+        var eDidFinish = expectation(description: "didFinish")
+        responder(at: 0).onDidFinish = { _ in eDidFinish.fulfill() }
+        withWebView { webView in
+            _=webView.load(req(urls.local))
+        }
+        waitForExpectations(timeout: 5)
+
+        responder(at: 0).clear()
+        eDidFinish = expectation(description: "didReload")
+        withWebView { webView in
+            _=webView.reloadFromOrigin()
         }
         waitForExpectations(timeout: 5)
 
@@ -602,6 +636,7 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
 
     // MARK: - Simulated requests
 
+    @MainActor
     func testSimulatedRequest() {
         navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
 
@@ -609,12 +644,36 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         responder(at: 0).onDidFinish = { _ in eDidFinish.fulfill() }
 
         withWebView { webView in
-            _=webView.loadSimulatedRequest(req(urls.https), responseHTML: String(data: data.html, encoding: .utf8)!)
+            _=webView.navigator(distributedNavigationDelegate: navigationDelegate)
+                .loadSimulatedRequest(req(urls.https), responseHTML: String(data: data.html, encoding: .utf8)!, withExpectedNavigationType: .custom(.init(rawValue: "custom")))
+
         }
         waitForExpectations(timeout: 5)
 
         assertHistory(ofResponderAt: 0, equalsTo: [
-            .navigationAction(req(urls.https), .other, src: main()),
+            .navigationAction(req(urls.https), .custom(.init(rawValue: "custom")), src: main()),
+            .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
+            .didStart(Nav(action: navAct(1), .started)),
+            .didCommit(Nav(action: navAct(1), .started, .committed)),
+            .didFinish(Nav(action: navAct(1), .finished, .committed))
+        ])
+    }
+
+    @MainActor
+    func testSimulatedRequestWithData() {
+        navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
+
+        let eDidFinish = expectation(description: "onDidFinish")
+        responder(at: 0).onDidFinish = { _ in eDidFinish.fulfill() }
+
+        withWebView { webView in
+            _=webView.navigator(distributedNavigationDelegate: navigationDelegate)
+                .loadSimulatedRequest(req(urls.https), response: URLResponse(url: urls.https, mimeType: "text/html", expectedContentLength: data.html.count, textEncodingName: "UTF-8"), responseData: data.html, withExpectedNavigationType: .custom(.init(rawValue: "custom")))
+        }
+        waitForExpectations(timeout: 5)
+
+        assertHistory(ofResponderAt: 0, equalsTo: [
+            .navigationAction(req(urls.https), .custom(.init(rawValue: "custom")), src: main()),
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
             .didCommit(Nav(action: navAct(1), .started, .committed)),
@@ -766,6 +825,119 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local1, status: nil, data.empty.count))),
+            .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
+            .didFinish(Nav(action: navAct(1), .finished, resp: resp(0), .committed))
+        ])
+    }
+
+    @MainActor
+    func testLoadHTMLString() throws {
+        navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
+
+        let eDidFinish = expectation(description: "onDidFinish")
+        responder(at: 0).onDidFinish = { nav in
+            XCTAssertEqual(nav.state, .finished)
+            eDidFinish.fulfill()
+        }
+
+        withWebView { webView in
+            _=webView.navigator(distributedNavigationDelegate: navigationDelegate)
+                .loadHTMLString(data.html.string()!, baseURL: urls.local1, withExpectedNavigationType: .custom(.init(rawValue: "custom")))
+        }
+        waitForExpectations(timeout: 5)
+
+        XCTAssertFalse(navAct(1).navigationAction.isTargetingNewWindow)
+        assertHistory(ofResponderAt: 0, equalsTo: [
+            .navigationAction(req(urls.local1), .custom(.init(rawValue: "custom")), src: main()),
+            .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
+            .didStart(Nav(action: navAct(1), .started)),
+            .didCommit(Nav(action: navAct(1), .started, .committed)),
+            .didFinish(Nav(action: navAct(1), .finished, .committed))
+        ])
+    }
+
+    @MainActor
+    func testLoadHTMLData() throws {
+        navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
+
+        let eDidFinish = expectation(description: "onDidFinish")
+        responder(at: 0).onDidFinish = { nav in
+            XCTAssertEqual(nav.state, .finished)
+            eDidFinish.fulfill()
+        }
+
+        withWebView { webView in
+            _=webView.navigator(distributedNavigationDelegate: navigationDelegate)
+                .load(data.html, mimeType: "text/html", characterEncodingName: "UTF-8", baseURL: urls.local1, withExpectedNavigationType: .custom(.init(rawValue: "custom")))
+        }
+        waitForExpectations(timeout: 5)
+
+        XCTAssertFalse(navAct(1).navigationAction.isTargetingNewWindow)
+        assertHistory(ofResponderAt: 0, equalsTo: [
+            .navigationAction(req(urls.local1), .custom(.init(rawValue: "custom")), src: main()),
+            .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
+            .didStart(Nav(action: navAct(1), .started)),
+            .didCommit(Nav(action: navAct(1), .started, .committed)),
+            .didFinish(Nav(action: navAct(1), .finished, .committed))
+        ])
+    }
+
+    // MARK: - Local file requests
+
+
+//    #selector(loadSimulatedRequest(_:response:responseData:)): #selector(navigation_loadSimulatedRequest(_:response:responseData:)),
+
+    @MainActor
+    func testFileURLNavigation() throws {
+        navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
+
+        let eDidFinish = expectation(description: "onDidFinish")
+        responder(at: 0).onDidFinish = { nav in
+            XCTAssertEqual(nav.state, .finished)
+            eDidFinish.fulfill()
+        }
+
+        let url = Bundle.module.url(forResource: "Resources/test", withExtension: "html")!
+        withWebView { webView in
+            _=webView.navigator(distributedNavigationDelegate: navigationDelegate)
+                .loadFileURL(url, allowingReadAccessTo: url, withExpectedNavigationType: .custom(.init(rawValue: "custom")))
+        }
+        waitForExpectations(timeout: 5)
+
+        XCTAssertFalse(navAct(1).navigationAction.isTargetingNewWindow)
+        assertHistory(ofResponderAt: 0, equalsTo: [
+            .navigationAction(req(url, [:]), .custom(.init(rawValue: "custom")), src: main()),
+            .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
+            .didStart(Nav(action: navAct(1), .started)),
+            .response(Nav(action: navAct(1), .responseReceived, resp: .resp(url, status: nil, try Data(contentsOf: url).count))),
+            .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
+            .didFinish(Nav(action: navAct(1), .finished, resp: resp(0), .committed))
+        ])
+    }
+
+    @MainActor
+    func testFileRequestNavigation() throws {
+        navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
+
+        let eDidFinish = expectation(description: "onDidFinish")
+        responder(at: 0).onDidFinish = { nav in
+            XCTAssertEqual(nav.state, .finished)
+            eDidFinish.fulfill()
+        }
+
+        let url = Bundle.module.url(forResource: "Resources/test", withExtension: "html")!
+        withWebView { webView in
+            _=webView.navigator(distributedNavigationDelegate: navigationDelegate)
+                .loadFileRequest(URLRequest(url: url), allowingReadAccessTo: url, withExpectedNavigationType: .custom(.init(rawValue: "custom")))
+        }
+        waitForExpectations(timeout: 5)
+
+        XCTAssertFalse(navAct(1).navigationAction.isTargetingNewWindow)
+        assertHistory(ofResponderAt: 0, equalsTo: [
+            .navigationAction(req(url, [:]), .custom(.init(rawValue: "custom")), src: main()),
+            .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
+            .didStart(Nav(action: navAct(1), .started)),
+            .response(Nav(action: navAct(1), .responseReceived, resp: .resp(url, status: nil, try Data(contentsOf: url).count))),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
             .didFinish(Nav(action: navAct(1), .finished, resp: resp(0), .committed))
         ])

--- a/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
+++ b/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
@@ -90,6 +90,7 @@ extension DistributedNavigationDelegateTestsBase {
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = navigationDelegateProxy
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
         currentHistoryItemIdentityCancellable = navigationDelegate.$currentHistoryItemIdentity.sink { [unowned self] historyItem in
             guard let historyItem,
                   !self.history.contains(where: { $0.value == historyItem }),
@@ -98,7 +99,7 @@ extension DistributedNavigationDelegateTestsBase {
 
             self.history[lastNavigationAction] = historyItem
         }
-
+#endif
         return webView
     }
 
@@ -374,12 +375,12 @@ extension DistributedNavigationDelegateTestsBase {
         }
     }
 
-    func frame(_ frameID: UInt64, _ url: URL, secOrigin: SecurityOrigin? = nil) -> FrameInfo {
+    func frame(_ frameID: UInt64!, _ url: URL, secOrigin: SecurityOrigin? = nil) -> FrameInfo {
         withWebView { webView in
             FrameInfo(webView: webView, handle: .init(rawValue: frameID), isMainFrame: false, url: url, securityOrigin: secOrigin ?? url.securityOrigin)
         }
     }
-    func frame(_ frameID: UInt64, _ url: String, secOrigin: SecurityOrigin? = nil) -> FrameInfo {
+    func frame(_ frameID: UInt64!, _ url: String, secOrigin: SecurityOrigin? = nil) -> FrameInfo {
         frame(frameID, URL(string: url)!, secOrigin: secOrigin)
     }
 
@@ -403,6 +404,7 @@ extension DistributedNavigationDelegateTestsBase {
             let line = useEventLine ? (event2?.line ?? lastEventLine) : line
             lastEventLine = line
 
+            guard event1 != nil || event2 != nil else { continue }
             if let diff = compare(Mirror(reflecting: event1 ?? event2!).children.first!.label!, event1, event2) {
                 printEncoded(responder: responderIdx)
                 XCTFail("\n#\(idx): " + diff, file: file, line: line)

--- a/Tests/NavigationTests/Helpers/WKNavigationActionMock.swift
+++ b/Tests/NavigationTests/Helpers/WKNavigationActionMock.swift
@@ -84,9 +84,11 @@ class WKFrameInfoMock: NSObject {
 
     @objc weak var webView: WKWebView?
 
+#if _FRAME_HANDLE_ENABLED
     @objc var handle: FrameHandle {
         isMainFrame ? .fallbackMainFrameHandle : .fallbackNonMainFrameHandle
     }
+#endif
 
     init(isMainFrame: Bool, request: URLRequest, securityOrigin: WKSecurityOrigin, webView: WKWebView?) {
         self.isMainFrame = isMainFrame

--- a/Tests/NavigationTests/NavigationAuthChallengeTests.swift
+++ b/Tests/NavigationTests/NavigationAuthChallengeTests.swift
@@ -107,10 +107,12 @@ class NavigationAuthChallengeTests: DistributedNavigationDelegateTestsBase {
 
         var frameID: UInt64!
         responder(at: 0).onNavigationAction = { [urls] navAction, _ in
+#if _FRAME_HANDLE_ENABLED
             if navAction.url.path == urls.local3.path {
                 frameID = navAction.targetFrame?.handle.frameID
                 XCTAssertNotEqual(frameID, WKFrameInfo.defaultMainFrameHandle)
             }
+#endif
             return .next
         }
 

--- a/Tests/NavigationTests/NavigationBackForwardTests.swift
+++ b/Tests/NavigationTests/NavigationBackForwardTests.swift
@@ -234,8 +234,10 @@ class NavigationBackForwardTests: DistributedNavigationDelegateTestsBase {
         var frameID: UInt64!
         responder(at: 0).onNavigationAction = { [urls] navAction, _ in
             if navAction.url.path == urls.local3.path {
+#if _FRAME_HANDLE_ENABLED
                 frameID = navAction.targetFrame?.handle.frameID
                 XCTAssertNotEqual(frameID, WKFrameInfo.defaultMainFrameHandle)
+#endif
             }
             return .next
         }
@@ -314,10 +316,12 @@ class NavigationBackForwardTests: DistributedNavigationDelegateTestsBase {
 
         var frameID: UInt64!
         responder(at: 0).onNavigationAction = { [urls] navAction, _ in
+#if _FRAME_HANDLE_ENABLED
             if navAction.url.path == urls.local3.path {
                 frameID = navAction.targetFrame?.handle.frameID
                 XCTAssertNotEqual(frameID, WKFrameInfo.defaultMainFrameHandle)
             }
+#endif
             return .next
         }
 

--- a/Tests/NavigationTests/NavigationDownloadsTests.swift
+++ b/Tests/NavigationTests/NavigationDownloadsTests.swift
@@ -79,8 +79,10 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
         var frameID: UInt64!
         responder(at: 0).onNavigationAction = { [urls] navAction, _ in
             if navAction.url.path == urls.local3.path {
+#if _FRAME_HANDLE_ENABLED
                 frameID = navAction.targetFrame?.handle.frameID
                 XCTAssertNotEqual(frameID, WKFrameInfo.defaultMainFrameHandle)
+#endif
                 return .download
             }
             return .next
@@ -178,10 +180,12 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
 
         var frameID: UInt64!
         responder(at: 0).onNavigationAction = { [urls] navAction, _ in
+#if _FRAME_HANDLE_ENABLED
             if navAction.url.path == urls.local1.path {
                 frameID = navAction.targetFrame?.handle.frameID
                 XCTAssertNotEqual(frameID, WKFrameInfo.defaultMainFrameHandle)
             }
+#endif
             return .next
         }
         responder(at: 0).onNavigationResponse = { _ in
@@ -220,8 +224,10 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
         var frameIDs = [String: UInt64]()
         responder(at: 0).onNavigationAction = { [urls] navAction, _ in
             guard navAction.url.matches(urls.local) else {
+#if _FRAME_HANDLE_ENABLED
                 frameIDs[navAction.url.path] = navAction.targetFrame?.handle.frameID
                 XCTAssertNotEqual(navAction.targetFrame?.handle.frameID, WKFrameInfo.defaultMainFrameHandle)
+#endif
                 return .download
             }
             return .next
@@ -243,15 +249,15 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local, data.htmlWith3iFrames.count, headers: .default + ["Content-Type": "text/html"]))),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
 
-            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local2.path]!, .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local2.path], .empty, secOrigin: urls.local.securityOrigin))),
             .navActionWillBecomeDownload(navAct(2)),
             .navActionBecameDownload(navAct(2), urls.local2),
 
-            .navigationAction(NavAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local3.path]!, .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local3.path], .empty, secOrigin: urls.local.securityOrigin))),
             .navActionWillBecomeDownload(navAct(3)),
             .navActionBecameDownload(navAct(3), urls.local3),
 
-            .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local4.path]!, .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local4.path], .empty, secOrigin: urls.local.securityOrigin))),
             .navActionWillBecomeDownload(navAct(4)),
             .navActionBecameDownload(navAct(4), urls.local4),
 
@@ -274,8 +280,10 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
         var frameIDs = [String: UInt64]()
         responder(at: 0).onNavigationAction = { [urls] navAction, _ in
             if !navAction.url.matches(urls.local) {
+#if _FRAME_HANDLE_ENABLED
                 frameIDs[navAction.url.path] = navAction.targetFrame?.handle.frameID
                 XCTAssertNotEqual(navAction.targetFrame?.handle.frameID, WKFrameInfo.defaultMainFrameHandle)
+#endif
             }
             return .allow
         }
@@ -303,9 +311,9 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local, data.htmlWith3iFrames.count, headers: .default + ["Content-Type": "text/html"]))),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
 
-            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local2.path]!, .empty, secOrigin: urls.local.securityOrigin))),
-            .navigationAction(NavAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local3.path]!, .empty, secOrigin: urls.local.securityOrigin))),
-            .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local4.path]!, .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local2.path], .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local3.path], .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local4.path], .empty, secOrigin: urls.local.securityOrigin))),
 
             .response(.resp(urls.local2, data.html.count, headers: .default + ["Content-Type": "text/html"], .nonMain), Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
             .navResponseWillBecomeDownload(1),

--- a/Tests/NavigationTests/Resources/test.html
+++ b/Tests/NavigationTests/Resources/test.html
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        some data
+        <a id="navlink" />
+    </body>
+</html>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1204125157999066/f
What kind of version bump will this require?: Minor

**Optional**:

CC: @ayoy 

**Description**:
- No feature changes
- Initial iOS adaptation effort to make private API usage opt-outable using compilation flags

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Disable _IS_REDIRECT_ENABLED, _MAIN_FRAME_NAVIGATION_ENABLED, _FRAME_HANDLE_ENABLED compilation flags, ensure tests pass either with those flags or without, all together or one by one
1. Disable other Navigation compilation flags, ensure build is not failing

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
