### PR TITLE
Update Package.swift syntax to Swift 5.7

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Set cache key hash
       run: |
-         has_only_tags=$(jq '[ .object.pins[].state | has("version") ] | all' Package.resolved)
+         has_only_tags=$(jq '[ .pins[].state | has("version") ] | all' Package.resolved)
          if [[ "$has_only_tags" == "true" ]]; then
            echo "cache_key_hash=${{ hashFiles('Package.resolved') }}" >> $GITHUB_ENV
          else

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,88 +1,86 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "ContentScopeScripts",
-        "repositoryURL": "https://github.com/duckduckgo/content-scope-scripts",
-        "state": {
-          "branch": null,
-          "revision": "801b7f23476f797c6eaa72b070e6c80abb82801a",
-          "version": "4.4.4"
-        }
-      },
-      {
-        "package": "Autofill",
-        "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
-        "state": {
-          "branch": null,
-          "revision": "26283ffcc7ed69a6853dfeca4514a2e552da2c96",
-          "version": "6.4.1"
-        }
-      },
-      {
-        "package": "GRDB",
-        "repositoryURL": "https://github.com/duckduckgo/GRDB.swift.git",
-        "state": {
-          "branch": null,
-          "revision": "8eac7de76dff73dc467d5c43f9beabc61a6d6e02",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "PrivacyDashboardResources",
-        "repositoryURL": "https://github.com/duckduckgo/privacy-dashboard",
-        "state": {
-          "branch": null,
-          "revision": "51e2b46f413bf3ef18afefad631ca70f2c25ef70",
-          "version": "1.4.0"
-        }
-      },
-      {
-        "package": "Punycode",
-        "repositoryURL": "https://github.com/gumob/PunycodeSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "4356ec54e073741449640d3d50a1fd24fd1e1b8b",
-          "version": "2.1.0"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": null,
-          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "Swifter",
-        "repositoryURL": "https://github.com/httpswift/swifter.git",
-        "state": {
-          "branch": null,
-          "revision": "9483a5d459b45c3ffd059f7b55f9638e268632fd",
-          "version": "1.5.0"
-        }
-      },
-      {
-        "package": "DDGSyncCrypto",
-        "repositoryURL": "https://github.com/duckduckgo/sync_crypto",
-        "state": {
-          "branch": null,
-          "revision": "df751674ee842d129c50a183668b033d02c2980d",
-          "version": "0.0.1"
-        }
-      },
-      {
-        "package": "TrackerRadarKit",
-        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit",
-        "state": {
-          "branch": null,
-          "revision": "4684440d03304e7638a2c8086895367e90987463",
-          "version": "1.2.1"
-        }
+  "pins" : [
+    {
+      "identity" : "content-scope-scripts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/duckduckgo/content-scope-scripts",
+      "state" : {
+        "revision" : "801b7f23476f797c6eaa72b070e6c80abb82801a",
+        "version" : "4.4.4"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "duckduckgo-autofill",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
+      "state" : {
+        "revision" : "26283ffcc7ed69a6853dfeca4514a2e552da2c96",
+        "version" : "6.4.1"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/duckduckgo/GRDB.swift.git",
+      "state" : {
+        "revision" : "8eac7de76dff73dc467d5c43f9beabc61a6d6e02",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "privacy-dashboard",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/duckduckgo/privacy-dashboard",
+      "state" : {
+        "revision" : "51e2b46f413bf3ef18afefad631ca70f2c25ef70",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "punycodeswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gumob/PunycodeSwift.git",
+      "state" : {
+        "revision" : "4356ec54e073741449640d3d50a1fd24fd1e1b8b",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swifter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/httpswift/swifter.git",
+      "state" : {
+        "revision" : "9483a5d459b45c3ffd059f7b55f9638e268632fd",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "sync_crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/duckduckgo/sync_crypto",
+      "state" : {
+        "revision" : "df751674ee842d129c50a183668b033d02c2980d",
+        "version" : "0.0.1"
+      }
+    },
+    {
+      "identity" : "trackerradarkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
+      "state" : {
+        "revision" : "4684440d03304e7638a2c8086895367e90987463",
+        "version" : "1.2.1"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -26,23 +26,23 @@ let package = Package(
         .library(name: "Navigation", targets: ["Navigation"]),
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("6.4.1")),
-        .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("2.0.0")),
-        .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.2.1")),
-        .package(url: "https://github.com/duckduckgo/sync_crypto", .exact("0.0.1")),
-        .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", .exact("4.4.4")),
-        .package(url: "https://github.com/duckduckgo/privacy-dashboard", .exact("1.4.0")),
-        .package(url: "https://github.com/httpswift/swifter.git", .exact("1.5.0")),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "6.4.1"),
+        .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.0.0"),
+        .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
+        .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.0.1"),
+        .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.4.4"),
+        .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "1.4.0"),
+        .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
     ],
     targets: [
         .target(
             name: "BrowserServicesKit",
             dependencies: [
-                "Autofill",
+                .product(name: "Autofill", package: "duckduckgo-autofill"),
                 .product(name: "ContentScopeScripts", package: "content-scope-scripts"),
                 "Persistence",
-                "GRDB",
+                .product(name: "GRDB", package: "GRDB.swift"),
                 "TrackerRadarKit",
                 "BloomFilterWrapper",
                 "Common",
@@ -96,7 +96,7 @@ let package = Package(
         .target(
             name: "Common",
             dependencies: [
-                .product(name: "Punnycode", package: "Punycode")
+                .product(name: "Punnycode", package: "PunycodeSwift")
             ],
             resources: [
                 .process("TLD/tlds.json")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203301625297703/1204272370666910/f
iOS PR: N/A
macOS PR: N/A
What kind of version bump will this require?: None

**Description**:
This change updates Package.swift to modern syntax and switches to Package.resolved version 2.

**Steps to test this PR**:
1. Verify that the lib and tests compile.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
