### PR TITLE
Make FeatureName a struct so it can be extended from client code

### DIFF
--- a/Sources/BrowserServicesKit/Statistics/VariantManager.swift
+++ b/Sources/BrowserServicesKit/Statistics/VariantManager.swift
@@ -19,10 +19,18 @@
 
 import Foundation
 
-public enum FeatureName: String {
-    case fireButtonWithColorFill
+/// Define new experimental features by extending the struct in client project.
+public struct FeatureName: RawRepresentable, Equatable {
+    
+    public var rawValue: String
+
     // Used for unit tests
-    case dummy
+    public static let dummy = FeatureName(rawValue: "dummy")
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
 }
 
 public protocol VariantManager {


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1204250965008955/f
iOS PR: -
macOS PR: -
What kind of version bump will this require?: Minor

**Description**:
Make FeatureName a struct so it can be extended from client code. Currently if we were to add an experiment feature it was requiring a BSK change.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
