### PR TITLE
Update autofill to 6.4.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "26283ffcc7ed69a6853dfeca4514a2e552da2c96",
-          "version": "6.4.1"
+          "revision": "4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
+          "version": "6.4.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .library(name: "Navigation", targets: ["Navigation"]),
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.4.1")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.4.3")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("2.0.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.2.1")),
         .package(url: "https://github.com/duckduckgo/sync_crypto", .exact("0.0.1")),


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.4.3


## Description
Updates Autofill to version [6.4.3](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.4.3).

## What's Changed

### Tests and Tooling

- Remove manual server setup in tests by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/289
- Add windows release automation by @szanto90balazs in https://github.com/duckduckgo/duckduckgo-autofill/pull/272
- Fix extension release flow by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/294
* Update Asana integration to include expected header by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/295

### Bugfixes

- Set tooltip initial offscreen position by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/291
- Only center tooltip on small screensizes by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/290


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.4.1...6.4.3

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).