### PR TITLE
Centralised Messaging for User Scripts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -130,7 +130,10 @@ let package = Package(
                 .define("TERMINATE_WITH_REASON_ENABLED", .when(platforms: [.macOS])),
             ]),
         .target(
-            name: "UserScript"
+            name: "UserScript",
+            dependencies: [
+                "Common"
+            ]
         ),
         .target(
             name: "PrivacyDashboard",
@@ -160,7 +163,7 @@ let package = Package(
             dependencies: [
                 "Networking"
             ]),
-        
+
         // MARK: - Test targets
         .testTarget(
             name: "BrowserServicesKitTests",

--- a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -21,6 +21,8 @@ import WebKit
 import Combine
 import ContentScopeScripts
 import UserScript
+import Common
+import os.log
 
 public final class ContentScopeProperties: Encodable {
     public let globalPrivacyControlValue: Bool
@@ -37,10 +39,11 @@ public final class ContentScopeProperties: Encodable {
         ]
     }
 }
+
 public struct ContentScopeFeature: Encodable {
-    
+
     public let settings: [String: ContentScopeFeatureToggles]
-    
+
     public init(featureToggles: ContentScopeFeatureToggles) {
         self.settings = ["featureToggles": featureToggles]
     }
@@ -49,18 +52,18 @@ public struct ContentScopeFeature: Encodable {
 public struct ContentScopeFeatureToggles: Encodable {
 
     public let emailProtection: Bool
-    
+
     public let credentialsAutofill: Bool
     public let identitiesAutofill: Bool
     public let creditCardsAutofill: Bool
-    
+
     public let credentialsSaving: Bool
-    
+
     public let passwordGeneration: Bool
-    
+
     public let inlineIconCredentials: Bool
     public let thirdPartyCredentialsProvider: Bool
-    
+
     // Explicitly defined memberwise init only so it can be public
     public init(emailProtection: Bool,
                 credentialsAutofill: Bool,
@@ -70,7 +73,7 @@ public struct ContentScopeFeatureToggles: Encodable {
                 passwordGeneration: Bool,
                 inlineIconCredentials: Bool,
                 thirdPartyCredentialsProvider: Bool) {
-        
+
         self.emailProtection = emailProtection
         self.credentialsAutofill = credentialsAutofill
         self.identitiesAutofill = identitiesAutofill
@@ -80,18 +83,18 @@ public struct ContentScopeFeatureToggles: Encodable {
         self.inlineIconCredentials = inlineIconCredentials
         self.thirdPartyCredentialsProvider = thirdPartyCredentialsProvider
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case emailProtection = "emailProtection"
-        
+
         case credentialsAutofill = "inputType_credentials"
         case identitiesAutofill = "inputType_identities"
         case creditCardsAutofill = "inputType_creditCards"
-    
+
         case credentialsSaving = "credentials_saving"
-        
+
         case passwordGeneration = "password_generation"
-        
+
         case inlineIconCredentials = "inlineIcon_credentials"
         case thirdPartyCredentialsProvider = "third_party_credentials_provider"
     }
@@ -107,38 +110,80 @@ public struct ContentScopePlatform: Encodable {
     #endif
 }
 
-public final class ContentScopeUserScript: NSObject, UserScript {
-    public let messageNames: [String] = []
+public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessaging {
 
-    public init(_ privacyConfigManager: PrivacyConfigurationManaging, properties: ContentScopeProperties) {
-        source = ContentScopeUserScript.generateSource(privacyConfigManager, properties: properties)
+    public var broker: UserScriptMessageBroker;
+    public let isIsolated: Bool
+    public var messageNames: [String] = []
+
+    public init(_ privacyConfigManager: PrivacyConfigurationManaging,
+                properties: ContentScopeProperties,
+                isIsolated: Bool = false
+    ) {
+        self.isIsolated = isIsolated
+        let contextName = self.isIsolated ? "contentScopeScriptsIsolated" : "contentScopeScripts";
+
+        self.broker = UserScriptMessageBroker(context: contextName)
+        self.messageNames = [contextName]
+        self.source = ContentScopeUserScript.generateSource(
+                privacyConfigManager,
+                properties: properties,
+                isolated: self.isIsolated,
+                config: self.broker.messagingConfig()
+        )
     }
 
-    public static func generateSource(_ privacyConfigurationManager: PrivacyConfigurationManaging, properties: ContentScopeProperties) -> String {
+    public static func generateSource(_ privacyConfigurationManager: PrivacyConfigurationManaging,
+                                      properties: ContentScopeProperties,
+                                      isolated: Bool,
+                                      config: WebkitMessagingConfig
+    ) -> String {
 
         guard let privacyConfigJson = String(data: privacyConfigurationManager.currentConfig, encoding: .utf8),
               let userUnprotectedDomains = try? JSONEncoder().encode(privacyConfigurationManager.privacyConfig.userUnprotectedDomains),
               let userUnprotectedDomainsString = String(data: userUnprotectedDomains, encoding: .utf8),
               let jsonProperties = try? JSONEncoder().encode(properties),
-              let jsonPropertiesString = String(data: jsonProperties, encoding: .utf8)
-              else {
+              let jsonPropertiesString = String(data: jsonProperties, encoding: .utf8),
+              let jsonConfig = try? JSONEncoder().encode(config),
+              let jsonConfigString = String(data: jsonConfig, encoding: .utf8)
+        else {
             return ""
         }
-        
-        return loadJS("contentScope", from: ContentScopeScripts.Bundle, withReplacements: [
+
+        let jsInclude = isolated ? "contentScopeIsolated" : "contentScope"
+
+        return loadJS(jsInclude, from: ContentScopeScripts.Bundle, withReplacements: [
             "$CONTENT_SCOPE$": privacyConfigJson,
             "$USER_UNPROTECTED_DOMAINS$": userUnprotectedDomainsString,
-            "$USER_PREFERENCES$": jsonPropertiesString
+            "$USER_PREFERENCES$": jsonPropertiesString,
+            "$WEBKIT_MESSAGING_CONFIG$": jsonConfigString
         ])
     }
 
-    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-    }
-
     public let source: String
-
     public let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
     public let forMainFrameOnly: Bool = false
-    public let requiresRunInPageContentWorld: Bool = true
+    public var requiresRunInPageContentWorld: Bool { !self.isIsolated }
+}
 
+@available(macOS 11.0, iOS 14.0, *)
+extension ContentScopeUserScript: WKScriptMessageHandlerWithReply {
+    public func userContentController(_ userContentController: WKUserContentController,
+                                      didReceive message: WKScriptMessage) async -> (Any?, String?) {
+        let action = broker.messageHandlerFor(message)
+        do {
+            let json = try await broker.execute(action: action, original: message)
+            return (json, nil)
+        } catch {
+            // forward uncaught errors to the client
+            return (nil, error.localizedDescription)
+        }
+    }
+}
+
+// MARK: - Fallback for macOS 10.15
+extension ContentScopeUserScript: WKScriptMessageHandler {
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        // unsupported
+    }
 }

--- a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -124,7 +124,10 @@ public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessa
         let contextName = self.isIsolated ? "contentScopeScriptsIsolated" : "contentScopeScripts";
 
         self.broker = UserScriptMessageBroker(context: contextName)
-        self.messageNames = [contextName]
+
+        // dont register any handlers at all if we're not in the isolated context
+        self.messageNames = self.isIsolated ? [contextName] : []
+
         self.source = ContentScopeUserScript.generateSource(
                 privacyConfigManager,
                 properties: properties,

--- a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -112,7 +112,7 @@ public struct ContentScopePlatform: Encodable {
 
 public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessaging {
 
-    public var broker: UserScriptMessageBroker;
+    public var broker: UserScriptMessageBroker
     public let isIsolated: Bool
     public var messageNames: [String] = []
 
@@ -123,16 +123,16 @@ public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessa
         self.isIsolated = isIsolated
         let contextName = self.isIsolated ? "contentScopeScriptsIsolated" : "contentScopeScripts";
 
-        self.broker = UserScriptMessageBroker(context: contextName)
+        broker = UserScriptMessageBroker(context: contextName)
 
         // dont register any handlers at all if we're not in the isolated context
-        self.messageNames = self.isIsolated ? [contextName] : []
+        messageNames = isIsolated ? [contextName] : []
 
-        self.source = ContentScopeUserScript.generateSource(
+        source = ContentScopeUserScript.generateSource(
                 privacyConfigManager,
                 properties: properties,
-                isolated: self.isIsolated,
-                config: self.broker.messagingConfig()
+                isolated: isIsolated,
+                config: broker.messagingConfig()
         )
     }
 

--- a/Sources/BrowserServicesKit/ContentScopeScript/SpecialPagesUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/SpecialPagesUserScript.swift
@@ -1,0 +1,64 @@
+//
+//  SpecialPagesUserScript.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+import Combine
+import ContentScopeScripts
+import UserScript
+import Common
+import os.log
+
+public final class SpecialPagesUserScript: NSObject, UserScript, UserScriptMessaging {
+    public var source: String = "";
+
+    public static let context = "specialPages"
+
+    // special pages messaging cannot be isolated as we'll want regular page-scripts to be able to communicate
+    public let broker = UserScriptMessageBroker(context: SpecialPagesUserScript.context, requiresRunInPageContentWorld: true );
+
+    public let messageNames: [String] = [
+        SpecialPagesUserScript.context
+    ]
+
+    public let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
+    public let forMainFrameOnly = true
+    public let requiresRunInPageContentWorld = true
+}
+
+@available(macOS 11.0, iOS 14.0, *)
+extension SpecialPagesUserScript: WKScriptMessageHandlerWithReply {
+    public func userContentController(_ userContentController: WKUserContentController,
+                                      didReceive message: WKScriptMessage) async -> (Any?, String?) {
+        let action = broker.messageHandlerFor(message)
+        do {
+            let json = try await broker.execute(action: action, original: message)
+            return (json, nil)
+        } catch {
+            // forward uncaught errors to the client
+            return (nil, error.localizedDescription)
+        }
+    }
+}
+
+// MARK: - Fallback for macOS 10.15
+extension SpecialPagesUserScript: WKScriptMessageHandler {
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        // unsupported
+    }
+}

--- a/Sources/UserScript/UserScriptMessaging.swift
+++ b/Sources/UserScript/UserScriptMessaging.swift
@@ -75,9 +75,9 @@ public protocol UserScriptMessaging: UserScript {
 }
 
 extension UserScriptMessaging {
-    public func registerSubFeature(delegate: Subfeature) {
+    public func registerSubfeature(delegate: Subfeature) {
         delegate.with(broker: broker)
-        broker.registerSubFeature(delegate: delegate)
+        broker.registerSubfeature(delegate: delegate)
     }
 }
 
@@ -107,7 +107,7 @@ public final class UserScriptMessageBroker: NSObject {
         self.requiresRunInPageContentWorld = requiresRunInPageContentWorld
     }
 
-    public func registerSubFeature(delegate: Subfeature) {
+    public func registerSubfeature(delegate: Subfeature) {
         callbacks[delegate.featureName] = delegate
     }
 

--- a/Sources/UserScript/UserScriptMessaging.swift
+++ b/Sources/UserScript/UserScriptMessaging.swift
@@ -1,0 +1,313 @@
+//
+//  UserScriptMessaging.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+import Combine
+import os.log
+
+/// A protocol to implement if you want to opt-in to centralised messaging.
+///
+/// For example, a feature that contains a Javascript implementation in C-S-S
+/// can conduct 2-way communication between the JS and Native layer.
+///
+public protocol Subfeature {
+    /// This represents a single handler. Features can register multiple handlers.
+    ///
+    /// The first part, `Any` represents the 'params' field of either RequestMessage or
+    /// NotificationMessage and can be easily converted into a type of your choosing.
+    ///
+    /// The second part is the original WKScriptMessage
+    ///
+    /// The response can be any Encodable value - it will be serialized into
+    /// the `result` field of [MessageResponse](https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.MessageResponse.html#result)
+    typealias Handler = (_ params: Any, _ original: WKScriptMessage) async throws -> Encodable?
+
+    /// This gives a feature the opportunity to select it's own handler on a
+    /// call-by-call basis. The 'method' key is present on `RequestMessage` & `NotificationMessage`
+    func handler(forMethodNamed methodName: String) -> Handler?
+
+    /// This allows the feature to be selective about which domains/origins it accepts messages from
+    var messageOriginPolicy: MessageOriginPolicy { get }
+
+    /// The top-level name of the feature. For example, if Duck Player was delivered through C-S-S, the
+    /// "featureName" would still be "duckPlayer" and the "context" would be related to the shared UserScript, in this
+    /// case that's "contentScopeScripts"
+    ///
+    /// For example:
+    /// context: "contentScopeScripts"
+    /// featureName: "duckPlayer"
+    /// method: "setUserValues"
+    /// params: "..."
+    /// id: "abc"
+    ///
+    var featureName: String { get }
+
+    /// Subfeatures may sometime need access to the message broker - for example to push messages into the page
+    var broker: UserScriptMessageBroker? { get set }
+    func with(broker: UserScriptMessageBroker)
+}
+
+extension Subfeature {
+    /// providing a blank implementation since not all features will need this
+    public func with(broker: UserScriptMessageBroker) {
+        // nothing
+    }
+}
+
+public protocol UserScriptMessaging: UserScript {
+    var broker: UserScriptMessageBroker { get }
+}
+
+extension UserScriptMessaging {
+    public func registerSubFeature(delegate: Subfeature) {
+        delegate.with(broker: broker)
+        broker.registerSubFeature(delegate: delegate)
+    }
+}
+
+/// The message broker just holds references to instances and distributes messages
+/// to them. There would be exactly 1 `UserScriptMessageBroker` per UserScript
+public final class UserScriptMessageBroker: NSObject {
+
+    public let hostProvider: UserScriptHostProvider
+    public let generatedSecret: String = UUID().uuidString
+
+    /// A value used to differentiate entire categories of messages. For example
+    /// ContentScopeScripts would have a single 'context', but then will have multiple
+    /// sub-features.
+    public let context: String
+    public let requiresRunInPageContentWorld: Bool
+
+    /// We determine which feature should receive a given message
+    /// based on this
+    var callbacks: [String: Subfeature] = [:]
+
+    public init(context: String,
+                hostProvider: UserScriptHostProvider = SecurityOriginHostProvider(),
+                requiresRunInPageContentWorld: Bool = false
+    ) {
+        self.context = context
+        self.hostProvider = hostProvider
+        self.requiresRunInPageContentWorld = requiresRunInPageContentWorld
+    }
+
+    public func registerSubFeature(delegate: Subfeature) {
+        callbacks[delegate.featureName] = delegate
+    }
+
+    public func messagingConfig() -> WebkitMessagingConfig {
+        var config = WebkitMessagingConfig(
+                webkitMessageHandlerNames: [context],
+                secret: generatedSecret,
+                hasModernWebkitAPI: true
+        )
+        return config
+    }
+
+    public func push(method: String, params: Encodable?, for delegate: Subfeature, into webView: WKWebView) {
+        guard let js = SubscriptionEvent.toJS(
+                context: context,
+                featureName: delegate.featureName,
+                subscriptionName: method,
+                params: params ?? [:] as [String: String]
+        )
+        else {
+            return
+        }
+        if #available(macOS 11.0, iOS 14.0, *) {
+            if !self.requiresRunInPageContentWorld {
+                webView.evaluateJavaScript(js, in: nil, in: WKContentWorld.defaultClient)
+            } else {
+                webView.evaluateJavaScript(js)
+            }
+        }
+    }
+
+    public enum Action {
+        case respond(handler: Subfeature.Handler, request: RequestMessage)
+        case notify(handler: Subfeature.Handler, notification: NotificationMessage)
+        case error(BrokerError)
+    }
+
+    /// Convert incoming messages, into an Action.
+    ///
+    /// Conditions for `error`:
+    ///  - does not contain `featureName`, `context` or `method`
+    ///  - delegate not found for `featureName`
+    ///  - origin not supported, due to a feature's configuration
+    ///  - delegate failed to provide a handler
+    ///
+    /// Conditions for `respond`
+    ///  - no errors
+    ///  - contains an `id`
+    ///
+    /// Conditions for `notify`
+    ///  - no errors
+    ///  - does NOT contain an `id`
+    public func messageHandlerFor(_ message: WKScriptMessage) -> Action {
+
+        /// first, check that the incoming message is roughly in the correct shape
+        guard let dict = message.messageBody as? [String: Any],
+              let featureName = dict["featureName"] as? String,
+              let context = dict["context"] as? String,
+              let method = dict["method"] as? String
+        else {
+            return .error(.invalidParams)
+        }
+
+        /// Now try to match the message to a registered delegate
+        guard let delegate = callbacks[featureName] else {
+            return .error(.notFoundFeature(featureName))
+        }
+
+        /// Check if the selected delegate accepts messages from this origin
+        guard delegate.messageOriginPolicy.isAllowed(hostProvider.hostForMessage(message)) else {
+            return .error(.policyRestriction)
+        }
+
+        /// Now ask the delegate to provide the handler
+        guard let handler = delegate.handler(forMethodNamed: method) else {
+            return .error(.notFoundHandler(feature: featureName, method: method))
+        }
+
+        /// just send empty params if absent
+        var methodParams: Any = [:] as Any
+        if let params = dict["params"] {
+            methodParams = params
+        }
+
+        /// if the incoming message had an 'id' field, it requires a response
+        if let id = dict["id"] as? String {
+
+            let incoming = RequestMessage(context: context, featureName: featureName, id: id, method: method, params: methodParams)
+
+            /// other we can respond through the reply handler as normal
+            return .respond(handler: handler, request: incoming)
+        }
+
+        /// If we get this far, we are confident the message was in the correct format
+        /// but we don't think it requires a response. Therefor we treat it as a fire-and-forget notification
+        let notification = NotificationMessage(context: context, featureName: featureName, method: method, params: methodParams)
+        return .notify(handler: handler, notification: notification)
+    }
+
+    /// Perform the side-effect described in an action
+    public func execute(action: Action, original: WKScriptMessage) async throws -> String {
+        switch action {
+            /// for `notify` we just need to execute the handler and continue
+            /// we **do not** forward any errors to the client
+            /// As far as the client is concerned, a `notification` is fire-and-forget
+        case .notify(let handler, let notification):
+            do {
+                try await handler(notification.params, original)
+            } catch {
+                os_log("UserScriptMessaging: unhandled exception %s", type: .error, String(describing: error.localizedDescription))
+            }
+            return "{}"
+
+            /// Here the client will be expecting a response, so we always to produce one
+            /// We catch errors from handlers so that we can forward the response to clients with the correct context
+            ///
+            /// Most of the logic here is around ensuring we send either `result` or `error` in the response
+            /// Since that's how the Javascript side determines if the request was successful or not.
+        case .respond(let handler, let request):
+            do {
+                let encodableResponse = try await handler(request.params, original)
+
+                // handle an error
+                guard let result = encodableResponse else {
+                    let response = MessageErrorResponse.forRequest(request: request, error: .missingEncodableResult).toJSON()
+                    return response
+                }
+
+                // send the result
+                if let response = MessageResponse.toJSON(request: request, result: result) {
+                    return response
+                }
+
+                let response = MessageErrorResponse.forRequest(request: request, error: .jsonEncodingFailed).toJSON()
+                return response
+
+            } catch {
+                let response = MessageErrorResponse.forRequest(request: request, error: .otherError(error)).toJSON()
+                return response
+            }
+
+            /// We re-throw errors here to let consumers forward them as needed.
+            ///
+            /// Errors here are different to those caught in `.respond` above, because they are not
+            /// always tied to a response. They could be relating the incoming payload being incorrect etc.
+        case .error(let error):
+            let error = NSError(domain: "UserScriptMessaging", code: 0, userInfo: [NSLocalizedDescriptionKey: error.localizedDescription])
+            throw error
+        }
+    }
+}
+
+public enum BrokerError: Error {
+    case invalidParams
+    case notFoundFeature(String)
+    case notFoundHandler(feature: String, method: String)
+    case policyRestriction
+}
+
+extension BrokerError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidParams:
+            return "The incoming message was not valid - one or more of 'featureName', 'method'  or 'context' was missing"
+        case .notFoundFeature(let feature):
+            return "feature named `\(feature)` was not found"
+        case .notFoundHandler(let feature, let method):
+            return "the incoming message is ignored because the feature `\(feature)` couldn't provide a handler for method `\(method)`"
+        case .policyRestriction:
+            return "invalid origin"
+        }
+    }
+}
+
+/// An explicit format for specifying how a hostname should be matched
+public enum HostnameMatchingRule {
+    case etldPlus1(hostname: String)
+    case exact(hostname: String)
+}
+
+/// Force consumers to be explicit about the difference between accepting messages
+/// from 'all domains' vs 'only a subset of domains'
+public enum MessageOriginPolicy {
+    case all
+    case only(rules: [HostnameMatchingRule])
+
+    public func isAllowed(_ origin: String) -> Bool {
+        switch self {
+        case .all: return true
+        case .only(let allowed):
+            return allowed.contains { allowed in
+                switch allowed {
+                    /// exact match
+                case .exact(hostname: let hostname):
+                    return hostname == origin
+                    /// etldPlus1, like duckduckgo.com to match dev.duckduckgo.com + duckduckgo.com
+                case .etldPlus1(hostname: let hostname):
+                    return false // todo - this isn't used yet!
+                }
+            }
+        }
+    }
+}

--- a/Sources/UserScript/UserScriptMessagingSchema.swift
+++ b/Sources/UserScript/UserScriptMessagingSchema.swift
@@ -1,0 +1,200 @@
+//
+//  UserScriptMessagingSchema.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import Foundation
+
+/// Fire-and-forget notifications from the user script
+///
+/// https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.NotificationMessage.html
+public struct NotificationMessage {
+    public let context: String
+    public let featureName: String
+    public let method: String
+    public let params: Any
+}
+
+/// A RequestMessage is just a NotificationMessage but with an 'id' field
+/// The presence of the 'id' field indicates that a response is expected
+///
+/// https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.RequestMessage.html
+public struct RequestMessage {
+    public let context: String
+    public let featureName: String
+    public let id: String
+    public let method: String
+    public let params: Any
+}
+
+/// Sent in response to a `RequestMessage`
+///
+/// https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.MessageResponse.html
+public struct MessageResponse {
+    public let context: String
+    public let featureName: String
+    public let id: String
+    public let result: Encodable
+
+    public static func toJSON(request: RequestMessage, result: Encodable) -> String? {
+
+        // construct a 'MessageResponse' -> this is done to verify the types against the schema
+        let res = MessageResponse(
+            context: request.context,
+            featureName: request.featureName,
+            id: request.id,
+            result: result
+        )
+
+        // I added this because I couldn't figure out the generic/recursive Encodable
+        let dictionary: [String: Encodable] = [
+            "context": res.context,
+            "featureName": res.featureName,
+            "id": res.id,
+            "result": res.result
+        ]
+
+        return GenericJSONOutput.toJSON(dict: dictionary)
+    }
+}
+
+/// Like a MessageResponse, except it has a 'MessageError' instead of a result
+///
+/// https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.MessageResponse.html
+public struct MessageErrorResponse: Encodable {
+    public let context: String
+    public let featureName: String
+    public let id: String
+    public let error: MessageError
+
+    public static func forRequest(request: RequestMessage, error: ResponseError) -> Self {
+        MessageErrorResponse(context: request.context, featureName: request.featureName, id: request.id, error: MessageError(message: error.localizedDescription))
+    }
+
+    public func toJSON() -> String {
+        let jsonData = try! JSONEncoder().encode(self)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+        return jsonString
+    }
+}
+
+public enum ResponseError: Error {
+    case missingEncodableResult
+    case jsonEncodingFailed
+    case otherError(Error)
+}
+
+extension ResponseError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .missingEncodableResult:
+            return "could not access encodable result"
+        case .jsonEncodingFailed:
+            return "could not convert result to json"
+        case .otherError(let error):
+            return error.localizedDescription
+        }
+    }
+}
+
+/// https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.MessageError.html
+public struct MessageError: Encodable {
+    public let message: String
+}
+
+/// Use this format to push data into UserScript
+///
+/// https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.SubscriptionEvent.html
+public struct SubscriptionEvent {
+    public let context: String
+    public let featureName: String
+    public let subscriptionName: String
+    public let params: Encodable
+
+    public func toJSON() -> String? {
+
+        // I added this because I couldn't figure out the generic/recursive Encodable
+        let dictionary: [String: Encodable] = [
+            "context": self.context,
+            "featureName": self.featureName,
+            "subscriptionName": self.subscriptionName,
+            "params": self.params
+        ]
+
+        return GenericJSONOutput.toJSON(dict: dictionary)
+    }
+
+    public static func toJS(context: String, featureName: String, subscriptionName: String, params: Encodable) -> String? {
+
+        let res = SubscriptionEvent(context: context, featureName: featureName, subscriptionName: subscriptionName, params: params)
+        guard let json = res.toJSON() else {
+            assertionFailure("Could not convert a SubscriptionEvent to JSON")
+            return nil
+        }
+
+        return """
+           (() => {
+              if (!('\(res.subscriptionName)' in window)) {
+                 console.warn("missing '\(res.subscriptionName)'", \(json))
+              } else {
+                  window.\(res.subscriptionName)?.(\(json));
+              }
+           })();
+           """
+    }
+}
+
+/// https://duckduckgo.github.io/content-scope-scripts/classes/Messaging.WebkitMessagingConfig.html
+public struct WebkitMessagingConfig: Encodable {
+    let webkitMessageHandlerNames: [String]
+    let secret: String
+    var hasModernWebkitAPI: Bool
+}
+
+// helper types for nested JSON output (please remove if there's a better way
+struct GenericJSONOutput: Encodable {
+    let dict: [String: Encodable]
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: AnyCodingKey.self)
+        for (key, value) in dict {
+            let codingKey = AnyCodingKey(stringValue: key)!
+            try container.encode(value, forKey: codingKey)
+        }
+    }
+
+    static func toJSON(dict: [String: Encodable]) -> String? {
+        let myData = GenericJSONOutput(dict: dict)
+        let encoder = JSONEncoder()
+
+        guard let jsonData = try? encoder.encode(myData),
+              let jsonString = String(data: jsonData, encoding: .utf8) else {
+            return nil
+        }
+
+        return jsonString
+    }
+}
+
+struct AnyCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int? { nil }
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) { nil }
+}

--- a/Tests/UserScriptTests/UserScriptMessagingTests.swift
+++ b/Tests/UserScriptTests/UserScriptMessagingTests.swift
@@ -1,0 +1,286 @@
+//
+//  ContentScopeMessagingTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+import WebKit
+@testable import UserScript
+
+class UserScriptMessagingTests: XCTestCase {
+
+    /// When an 'id' field is present on an incoming message, it means
+    /// that the client is expecting a response. This test ensures that
+    /// a 'result' keys exists on the response, as per [MessageResponse](https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.MessageResponse.html)
+    func testDelegateRespondsWithResult() async {
+        let (testee, action, original) = setupWith(message: [
+            "context": "any_context",
+            "featureName": "fooBarFeature",
+            "method": "responseExample",
+            "id": "abcdef01623456",
+            "params": [
+                "name": "kittie"
+            ]
+        ])
+
+        let expectation = XCTestExpectation(description: "replyHandler called")
+
+        do {
+            let json = try await testee.execute(action: action, original: original)
+
+            // convert back from json to test the e2e flow
+            if let data = json.data(using: .utf8),
+                let obj = try? JSONSerialization.jsonObject(with: data),
+                let dict = obj as? [String: Any],
+                let result = dict["result"] as? [String: Any] {
+
+                XCTAssertEqual(dict["context"] as? String, testee.context)
+                XCTAssertEqual(dict["featureName"] as? String, "fooBarFeature")
+                XCTAssertEqual(dict["id"] as? String, "abcdef01623456")
+
+                // here we care that the data was returned inside 'result'
+                XCTAssertEqual(result["name"] as? String, "Kittie")
+
+                expectation.fulfill()
+            }
+        } catch {}
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    /// This test verifies that the replyHandler is called for notifications,
+    /// but that it just contains an empty Object. This is important because it
+    /// prevents the Promise from being rejected on the JS side.
+    ///
+    /// Note: the incoming message has no `id` field. This is what makes it a 'notification'
+    func testDelegateHandlesNotification() async {
+
+        let (testee, action, original) = setupWith(message: [
+            "context": "any_context",
+            "featureName": "fooBarFeature",
+            "method": "notifyExample",
+            "params": [
+                "name": "kittie"
+            ]
+        ])
+
+        // expectation waiter
+        let expectation = XCTestExpectation(description: "replyHandler called")
+
+        do {
+            let json = try await testee.execute(action: action, original: original)
+
+            // in a notification, we send back an empty object to prevent the promise from rejecting on the client
+            XCTAssertEqual("{}", json)
+            expectation.fulfill()
+        } catch {}
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    /// This test verifies that errors from handlers are reflected back to the JS side.
+    /// This is an important part of the flow - because when a `request` is sent from the JS
+    /// it can use the error-response to close the loop between request/response.
+    func testDelegateRespondsWithErrorResponse() async {
+
+        let (testee, action, original) = setupWith(message: [
+            "context": "any_context",
+            "featureName": "fooBarFeature",
+            "method": "errorExample",
+            "id": "abcdef01623456",
+            "params": [
+                "name": "kittie"
+            ]
+        ])
+
+        let expectation = XCTestExpectation(description: "replyHandler called")
+
+        do {
+            let json = try await testee.execute(action: action, original: original)
+            if let data = json.data(using: .utf8),
+               let obj = try? JSONSerialization.jsonObject(with: data),
+               let dict = obj as? [String: Any],
+               let error = dict["error"] as? [String: Any] {
+
+                XCTAssertEqual(dict["context"] as? String, testee.context)
+                XCTAssertEqual(dict["featureName"] as? String, "fooBarFeature")
+                XCTAssertEqual(dict["id"] as? String, "abcdef01623456")
+
+                // we care that 'error.message' is reflected to the client
+                XCTAssertEqual(error["message"] as? String, "Some Error")
+
+                expectation.fulfill()
+            }
+        } catch {}
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    /// Ensure that an error is thrown if the feature was not registered
+    func testThrowsOnMissingFeature() async {
+        let (testee, action, original) = setupWith(message: [
+            "context": "any_context",
+            "featureName": "this_feature_doesnt_exist",
+            "method": "an_unknown_method_name_but_no_id",
+            "params": [
+                "foo": "bar"
+            ]
+        ])
+
+        do {
+            _ = try await testee.execute(action: action, original: original)
+        } catch let error {
+            XCTAssertEqual(error.localizedDescription, "feature named `this_feature_doesnt_exist` was not found")
+        }
+    }
+
+    /// Ensure that an error is thrown if a feature was found, but it wasn't able to select a handler for the
+    /// particular incoming 'method'
+    func testThrowsOnMissingMethod() async {
+        let (testee, action, original) = setupWith(message: [
+            "context": "any_context",
+            "featureName": "fooBarFeature",
+            "method": "an_unknown_method_name_but_no_id",
+            "params": [
+                "foo": "bar"
+            ]
+        ])
+
+        do {
+            _ = try await testee.execute(action: action, original: original)
+        } catch let error {
+            XCTAssertEqual(error.localizedDescription, "the incoming message is ignored because the feature `fooBarFeature` couldn't provide a handler for method `an_unknown_method_name_but_no_id`")
+        }
+    }
+
+    /// Ensure that an error is thrown if the `context` key is absent. `context` is not *technically* needed
+    /// on the webkit implementation (because the webkit MessageHandler must of been correct), this test is
+    /// more about compliance with the shared/documented types
+    func testThrowsOnMissingContext() async {
+        let (testee, action, original) = setupWith(message: [
+            "featureName": "fooBarFeature",
+            "method": "an_unknown_method_name_but_no_id",
+            "params": [
+                "foo": "bar"
+            ]
+        ])
+
+        do {
+            _ = try await testee.execute(action: action, original: original)
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "The incoming message was not valid - one or more of 'featureName', 'method'  or 'context' was missing")
+        }
+    }
+}
+
+/// A helper for registering a test delegate and creating a MockMsg based on the
+/// incoming dictionary (which represents a message coming from a webview)
+///
+/// - Parameter message: The incoming message
+///
+func setupWith(message: [String: Any]) -> (UserScriptMessageBroker, UserScriptMessageBroker.Action, WKScriptMessage) {
+    // create the instance of ContentScopeMessaging
+    let testee = UserScriptMessageBroker(context: message["context"] as? String ?? "default")
+
+    // register a feature for a given name
+    testee.registerSubFeature(delegate: TestDelegate())
+
+    // Mock the call from the webview.
+    let msg1 = MockMsg(name: testee.context, body: message)
+
+    // get the handler action
+    let action = testee.messageHandlerFor(msg1)
+
+    return (testee, action, msg1)
+}
+
+/// An example of how to conform to `ContentScopeScriptsSubFeature`
+/// It contains 3 examples that are typical of a feature that needs to
+/// communicate to a UserScript
+struct TestDelegate: Subfeature {
+    weak var broker: UserScriptMessageBroker?
+
+    var featureName = "fooBarFeature"
+
+    /// This feature will accept messages from .all - meaning every origin
+    ///
+    /// Some features may want to restrict the origin's that it accepts messages from
+    var messageOriginPolicy: MessageOriginPolicy = .all
+
+    /// An example of how to provide different handlers bad on
+    func handler(forMethodNamed methodName: String) -> Subfeature.Handler? {
+        switch methodName {
+        case "notifyExample": return notifyExample
+        case "errorExample": return errorExample
+        case "responseExample": return responseExample
+        default:
+            return nil
+        }
+    }
+
+    /// An example of a simple Encodable data type that can be used directly in replies
+    struct Person: Encodable {
+        let name: String
+    }
+
+    /// An example that represents handling a [NotificationMessage](https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.NotificationMessage.html)
+    func notifyExample(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        print("not replying...")
+        return nil
+    }
+
+    /// An example that represents throwing an exception from a handler
+    ///
+    /// Note: if this happens as part of a 'request', the error string will be forwarded onto the client side JS
+    func errorExample(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        let error = NSError(domain: "MyHandler", code: 0, userInfo: [NSLocalizedDescriptionKey: "Some Error"])
+        throw error
+    }
+
+    /// An example of how a handler can reply with any Encodable data type
+    func responseExample(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        let person = Person(name: "Kittie")
+        return person
+    }
+}
+
+class MockMsg: WKScriptMessage {
+
+    let mockedName: String
+    let mockedBody: Any
+    let mockedWebView: WKWebView?
+
+    override var name: String {
+        return mockedName
+    }
+
+    override var body: Any {
+        return mockedBody
+    }
+
+    override var webView: WKWebView? {
+        return mockedWebView
+    }
+
+    init(name: String, body: Any, webView: WKWebView? = nil) {
+        self.mockedName = name
+        self.mockedBody = body
+        self.mockedWebView = webView
+        super.init()
+    }
+}

--- a/Tests/UserScriptTests/UserScriptMessagingTests.swift
+++ b/Tests/UserScriptTests/UserScriptMessagingTests.swift
@@ -198,7 +198,7 @@ func setupWith(message: [String: Any]) -> (UserScriptMessageBroker, UserScriptMe
     let testee = UserScriptMessageBroker(context: message["context"] as? String ?? "default")
 
     // register a feature for a given name
-    testee.registerSubFeature(delegate: TestDelegate())
+    testee.registerSubfeature(delegate: TestDelegate())
 
     // Mock the call from the webview.
     let msg1 = MockMsg(name: testee.context, body: message)
@@ -209,7 +209,7 @@ func setupWith(message: [String: Any]) -> (UserScriptMessageBroker, UserScriptMe
     return (testee, action, msg1)
 }
 
-/// An example of how to conform to `ContentScopeScriptsSubFeature`
+/// An example of how to conform to `Subfeature`
 /// It contains 3 examples that are typical of a feature that needs to
 /// communicate to a UserScript
 struct TestDelegate: Subfeature {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: 
iOS PR:  
macOS PR: 
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

TODO
- Catalina/encryption support needs to be added to the new messaging broker

**tl;dr** - multiple features will soon be messaging from single UserScripts

```swift
/// An example of how to conform to `SubFeature`
/// It contains 3 examples that are typical of a feature that needs to
/// communicate to a UserScript
struct TestDelegate: Subfeature {
    weak var broker: UserScriptMessageBroker?

    var featureName = "fooBarFeature"

    /// This feature will accept messages from .all - meaning every origin
    ///
    /// Some features may want to restrict the origin's that it accepts messages from
    var messageOriginPolicy: MessageOriginPolicy = .all

    /// An example of how to provide different handlers bad on
    func handler(forMethodNamed methodName: String) -> Subfeature.Handler? {
        switch methodName {
        case "notifyExample": return notifyExample
        case "errorExample": return errorExample
        case "responseExample": return responseExample
        default:
            return nil
        }
    }

    /// An example of a simple Encodable data type that can be used directly in replies
    struct Person: Encodable {
        let name: String
    }

    /// An example that represents handling a [NotificationMessage](https://duckduckgo.github.io/content-scope-scripts/classes/Messaging_Schema.NotificationMessage.html)
    func notifyExample(params: Any, original: WKScriptMessage) async throws -> Encodable? {
        print("not replying...")
        return nil
    }

    /// An example that represents throwing an exception from a handler
    ///
    /// Note: if this happens as part of a 'request', the error string will be forwarded onto the client side JS
    func errorExample(params: Any, original: WKScriptMessage) async throws -> Encodable? {
        let error = NSError(domain: "MyHandler", code: 0, userInfo: [NSLocalizedDescriptionKey: "Some Error"])
        throw error
    }

    /// An example of how a handler can reply with any Encodable data type
    func responseExample(params: Any, original: WKScriptMessage) async throws -> Encodable? {
        let person = Person(name: "Kittie")
        return person
    }
}

contentScopeUserScript.registerSubFeature(delegate: TestDelegate())
```

**Description**:

- Content Scope Scripts is adding features that require messaging - there will be multiple such features in the future.
- Therefor, on the JS side we've created a standardised system for messaging to and from WebViews that include enough information for the native platforms to distribute the messages as they see fit.
- CC @jaceklyp 

- We have Specified a number of types that native platforms must implement and understand, such as
  - `NotificationMessage` (a fire-and-forget message)
  - `RequestMessage` (a notification that *requires* a response)
  - `MessageResponse` (a response to a `RequestMessage`)
  - `SubscriptionEvent` (ability to *push* data to WebViews)

- Messaging https://duckduckgo.github.io/content-scope-scripts/modules/Messaging.html
- MessagingSchema https://duckduckgo.github.io/content-scope-scripts/modules/Messaging_Schema.html

<img width="797" alt="image" src="https://user-images.githubusercontent.com/1643522/233810697-092a1ecf-f818-4def-b3ff-857b515c3671.png">

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
