### PR TITLE
Remove codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @duckduckgo/apple-devs


### PR DESCRIPTION

Task/Issue URL:  https://app.asana.com/0/1202500774821704/1204012835277482

**Description**:
There's an issue where GH automatically assigns codeowners again after a PR was approved and changes are made afterwards. Until we change GH to stop doing that with some custom workflow, it's better to remove codeowners and let people manually pick apple-devs if they want automatic assignment

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
