### PR TITLE
fix delayed new window with empty url creation handling

### DIFF
--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -424,6 +424,12 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
             assertionFailure("session restoration happening without NavigationAction")
             navigation = Navigation(identity: NavigationIdentity(wkNavigation), responders: responders, state: .expected(nil), isCurrent: true)
             navigation.navigationActionReceived(.sessionRestoreNavigation(webView: webView, mainFrameNavigation: navigation))
+            navigation.willStart()
+        } else if let wkNavigation {
+            navigation = Navigation(identity: NavigationIdentity(wkNavigation), responders: responders, state: .expected(nil), isCurrent: true)
+            let navigationAction = NavigationAction(request: URLRequest(url: .empty), navigationType: .other, currentHistoryItemIdentity: nil, redirectHistory: nil, isUserInitiated: false, sourceFrame: .mainFrame(for: webView), targetFrame: .mainFrame(for: webView), shouldDownload: false, mainFrameNavigation: navigation)
+            navigation.navigationActionReceived(navigationAction)
+            navigation.willStart()
         } else {
             return
         }

--- a/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
+++ b/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
@@ -368,9 +368,9 @@ extension DistributedNavigationDelegateTestsBase {
 
     // MARK: FrameInfo mocking
 
-    func main(_ current: URL = .empty, secOrigin: SecurityOrigin? = nil) -> FrameInfo {
+    func main(webView webViewArg: WKWebView? = nil, _ current: URL = .empty, secOrigin: SecurityOrigin? = nil) -> FrameInfo {
         withWebView { webView in
-            FrameInfo(webView: webView, handle: webView.mainFrameHandle, isMainFrame: true, url: current, securityOrigin: secOrigin ?? current.securityOrigin)
+            FrameInfo(webView: webViewArg ?? webView, handle: webViewArg?.mainFrameHandle ?? webView.mainFrameHandle, isMainFrame: true, url: current, securityOrigin: secOrigin ?? current.securityOrigin)
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1204120174304690/f
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1022
What kind of version bump will this require?: Patch

**Optional**:

**Description**:
- Fixes new window navigating to empty URL asserting

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. in js console: window.open("")
2. allow opening popup: the popup should open without assertion

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
