### PR TITLE
Add invalid payload pixel handler

### DIFF
--- a/Sources/Common/EventMapping.swift
+++ b/Sources/Common/EventMapping.swift
@@ -22,7 +22,8 @@ import Foundation
 open class EventMapping<Event> {
     public typealias Mapping = (_ event: Event,
                                 _ error: Error?,
-                                _ params: [String: String]?, _ onComplete: @escaping (Error?) -> Void) -> Void
+                                _ params: [String: String]?,
+                                _ onComplete: @escaping (Error?) -> Void) -> Void
 
     private let eventMapper: Mapping
 

--- a/Sources/Configuration/ConfigurationDebugEvents.swift
+++ b/Sources/Configuration/ConfigurationDebugEvents.swift
@@ -1,0 +1,25 @@
+//
+//  ConfigurationDebugEvents.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public enum ConfigurationDebugEvents {
+
+    case invalidPayload(Configuration)
+
+}

--- a/Sources/Configuration/ConfigurationFetching.swift
+++ b/Sources/Configuration/ConfigurationFetching.swift
@@ -44,13 +44,17 @@ public final class ConfigurationFetcher: ConfigurationFetching {
     private let validator: ConfigurationValidating
     private let urlSession: URLSession
     private let log: OSLog
-    
-    public convenience init(store: ConfigurationStoring, urlSession: URLSession = .shared, log: OSLog = .disabled) {
-        self.init(store: store, validator: ConfigurationValidator(), log: log)
+
+    public convenience init(store: ConfigurationStoring,
+                            urlSession: URLSession = .shared,
+                            log: OSLog = .disabled,
+                            eventMapping: EventMapping<ConfigurationDebugEvents>? = nil) {
+        let validator = ConfigurationValidator(eventMapping: eventMapping)
+        self.init(store: store, validator: validator, log: log)
     }
     
     init(store: ConfigurationStoring,
-         validator: ConfigurationValidating = ConfigurationValidator(),
+         validator: ConfigurationValidating,
          urlSession: URLSession = .shared,
          log: OSLog = .disabled) {
         self.store = store

--- a/Sources/Configuration/ConfigurationValidating.swift
+++ b/Sources/Configuration/ConfigurationValidating.swift
@@ -19,6 +19,7 @@
 import Foundation
 import BrowserServicesKit
 import TrackerRadarKit
+import Common
 
 protocol ConfigurationValidating {
     
@@ -28,9 +29,15 @@ protocol ConfigurationValidating {
 
 public struct ConfigurationValidator: ConfigurationValidating {
 
-    func validate(_ data: Data, for location: Configuration) throws {
+    private let eventMapping: EventMapping<ConfigurationDebugEvents>?
+
+    init(eventMapping: EventMapping<ConfigurationDebugEvents>? = nil) {
+        self.eventMapping = eventMapping
+    }
+
+    func validate(_ data: Data, for configuration: Configuration) throws {
         do {
-            switch location {
+            switch configuration {
             case .privacyConfiguration:
                 try validatePrivacyConfiguration(with: data)
             case .trackerDataSet:
@@ -39,6 +46,7 @@ public struct ConfigurationValidator: ConfigurationValidating {
                 break
             }
         } catch {
+            eventMapping?.fire(.invalidPayload(configuration), error: error)
             throw ConfigurationFetcher.Error.invalidPayload
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1204156637909205/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1544
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1039
What kind of version bump will this require?: Patch

**Description**:
Add invalid payload pixel whenever we receive unparsable privacy config / tds.

**Steps to test this PR**:
1. Edit the code inside ConfigurationValidator:validate(_:for:) method and override the argument data with e.g. "Hello World".data(using: .utf8)
2. Run the app for the first time and make sure the pixel is being fired (there is an actual call to the Pixel.fire method)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)