### PR TITLE
add didCancelNavigationAction

### DIFF
--- a/Sources/Navigation/ClosureNavigationResponder.swift
+++ b/Sources/Navigation/ClosureNavigationResponder.swift
@@ -27,6 +27,11 @@ public struct ClosureNavigationResponder: NavigationResponder {
         await self.decidePolicy?(navigationAction, &preferences)
     }
 
+    let didCancelNavigationAction: ((_ navigationAction: NavigationAction, _ expectedNavigations: [ExpectedNavigation]?) -> Void)?
+    public func didCancelNavigationAction(_ navigationAction: NavigationAction, withRedirectNavigations expectedNavigations: [ExpectedNavigation]?) {
+        didCancelNavigationAction?(navigationAction, expectedNavigations)
+    }
+
     let willStart: ((_ navigation: Navigation) -> Void)?
     public func willStart(_ navigation: Navigation) {
         willStart?(navigation)
@@ -90,6 +95,7 @@ public struct ClosureNavigationResponder: NavigationResponder {
     }
 
     public init(decidePolicy: ((_: NavigationAction, _: inout NavigationPreferences) async -> NavigationActionPolicy?)? = nil,
+                didCancel: ((_ navigationAction: NavigationAction, _ expectedNavigations: [ExpectedNavigation]?) -> Void)? = nil,
                 willStart: ((_: Navigation) -> Void)? = nil,
                 didStart: ((_: Navigation) -> Void)? = nil,
                 authenticationChallenge: ((_: URLAuthenticationChallenge, Navigation?) async -> AuthChallengeDisposition?)? = nil,
@@ -104,6 +110,7 @@ public struct ClosureNavigationResponder: NavigationResponder {
                 navigationResponseDidBecomeDownload: ((NavigationResponse, WebKitDownload) -> Void)? = nil,
                 webContentProcessDidTerminate: ((WKProcessTerminationReason?) -> Void)? = nil) {
         self.decidePolicy = decidePolicy
+        self.didCancelNavigationAction = didCancel
         self.willStart = willStart
         self.didStart = didStart
         self.authenticationChallenge = authenticationChallenge

--- a/Sources/Navigation/Navigation.swift
+++ b/Sources/Navigation/Navigation.swift
@@ -103,6 +103,7 @@ public extension NavigationProtocol {
     }
 
     func overrideResponders(with decidePolicy: ((_: NavigationAction, _: inout NavigationPreferences) async -> NavigationActionPolicy?)? = nil,
+                            didCancel: ((_ navigationAction: NavigationAction, _ expectedNavigations: [ExpectedNavigation]?) -> Void)? = nil,
                             willStart: ((_: Navigation) -> Void)? = nil,
                             didStart: ((_: Navigation) -> Void)? = nil,
                             authenticationChallenge: ((_: URLAuthenticationChallenge, Navigation?) async -> AuthChallengeDisposition?)? = nil,
@@ -115,10 +116,11 @@ public extension NavigationProtocol {
                             navigationActionDidBecomeDownload: ((NavigationAction, WebKitDownload) -> Void)? = nil,
                             navigationResponseWillBecomeDownload: ((NavigationResponse, WKWebView) -> Void)? = nil,
                             navigationResponseDidBecomeDownload: ((NavigationResponse, WebKitDownload) -> Void)? = nil) {
-        self.overrideResponders(.struct(ClosureNavigationResponder(decidePolicy: decidePolicy, willStart: willStart, didStart: didStart, authenticationChallenge: authenticationChallenge, redirected: redirected, navigationResponse: navigationResponse, didCommit: didCommit, navigationDidFinish: navigationDidFinish, navigationDidFail: navigationDidFail, navigationActionWillBecomeDownload: navigationActionWillBecomeDownload, navigationActionDidBecomeDownload: navigationActionDidBecomeDownload, navigationResponseWillBecomeDownload: navigationResponseWillBecomeDownload, navigationResponseDidBecomeDownload: navigationResponseDidBecomeDownload)))
+        self.overrideResponders(.struct(ClosureNavigationResponder(decidePolicy: decidePolicy, didCancel: didCancel, willStart: willStart, didStart: didStart, authenticationChallenge: authenticationChallenge, redirected: redirected, navigationResponse: navigationResponse, didCommit: didCommit, navigationDidFinish: navigationDidFinish, navigationDidFail: navigationDidFail, navigationActionWillBecomeDownload: navigationActionWillBecomeDownload, navigationActionDidBecomeDownload: navigationActionDidBecomeDownload, navigationResponseWillBecomeDownload: navigationResponseWillBecomeDownload, navigationResponseDidBecomeDownload: navigationResponseDidBecomeDownload)))
     }
 
     func appendResponder(with decidePolicy: ((_: NavigationAction, _: inout NavigationPreferences) async -> NavigationActionPolicy?)? = nil,
+                         didCancel: ((_ navigationAction: NavigationAction, _ expectedNavigations: [ExpectedNavigation]?) -> Void)? = nil,
                          willStart: ((_: Navigation) -> Void)? = nil,
                          didStart: ((_: Navigation) -> Void)? = nil,
                          authenticationChallenge: ((_: URLAuthenticationChallenge, Navigation?) async -> AuthChallengeDisposition?)? = nil,
@@ -131,10 +133,11 @@ public extension NavigationProtocol {
                          navigationActionDidBecomeDownload: ((NavigationAction, WebKitDownload) -> Void)? = nil,
                          navigationResponseWillBecomeDownload: ((NavigationResponse, WKWebView) -> Void)? = nil,
                          navigationResponseDidBecomeDownload: ((NavigationResponse, WebKitDownload) -> Void)? = nil) {
-        self.navigationResponders.append(.struct(ClosureNavigationResponder(decidePolicy: decidePolicy, willStart: willStart, didStart: didStart, authenticationChallenge: authenticationChallenge, redirected: redirected, navigationResponse: navigationResponse, didCommit: didCommit, navigationDidFinish: navigationDidFinish, navigationDidFail: navigationDidFail, navigationActionWillBecomeDownload: navigationActionWillBecomeDownload, navigationActionDidBecomeDownload: navigationActionDidBecomeDownload, navigationResponseWillBecomeDownload: navigationResponseWillBecomeDownload, navigationResponseDidBecomeDownload: navigationResponseDidBecomeDownload)))
+        self.navigationResponders.append(.struct(ClosureNavigationResponder(decidePolicy: decidePolicy, didCancel: didCancel, willStart: willStart, didStart: didStart, authenticationChallenge: authenticationChallenge, redirected: redirected, navigationResponse: navigationResponse, didCommit: didCommit, navigationDidFinish: navigationDidFinish, navigationDidFail: navigationDidFail, navigationActionWillBecomeDownload: navigationActionWillBecomeDownload, navigationActionDidBecomeDownload: navigationActionDidBecomeDownload, navigationResponseWillBecomeDownload: navigationResponseWillBecomeDownload, navigationResponseDidBecomeDownload: navigationResponseDidBecomeDownload)))
     }
 
     func prependResponder(with decidePolicy: ((_: NavigationAction, _: inout NavigationPreferences) async -> NavigationActionPolicy?)? = nil,
+                          didCancel: ((_ navigationAction: NavigationAction, _ expectedNavigations: [ExpectedNavigation]?) -> Void)? = nil,
                           willStart: ((_: Navigation) -> Void)? = nil,
                           didStart: ((_: Navigation) -> Void)? = nil,
                           authenticationChallenge: ((_: URLAuthenticationChallenge, Navigation?) async -> AuthChallengeDisposition?)? = nil,
@@ -147,7 +150,7 @@ public extension NavigationProtocol {
                           navigationActionDidBecomeDownload: ((NavigationAction, WebKitDownload) -> Void)? = nil,
                           navigationResponseWillBecomeDownload: ((NavigationResponse, WKWebView) -> Void)? = nil,
                           navigationResponseDidBecomeDownload: ((NavigationResponse, WebKitDownload) -> Void)? = nil) {
-        self.navigationResponders.prepend(.struct(ClosureNavigationResponder(decidePolicy: decidePolicy, willStart: willStart, didStart: didStart, authenticationChallenge: authenticationChallenge, redirected: redirected, navigationResponse: navigationResponse, didCommit: didCommit, navigationDidFinish: navigationDidFinish, navigationDidFail: navigationDidFail, navigationActionWillBecomeDownload: navigationActionWillBecomeDownload, navigationActionDidBecomeDownload: navigationActionDidBecomeDownload, navigationResponseWillBecomeDownload: navigationResponseWillBecomeDownload, navigationResponseDidBecomeDownload: navigationResponseDidBecomeDownload)))
+        self.navigationResponders.prepend(.struct(ClosureNavigationResponder(decidePolicy: decidePolicy, didCancel: didCancel, willStart: willStart, didStart: didStart, authenticationChallenge: authenticationChallenge, redirected: redirected, navigationResponse: navigationResponse, didCommit: didCommit, navigationDidFinish: navigationDidFinish, navigationDidFail: navigationDidFail, navigationActionWillBecomeDownload: navigationActionWillBecomeDownload, navigationActionDidBecomeDownload: navigationActionDidBecomeDownload, navigationResponseWillBecomeDownload: navigationResponseWillBecomeDownload, navigationResponseDidBecomeDownload: navigationResponseDidBecomeDownload)))
     }
 
 }

--- a/Sources/Navigation/NavigationResponder.swift
+++ b/Sources/Navigation/NavigationResponder.swift
@@ -30,6 +30,12 @@ public protocol NavigationResponder {
     @MainActor
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy?
 
+    /// Called when NavigationAction did not turn into a Navigation (received .cancel or .redirect)
+    /// won‘t be called for cancelled server-redirect NavigationActions, `navigationDidFail` will be called instead
+    /// won‘t be called for NavigationAction turned into downloads, `navigationAction(_:willBecomeDownloadIn:)` will be called instead
+    @MainActor
+    func didCancelNavigationAction(_ navigationAction: NavigationAction, withRedirectNavigations expectedNavigations: [ExpectedNavigation]?)
+
     // MARK: Navigation
 
     /// Called only for Main Frame Navigation Actions when all of the Responders returned `.next` or one of the Responders returned `.allow`  for `decidePolicy(for:navigationAction)` query
@@ -118,6 +124,8 @@ public protocol NavigationResponder {
 public extension NavigationResponder {
 
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? { .next }
+
+    func didCancelNavigationAction(_ navigationAction: NavigationAction, withRedirectNavigations expectedNavigations: [ExpectedNavigation]?) {}
 
     func willStart(_ navigation: Navigation) {}
     func didStart(_ navigation: Navigation) {}

--- a/Tests/NavigationTests/ClosureNavigationResponderTests.swift
+++ b/Tests/NavigationTests/ClosureNavigationResponderTests.swift
@@ -101,6 +101,105 @@ class ClosureNavigationResponderTests: DistributedNavigationDelegateTestsBase {
     }
 
     @MainActor
+    func testWhenNavigationActionCancelled_didCancelIsCalled() throws {
+        navigationDelegate.setResponders(.strong(NavigationResponderMock()))
+
+        let navigator = withWebView { Navigator(webView: $0, distributedNavigationDelegate: navigationDelegate, currentNavigation: nil) }
+
+        try server.start(8084)
+        let eNavAction = expectation(description: "navigationAction")
+        let eDidCancel = expectation(description: "didCancel")
+        navigator.load(req(urls.local))?
+            .overrideResponders { _, _ in
+                eNavAction.fulfill()
+                return .cancel
+            } didCancel: { _, expected in
+                XCTAssertNil(expected)
+                eDidCancel.fulfill()
+            } willStart: { _ in
+                XCTFail("unexpected willStart")
+            } didStart: { _ in
+                XCTFail("unexpected didStart")
+            } authenticationChallenge: { _, _ in
+                XCTFail("unexpected authenticationChallenge")
+                return .next
+            } redirected: { _, _ in
+                XCTFail("unexpected redirected")
+            } navigationResponse: { _ in
+                XCTFail("unexpected navigationResponse")
+                return .next
+            } didCommit: { _ in
+                XCTFail("unexpected didCommit")
+            } navigationDidFinish: { _ in
+                XCTFail("unexpected didFinish")
+            } navigationDidFail: { _, _ in
+                XCTFail("unexpected didFail")
+            } navigationActionWillBecomeDownload: { _, _ in
+                XCTFail("unexpected navigationActionWillBecomeDownload")
+            } navigationActionDidBecomeDownload: { _, _ in
+                XCTFail("unexpected navigationActionWillBecomeDownload")
+            } navigationResponseWillBecomeDownload: { _, _ in
+                XCTFail("unexpected navigationResponseWillBecomeDownload")
+            } navigationResponseDidBecomeDownload: { _, _ in
+                XCTFail("unexpected navigationResponseWillBecomeDownload")
+            }
+
+        waitForExpectations(timeout: 5)
+    }
+
+    @MainActor
+    func testWhenNavigationActionRedirected_didCancelIsCalled() throws {
+        navigationDelegate.setResponders(.strong(NavigationResponderMock()))
+
+        let navigator = withWebView { Navigator(webView: $0, distributedNavigationDelegate: navigationDelegate, currentNavigation: nil) }
+
+        try server.start(8084)
+        let eNavAction = expectation(description: "navigationAction")
+        let eDidCancel = expectation(description: "didCancel")
+
+        navigator.load(req(urls.local))?
+            .overrideResponders { [urls] navAction, _ in
+                eNavAction.fulfill()
+
+                return .redirect(navAction.mainFrameTarget!) { navigator in
+                    navigator.load(req(urls.local2))?.overrideResponders { _, _ in .cancel }
+                    navigator.load(req(urls.local3))?.overrideResponders { _, _ in .cancel }
+                }
+            } didCancel: { _, expected in
+                XCTAssertEqual(expected?.count, 2)
+                eDidCancel.fulfill()
+            } willStart: { _ in
+                XCTFail("unexpected willStart")
+            } didStart: { _ in
+                XCTFail("unexpected didStart")
+            } authenticationChallenge: { _, _ in
+                XCTFail("unexpected authenticationChallenge")
+                return .next
+            } redirected: { _, _ in
+                XCTFail("unexpected redirected")
+            } navigationResponse: { _ in
+                XCTFail("unexpected navigationResponse")
+                return .next
+            } didCommit: { _ in
+                XCTFail("unexpected didCommit")
+            } navigationDidFinish: { _ in
+                XCTFail("unexpected didFinish")
+            } navigationDidFail: { _, _ in
+                XCTFail("unexpected didFail")
+            } navigationActionWillBecomeDownload: { _, _ in
+                XCTFail("unexpected navigationActionWillBecomeDownload")
+            } navigationActionDidBecomeDownload: { _, _ in
+                XCTFail("unexpected navigationActionWillBecomeDownload")
+            } navigationResponseWillBecomeDownload: { _, _ in
+                XCTFail("unexpected navigationResponseWillBecomeDownload")
+            } navigationResponseDidBecomeDownload: { _, _ in
+                XCTFail("unexpected navigationResponseWillBecomeDownload")
+            }
+
+        waitForExpectations(timeout: 5)
+    }
+
+    @MainActor
     func testWhenNavigationFails_didFailIsCalled() throws {
         navigationDelegate.setResponders(.strong(NavigationResponderMock()))
 
@@ -196,7 +295,7 @@ class ClosureNavigationResponderTests: DistributedNavigationDelegateTestsBase {
                 .appendResponder { _, _ in
                     XCTFail("unexpected navigationAction")
                     return .cancel
-                }  willStart: { _ in
+                } willStart: { _ in
                     eWillStart.fulfill()
                 } didStart: { _ in
                     eDidStart.fulfill()

--- a/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
+++ b/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
@@ -103,9 +103,12 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(req(urls.local1), .other, src: main()),
+            .didCancel(navAct(1))
         ])
         assertHistory(ofResponderAt: 1, equalsToHistoryOfResponderAt: 0)
-        assertHistory(ofResponderAt: 2, equalsTo: [])
+        assertHistory(ofResponderAt: 2, equalsTo: [
+            .didCancel(navAct(1))
+        ])
     }
     
     func testWhenResponderCancelsNavigationResponse_followingRespondersNotCalled() throws {
@@ -765,7 +768,8 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         waitForExpectations(timeout: 5)
 
         assertHistory(ofResponderAt: 0, equalsTo: [
-            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .link, from: history[1], .userInitiated, src: main(urls.local), targ: nil))
+            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .link, from: history[1], .userInitiated, src: main(urls.local), targ: nil)),
+            .didCancel(navAct(2))
         ])
     }
 
@@ -1483,6 +1487,7 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(req(urls.local), .other, src: main()),
             .navigationAction(req(urls.local2), .other, src: main()),
+            .didCancel(navAct(2))
         ])
     }
 
@@ -1605,6 +1610,7 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(req(urls.local), .other, src: main()),
             .navigationAction(req(urls.local2), .other, src: main()),
+            .didCancel(navAct(2))
         ])
     }
 

