### PR TITLE
Allow a Not Modified response when fetching the remote config

### DIFF
--- a/Sources/Configuration/ConfigurationFetching.swift
+++ b/Sources/Configuration/ConfigurationFetching.swift
@@ -74,7 +74,7 @@ public final class ConfigurationFetcher: ConfigurationFetching {
       An error of type Error is thrown if the configuration fails to fetch or validate.
     */
     public func fetch(_ configuration: Configuration) async throws {
-        let fetchResult = try await fetch(from: configuration.url, withEtag: etag(for: configuration), requirements: .default)
+        let fetchResult = try await fetch(from: configuration.url, withEtag: etag(for: configuration), requirements: .all)
         if let data = fetchResult.data {
             try validator.validate(data, for: configuration)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199230911884351/1204316018265366/f
iOS PR: Please drag and drop BSK into the iOS app to test, PR will come after this PR has been approved
macOS PR: Please drag and drop BSK into the macOS app to test, PR will come after this PR has been approved
What kind of version bump will this require?: Patch

**Optional**:

CC: @jaceklyp 

**Description**:

This PR updates the config fetch call to allow for a Not Modified response.

This issue was manifesting in the macOS app by causing a high volume of config fetch failure pixels, and when investigating these it turned out they were of the `invalidStatusCode: 304` type.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Drag and drop this branch into the macOS app
1. Turn on pixel logging in `Logging.swift`
1. Run the app, and check that you don't see the `cfgfetch` failure pixel
1. Make sure that the config can still fetch successfully
1. Repeat the steps for the iOS app

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
