### PR TITLE
HTTPS upgrade threading

### DIFF
--- a/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgrade.swift
+++ b/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgrade.swift
@@ -26,7 +26,7 @@ public enum HTTPSUpgradeError: Error {
     case nonHttp
     case domainExcluded
     case featureDisabled
-    case nonUpgradable
+    case nonUpgradable(HTTPSBloomFilterSpecification?)
     case bloomFilterTaskNotSet
     case noBloomFilter
 }
@@ -58,7 +58,7 @@ public actor HTTPSUpgrade {
             return .success(upgradedUrl)
 
         case .success(false):
-            return .failure(.nonUpgradable)
+            return .failure(.nonUpgradable(store.bloomFilterSpecification))
 
         case .failure(let error):
             return .failure(error)

--- a/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgradeStore.swift
+++ b/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgradeStore.swift
@@ -22,7 +22,7 @@ public protocol HTTPSUpgradeStore {
     
     // MARK: - Bloom filter
     
-    var bloomFilter: BloomFilterWrapper? { get }
+    var bloomFilter: (BloomFilterWrapper, HTTPSBloomFilterSpecification)? { get }
     var bloomFilterSpecification: HTTPSBloomFilterSpecification? { get }
     
     // MARK: - Excluded domains

--- a/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgradeStore.swift
+++ b/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgradeStore.swift
@@ -19,14 +19,13 @@
 import BloomFilterWrapper
 
 public protocol HTTPSUpgradeStore {
-    
+
     // MARK: - Bloom filter
-    
-    var bloomFilter: (BloomFilterWrapper, HTTPSBloomFilterSpecification)? { get }
-    var bloomFilterSpecification: HTTPSBloomFilterSpecification? { get }
-    
+
+    func loadBloomFilter() -> (wrapper: BloomFilterWrapper, specification: HTTPSBloomFilterSpecification)?
+
     // MARK: - Excluded domains
-    
+
     func hasExcludedDomain(_ domain: String) -> Bool
-    
+
 }

--- a/Tests/BrowserServicesKitTests/SmarterEncryption/HTTPSUpgradeReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/SmarterEncryption/HTTPSUpgradeReferenceTests.swift
@@ -112,7 +112,7 @@ final class HTTPSUpgradeReferenceTests: XCTestCase {
     func testHTTPSUpgradesNavigations() async {
         let tests = httpsUpgradesTestSuite.navigations.tests
         let httpsUpgrade = HTTPSUpgrade(store: mockStore, privacyManager: makePrivacyManager())
-        httpsUpgrade.loadData()
+        await httpsUpgrade.loadData()
         
         for test in tests {
             os_log("TEST: %s", test.name)
@@ -138,7 +138,7 @@ final class HTTPSUpgradeReferenceTests: XCTestCase {
     
     func testLocalUnprotectedDomainShouldNotUpgradeToHTTPS() async {
         let httpsUpgrade = HTTPSUpgrade(store: mockStore, privacyManager: makePrivacyManager(config: nil, unprotectedDomains: ["secure.thirdtest.com"]))
-        httpsUpgrade.loadData()
+        await httpsUpgrade.loadData()
         
         let url = URL(string: "http://secure.thirdtest.com")!
         
@@ -153,7 +153,7 @@ final class HTTPSUpgradeReferenceTests: XCTestCase {
     
     func testLocalUnprotectedDomainShouldUpgradeSubdomainToHTTPS() async {
         let httpsUpgrade = HTTPSUpgrade(store: mockStore, privacyManager: makePrivacyManager(config: nil, unprotectedDomains: ["thirdtest.com"]))
-        httpsUpgrade.loadData()
+        await httpsUpgrade.loadData()
         
         let url = URL(string: "http://secure.thirdtest.com")!
         

--- a/Tests/BrowserServicesKitTests/SmarterEncryption/HTTPSUpgradeStoreMock.swift
+++ b/Tests/BrowserServicesKitTests/SmarterEncryption/HTTPSUpgradeStoreMock.swift
@@ -21,10 +21,14 @@
 @testable import BloomFilterWrapper
 
 struct HTTPSUpgradeStoreMock: HTTPSUpgradeStore {
-    
+
     var bloomFilter: BloomFilterWrapper?
     var bloomFilterSpecification: HTTPSBloomFilterSpecification?
-    
+    func loadBloomFilter() -> (wrapper: BloomFilterWrapper, specification: BrowserServicesKit.HTTPSBloomFilterSpecification)? {
+        guard let bloomFilter, let bloomFilterSpecification else { return nil }
+        return (bloomFilter, bloomFilterSpecification)
+    }
+
     var excludedDomains: [String]
     func hasExcludedDomain(_ domain: String) -> Bool {
         excludedDomains.contains(domain)

--- a/Tests/BrowserServicesKitTests/SmarterEncryption/HTTPSUpgradeStoreMock.swift
+++ b/Tests/BrowserServicesKitTests/SmarterEncryption/HTTPSUpgradeStoreMock.swift
@@ -33,5 +33,5 @@ struct HTTPSUpgradeStoreMock: HTTPSUpgradeStore {
     func hasExcludedDomain(_ domain: String) -> Bool {
         excludedDomains.contains(domain)
     }
-    
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1204105120334404/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1536
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1031
What kind of version bump will this require?: Major/Minor/Patch

**Description**:
- Updating threading for Bloom Filter loading

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
- Validate threading correctness
- Validate config updating bloom filter