--- a/Tests/NavigationTests/Helpers/NavigationResponderMock.swift
+++ b/Tests/NavigationTests/Helpers/NavigationResponderMock.swift
@@ -27,6 +27,7 @@ import Common
 
 enum TestsNavigationEvent: TestComparable {
     case navigationAction(NavAction, NavigationPreferences = .default, line: UInt = #line)
+    case didCancel(NavAction, expected: Int? = nil, line: UInt = #line)
     case navActionWillBecomeDownload(NavAction, line: UInt = #line)
     case navActionBecameDownload(NavAction, String, line: UInt = #line)
     case willStart(Nav, line: UInt = #line)
@@ -226,6 +227,12 @@ class NavigationResponderMock: NavigationResponder {
             return.next
         }
         return await onNavigationAction(navigationAction, &preferences)
+    }
+
+    var onDidCancelNavigationAction: (@MainActor (NavigationAction, [ExpectedNavigation]?) -> Void)?
+    func didCancelNavigationAction(_ navigationAction: NavigationAction, withRedirectNavigations expectedNavigations: [ExpectedNavigation]?) {
+        let event = append(.didCancel(NavAction(navigationAction), expected: expectedNavigations?.count))
+        onDidCancelNavigationAction?(navigationAction, expectedNavigations) ?? defaultHandler(event)
     }
 
     var onNavActionWillBecomeDownload: (@MainActor (NavigationAction) -> Void)?

--- a/Tests/NavigationTests/Helpers/NavigationTestHelpers.swift
+++ b/Tests/NavigationTests/Helpers/NavigationTestHelpers.swift
@@ -57,6 +57,8 @@ extension TestsNavigationEvent {
                 } else {
                     return ".navigationAction(" + arg.navigationAction.encoded(context).dropping(prefix: ".init") + ")"
                 }
+            case .didCancel(let arg, expected: let arg2, line: _):
+                return ".didCancel(\(arg.navigationAction.encoded(context))\(arg2 != nil ? ", expected: \(arg2!)" : ""))"
             case .navActionWillBecomeDownload(let arg, line: _):
                 return ".navActionWillBecomeDownload(\(arg.navigationAction.encoded(context)))"
             case .navActionBecameDownload(let arg, let arg2, line: _):

--- a/Tests/NavigationTests/NavigationRedirectsTests.swift
+++ b/Tests/NavigationTests/NavigationRedirectsTests.swift
@@ -827,6 +827,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
         XCTAssertFalse(navAct(1).navigationAction.isTargetingNewWindow)
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(NavAction(req(urls.local), .other, src: main())),
+            .didCancel(navAct(1), expected: 1),
 
             .navigationAction(NavAction(req(urls.https), .custom(.init(rawValue: "redir")), src: main())),
             .willStart(Nav(action: navAct(2), redirects: [navAct(1)], .approved, isCurrent: false)),
@@ -866,6 +867,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
         XCTAssertFalse(navAct(1).navigationAction.isTargetingNewWindow)
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(NavAction(req(urls.local), .other, src: main())),
+            .didCancel(navAct(1), expected: 1),
 
             .willStart(Nav(action: NavAction(req(urls.aboutBlank), .redirect(.developer), src: main()), redirects: [navAct(1)], .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(2), redirects: [navAct(1)], .started)),
@@ -913,6 +915,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
         XCTAssertFalse(navAct(1).navigationAction.isTargetingNewWindow)
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(NavAction(req(urls.local), .other, src: main())),
+            .didCancel(navAct(1), expected: 1),
 
             .navigationAction(NavAction(req(urls.local2), .redirect(.developer), src: main())),
             .willStart(Nav(action: navAct(2), redirects: [navAct(1)], .approved, isCurrent: false)),
@@ -962,6 +965,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
         })
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(NavAction(req(urls.local), .other, src: main())),
+            .didCancel(navAct(1), expected: 2),
 
             // .navigationAction(NavAction(req(urls.local2), .redirect(.developer), src: main())),
             // .willStart(Nav(action: navAct(2), redirects: [navAct(1)], .approved, isCurrent: false)),
@@ -1034,7 +1038,8 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
 
         assertHistory(ofResponderAt: 0, equalsTo: [
             .navigationAction(NavAction(req(urls.local), .other, from: history[2], src: main(urls.local2))),
-
+            .didCancel(navAct(3), expected: 2),
+            
             // .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .redirect(.developer), from: history[2], src: main(urls.local2))),
             // .willStart(Nav(action: navAct(4), redirects: [navAct(3)], .approved, isCurrent: false)),
             // .didFail(Nav(action: NavAction(req(urls.local4, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .redirect(.developer), from: history[2], src: main(urls.local2)), redirects: [navAct(3)], .failed(WKError(NSURLErrorCancelled)), isCurrent: false), NSURLErrorCancelled),
@@ -1192,6 +1197,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
 
             .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .redirect(.client(delay: 1.0)), from: history[1], redirects: [navAct(1)], src: main(urls.local))),
+            .didCancel(navAct(2)),
             .didFinish(Nav(action: navAct(1), .finished, resp: resp(0), .committed)),
         ])
     }
@@ -1237,6 +1243,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
 
             .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .redirect(.client(delay: 1.0)), from: history[1], redirects: [navAct(1)], src: main(urls.local))),
+            .didCancel(navAct(2)),
             .didFinish(Nav(action: navAct(1), .finished, resp: resp(0), .committed)),
         ])
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199230911884351/1203902804957451/f
macOS PR: https://github.com/duckduckgo/macos-browser/pull/892
What kind of version bump will this require?: Minor/Patch

**Description**:
- Added didCancelNavigationAction NavigationResponder method for tracking lifetime of cancelled NavigationActions (for testing purposes)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate the tests pass
