### PR TITLE
Bump GRDB to 2.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/duckduckgo/GRDB.swift.git",
         "state": {
           "branch": null,
-          "revision": "8eac7de76dff73dc467d5c43f9beabc61a6d6e02",
-          "version": "2.0.0"
+          "revision": "053d890417cdb587377156bc18f230a2caca8a51",
+          "version": "2.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.3.0")),
-        .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("2.0.0")),
+        .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("2.1.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.2.1")),
         .package(url: "https://github.com/duckduckgo/sync_crypto", .exact("0.0.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1204022201522438/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1572
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1060
What kind of version bump will this require?: Minor

**Description**:
Use GRDB packaged as xcframework to reduce build time.

**Steps to test this PR**:
1. Verify that unit tests pass.
1. Follow testing steps in platform PRs.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
