### PR TITLE
Configuration updates optimizations

### DIFF
--- a/Sources/Configuration/ConfigurationFetching.swift
+++ b/Sources/Configuration/ConfigurationFetching.swift
@@ -127,7 +127,9 @@ public final class ConfigurationFetcher: ConfigurationFetching {
     }
     
     private func fetch(from url: URL, withEtag etag: String?, requirements: APIResponseRequirements) async throws -> ConfigurationFetchResult {
-        let configuration = APIRequest.Configuration(url: url, headers: APIRequest.Headers().default(with: etag))
+        let configuration = APIRequest.Configuration(url: url,
+                                                     headers: APIRequest.Headers().default(with: etag),
+                                                     cachePolicy: .reloadIgnoringLocalCacheData)
         let request = APIRequest(configuration: configuration, requirements: requirements, urlSession: urlSession, log: log)
         let (data, response) = try await request.fetch()
         return (response.etag!, data)

--- a/Sources/Configuration/ConfigurationFetching.swift
+++ b/Sources/Configuration/ConfigurationFetching.swift
@@ -74,7 +74,7 @@ public final class ConfigurationFetcher: ConfigurationFetching {
       An error of type Error is thrown if the configuration fails to fetch or validate.
     */
     public func fetch(_ configuration: Configuration) async throws {
-        let fetchResult = try await fetch(from: configuration.url, withEtag: etag(for: configuration))
+        let fetchResult = try await fetch(from: configuration.url, withEtag: etag(for: configuration), requirements: .default)
         if let data = fetchResult.data {
             try validator.validate(data, for: configuration)
         }
@@ -100,7 +100,7 @@ public final class ConfigurationFetcher: ConfigurationFetching {
         try await withThrowingTaskGroup(of: (Configuration, ConfigurationFetchResult).self) { group in
             configurations.forEach { configuration in
                 group.addTask {
-                    let fetchResult = try await self.fetch(from: configuration.url, withEtag: self.etag(for: configuration))
+                    let fetchResult = try await self.fetch(from: configuration.url, withEtag: self.etag(for: configuration), requirements: .all)
                     if let data = fetchResult.data {
                         try self.validator.validate(data, for: configuration)
                     }
@@ -126,9 +126,9 @@ public final class ConfigurationFetcher: ConfigurationFetching {
         return store.loadEmbeddedEtag(for: configuration)
     }
     
-    private func fetch(from url: URL, withEtag etag: String?) async throws -> ConfigurationFetchResult {
+    private func fetch(from url: URL, withEtag etag: String?, requirements: APIResponseRequirements) async throws -> ConfigurationFetchResult {
         let configuration = APIRequest.Configuration(url: url, headers: APIRequest.Headers().default(with: etag))
-        let request = APIRequest(configuration: configuration, requirements: [.all], urlSession: urlSession, log: log)
+        let request = APIRequest(configuration: configuration, requirements: requirements, urlSession: urlSession, log: log)
         let (data, response) = try await request.fetch()
         return (response.etag!, data)
     }

--- a/Sources/Networking/APIRequestConfiguration.swift
+++ b/Sources/Networking/APIRequestConfiguration.swift
@@ -32,6 +32,7 @@ extension APIRequest {
         let body: Data?
         let timeoutInterval: TimeInterval
         let attribution: URLRequestAttribution?
+        let cachePolicy: URLRequest.CachePolicy?
         
         public init(url: URL,
                     method: HTTPMethod = .get,
@@ -40,7 +41,8 @@ extension APIRequest {
                     headers: HTTPHeaders = APIRequest.Headers().default,
                     body: Data? = nil,
                     timeoutInterval: TimeInterval = 60.0,
-                    attribution: URLRequestAttribution? = .developer) {
+                    attribution: URLRequestAttribution? = .developer,
+                    cachePolicy: URLRequest.CachePolicy? = nil) {
             self.url = url
             self.method = method
             self.queryParameters = queryParameters
@@ -49,6 +51,7 @@ extension APIRequest {
             self.body = body
             self.timeoutInterval = timeoutInterval
             self.attribution = attribution
+            self.cachePolicy = cachePolicy
         }
         
         var request: URLRequest {
@@ -57,6 +60,9 @@ extension APIRequest {
             request.allHTTPHeaderFields = headers
             request.httpMethod = method.rawValue
             request.httpBody = body
+            if let cachePolicy = cachePolicy {
+                request.cachePolicy = cachePolicy
+            }
             if #available(iOS 15.0, macOS 12.0, *) {
                 if let attribution = attribution?.urlRequestAttribution {
                     request.attribution = attribution


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1204221714684545/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1551
macOS PR: TBD
What kind of version bump will this require?: Patch

**Description**:
Ignores local cache when fetching configuration.
fetchTrackerBlockingDependencies doesn't return true anymore but throws if privacy assets haven't changes.

**Steps to test this PR**:
1. Make sure all tests pass.
1. Run the app for the 2nd time and notice if all privacy assets get 304 in response (they should).
1. Run the app for the 2nd time and notice if all privacy assets (except for bloomFilterSpec and bloomFilterBinary) throw on 304 instead of setting didFetchAnyTrackerBlockingDependencies = true. 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
