### PR TITLE
fix crash in Navigation.debugDescription, wrap os_log

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -18,7 +18,6 @@
 //
 
 import WebKit
-import os
 import Common
 import UserScript
 

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -17,8 +17,8 @@
 //  limitations under the License.
 //
 
+import Common
 import WebKit
-import os.log
 import UserScript
 
 public class AutofillUserScript: NSObject, UserScript, UserScriptMessageEncryption {

--- a/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionDetection.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionDetection.swift
@@ -18,7 +18,6 @@
 //
 
 import Foundation
-import OSLog
 import Common
 
 public protocol AdClickAttributionDetectionDelegate: AnyObject {

--- a/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionLogic.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionLogic.swift
@@ -18,7 +18,6 @@
 //
 
 import Foundation
-import os
 import ContentBlocking
 import Common
 

--- a/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionRulesProvider.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionRulesProvider.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import TrackerRadarKit
-import os
 import Common
 
 public protocol AdClickAttributionRulesProviding {

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import WebKit
-import os.log
 import TrackerRadarKit
 import Combine
 import Common

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSourceManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSourceManager.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import TrackerRadarKit
-import os
 import Common
 
 /**

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesCompilationTask.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesCompilationTask.swift
@@ -17,9 +17,9 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
 import WebKit
-import os.log
 import TrackerRadarKit
 
 extension ContentBlockerRulesManager {

--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/SurrogatesUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/SurrogatesUserScript.swift
@@ -18,7 +18,6 @@
 //
 
 import WebKit
-import os
 import TrackerRadarKit
 import UserScript
 import ContentBlocking

--- a/Sources/BrowserServicesKit/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapper.swift
+++ b/Sources/BrowserServicesKit/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapper.swift
@@ -17,8 +17,8 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
-import os.log
 
 struct JsonToRemoteConfigModelMapper {
 

--- a/Sources/BrowserServicesKit/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/Sources/BrowserServicesKit/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -17,8 +17,8 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
-import os.log
 
 // swiftlint:disable cyclomatic_complexity
 private enum AttributesKey: String, CaseIterable {

--- a/Sources/BrowserServicesKit/RemoteMessaging/RemoteMessagingConfigMatcher.swift
+++ b/Sources/BrowserServicesKit/RemoteMessaging/RemoteMessagingConfigMatcher.swift
@@ -17,8 +17,8 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
-import os.log
 
 public struct RemoteMessagingConfigMatcher {
 

--- a/Sources/BrowserServicesKit/RemoteMessaging/RemoteMessagingConfigProcessor.swift
+++ b/Sources/BrowserServicesKit/RemoteMessaging/RemoteMessagingConfigProcessor.swift
@@ -17,8 +17,8 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
-import os.log
 
 public struct RemoteMessagingConfigProcessor {
 

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultDatabaseProvider.swift
@@ -16,9 +16,9 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
 import GRDB
-import os.log
 
 protocol SecureVaultDatabaseProvider {
 

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import Combine
-import os
 import Common
 
 public enum AutofillType {

--- a/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgrade.swift
+++ b/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgrade.swift
@@ -17,8 +17,8 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
-import os.log
 import BloomFilterWrapper
 
 public enum HTTPSUpgradeError: Error {

--- a/Sources/BrowserServicesKit/SmarterEncryption/Store/AppHTTPSUpgradeStore.swift
+++ b/Sources/BrowserServicesKit/SmarterEncryption/Store/AppHTTPSUpgradeStore.swift
@@ -21,7 +21,6 @@ import BloomFilterWrapper
 import Common
 import Foundation
 import CoreData
-import os.log
 import Persistence
 
 public struct AppHTTPSUpgradeStore: HTTPSUpgradeStore {

--- a/Sources/BrowserServicesKit/Suggestions/APIResult.swift
+++ b/Sources/BrowserServicesKit/Suggestions/APIResult.swift
@@ -17,7 +17,6 @@
 //
 
 import Foundation
-import os.log
 
 /// A structure representing suggestions fetched from duckduckgo.com/ac
 public struct APIResult: Codable {

--- a/Sources/Common/DecodableHelper.swift
+++ b/Sources/Common/DecodableHelper.swift
@@ -17,7 +17,7 @@
 //
 
 import Foundation
-import os
+import os.log
 
 public struct DecodableHelper {
     public static func decode<Input: Any, Target: Decodable>(from input: Input) -> Target? {

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -54,6 +54,10 @@ extension OSLog {
 
         public let category: String
 
+        public init(rawValue: String) {
+            self.category = rawValue
+        }
+
         public var wrappedValue: OSLog {
             var isEnabled = OSLog.enabledLoggingCategories.contains(category)
 #if CI
@@ -72,7 +76,7 @@ extension OSLog {
 public extension OSLog.OSLogWrapper {
 
     init(_ category: OSLog.Categories) {
-        self.category = category.rawValue
+        self.init(rawValue: category.rawValue)
     }
 
 }

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -104,8 +104,18 @@ public func os_log(message: @autoclosure () -> String, log: OSLog = .default, ty
 // MARK : - type first
 
 @inlinable
-public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString) {
+public func os_log(_ type: OSLogType, log: OSLog = .default, _ message: StaticString) {
     os.os_log(message, log: log, type: type)
+}
+
+@inlinable
+public func os_log(log: OSLog, _ message: StaticString) {
+    os.os_log(message, log: log, type: .default)
+}
+
+@inlinable
+public func os_log(_ message: StaticString) {
+    os.os_log(message, log: .default, type: .default)
 }
 
 @inlinable

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -40,7 +40,7 @@ extension OSLog {
     @OSLogWrapper(.passwordManager) public static var passwordManager
     @OSLogWrapper(.remoteMessaging) public static var remoteMessaging
 
-    static var enabledLoggingCategories = Set<String>()
+    public static var enabledLoggingCategories = Set<String>()
 
     static let isRunningInDebugEnvironment: Bool = {
         ProcessInfo().environment[ProcessInfo.Constants.osActivityMode] == ProcessInfo.Constants.debug

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -20,6 +20,8 @@
 import Foundation
 import os
 
+public typealias OSLog = os.OSLog
+
 extension OSLog {
 
     public static var userScripts: OSLog {
@@ -48,3 +50,98 @@ struct Logging {
     fileprivate static let remoteMessagingLog: OSLog = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "DuckDuckGo", category: "Remote Messaging")
 
 }
+
+// swiftlint:disable line_length
+
+// MARK : - message first
+
+@inlinable
+public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType) {
+    os.os_log(message, log: log, type: type)
+}
+
+@inlinable
+public func os_log(_ message: StaticString, log: OSLog) {
+    os.os_log(message, log: log, type: .default)
+}
+
+@inlinable
+public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1())
+}
+
+@inlinable
+public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1(), arg2())
+}
+
+@inlinable
+public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1(), arg2(), arg3())
+}
+
+@inlinable
+public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg, _ arg4: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1(), arg2(), arg3(), arg4())
+}
+
+@inlinable
+public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg, _ arg4: @autoclosure () -> some CVarArg, _ arg5: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1(), arg2(), arg3(), arg4(), arg5())
+}
+
+@inlinable
+public func os_log(message: @autoclosure () -> String, log: OSLog = .default, type: OSLogType = .default) {
+    guard log != .disabled else { return }
+    os_log("%s", log: log, type: type, message())
+}
+
+// MARK : - type first
+
+@inlinable
+public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString) {
+    os.os_log(message, log: log, type: type)
+}
+
+@inlinable
+public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1())
+}
+
+@inlinable
+public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1(), arg2())
+}
+
+@inlinable
+public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1(), arg2(), arg3())
+}
+
+@inlinable
+public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg, _ arg4: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1(), arg2(), arg3(), arg4())
+}
+
+@inlinable
+public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg, _ arg4: @autoclosure () -> some CVarArg, _ arg5: @autoclosure () -> some CVarArg) {
+    guard log != .disabled else { return }
+    os.os_log(message, log: log, type: type, arg1(), arg2(), arg3(), arg4(), arg5())
+}
+
+@inlinable
+public func os_log(_ type: OSLogType = .default, log: OSLog = .default, message: @autoclosure () -> String) {
+    guard log != .disabled else { return }
+    os_log("%s", log: log, type: type, message())
+}
+
+// swiftlint:enable line_length

--- a/Sources/Configuration/ConfigurationFetching.swift
+++ b/Sources/Configuration/ConfigurationFetching.swift
@@ -20,7 +20,6 @@
 import Foundation
 import Common
 import Networking
-import os.log
 
 protocol ConfigurationFetching {
 

--- a/Sources/DDGSync/internal/RecoveryKeyTransmitter.swift
+++ b/Sources/DDGSync/internal/RecoveryKeyTransmitter.swift
@@ -18,7 +18,6 @@
 //
 
 import Foundation
-import os
 
 struct RecoveryKeyTransmitter: RecoveryKeyTransmitting {
 

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -19,7 +19,6 @@
 import Combine
 import Common
 import Foundation
-import os.log
 import WebKit
 
 // swiftlint:disable file_length

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -179,6 +179,9 @@ private extension DistributedNavigationDelegate {
         })
     }
 
+    /// Instantiates a new Navigation object for a NavigationAction
+    /// or returns an ExpectedNavigation instance for navigations initiated using Navigator
+    /// or returns ongoing Navigation for server redirects
     /// Maps `WKNavigationAction` to `NavigationAction` according to an active server redirect or an expected NavigationType
     @MainActor
     func navigation(for wkNavigationAction: WKNavigationAction, in webView: WKWebView) -> Navigation? {
@@ -258,14 +261,22 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
     @MainActor
     public func webView(_ webView: WKWebView, decidePolicyFor wkNavigationAction: WKNavigationAction, preferences wkPreferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) { // swiftlint:disable:this function_body_length
 
+        // new navigation or an ongoing navigation?
         let navigation = navigation(for: wkNavigationAction, in: webView)
+        // extract WKNavigationAction mapped to NavigationAction from the Navigation or make new for non-main-frame Navigation Actions
         let navigationAction = navigation?.navigationAction
             ?? NavigationAction(webView: webView, navigationAction: wkNavigationAction, currentHistoryItemIdentity: currentHistoryItemIdentity, redirectHistory: nil, mainFrameNavigation: startedNavigation)
+        // associate NavigationAction with WKNavigationAction object
         wkNavigationAction.navigationAction = navigationAction
 
+        // only for MainFrame navigations: get currently ongoing (started) MainFrame Navigation
+        // or Navigation object associated with the NavigationAction (weak)
         let mainFrameNavigation = withExtendedLifetime(navigation) {
             navigationAction.isForMainFrame ? navigationAction.mainFrameNavigation : nil
         }
+        // ensure the NavigationAction is added to the Navigation
+        mainFrameNavigation?.navigationActionReceived(navigationAction)
+
         assert(navigationAction.mainFrameNavigation != nil || !navigationAction.isForMainFrame)
         os_log("decidePolicyFor: %s", log: log, type: .default, navigationAction.debugDescription)
 
@@ -284,12 +295,14 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
         }
 
         var preferences = NavigationPreferences(userAgent: webView.customUserAgent, preferences: wkPreferences)
+        // pass async decision making to Navigation.navigationResponders (or the delegate navigationResponders for non-main-frame navigations)
         let task = makeAsyncDecision(with: mainFrameNavigation?.navigationResponders ?? responders) { @MainActor responder in
             dispatchPrecondition(condition: .onQueue(.main))
 
+            // get to next responder until we get non-nil (.next == nil) decision
             guard let decision = await responder.decidePolicy(for: navigationAction, preferences: &preferences) else { return .next }
             os_log("%s: %s decision: %s", log: self.log, type: .default, navigationAction.debugDescription, "\(type(of: responder))", decision.debugDescription)
-
+            // pass non-nil decision to `completion:`
             return decision
 
         } completion: { @MainActor [self] (decision: NavigationActionPolicy?) in
@@ -320,10 +333,12 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
 
                 decisionHandler(.cancel, wkPreferences)
                 var expectedNavigations = [ExpectedNavigation]()
+                // run the `redirect` closure with a Navigator wrapper collecting all the ExpectedNavigations produced
                 withUnsafeMutablePointer(to: &expectedNavigations) { expectedNavigationsPtr in
                     let navigator = webView.navigator(distributedNavigationDelegate: self, redirectedNavigation: mainFrameNavigation, expectedNavigations: expectedNavigationsPtr)
                     redirect(navigator)
                 }
+                // ignore already started Navigations (they will receive didFail)
                 if mainFrameNavigation?.isCurrent != true {
                     didCancelNavigationAction(navigationAction, withRedirectNavigations: expectedNavigations)
                 }
@@ -335,7 +350,7 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
             // don‘t release the original WKNavigationAction until the end
             withExtendedLifetime(wkNavigationAction) {}
 
-        } cancellation: {
+        } /* Task */ cancellation: {
             dispatchPrecondition(condition: .onQueue(.main))
 
             os_log("Task cancelled for %s", log: self.log, type: .default, navigationAction.debugDescription)

--- a/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
+++ b/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
@@ -17,7 +17,6 @@
 //
 
 import Common
-import os.log
 import WebKit
 
 public extension WKFrameInfo {

--- a/Sources/Navigation/Extensions/WKNavigationActionExtension.swift
+++ b/Sources/Navigation/Extensions/WKNavigationActionExtension.swift
@@ -17,7 +17,6 @@
 //
 
 import Common
-import os.log
 import WebKit
 
 // swiftlint:disable line_length

--- a/Sources/Navigation/Navigation.swift
+++ b/Sources/Navigation/Navigation.swift
@@ -218,10 +218,7 @@ extension Navigation {
             // receiving another NavigationAction when already started means server redirect
             willPerformServerRedirect(with: navigationAction)
 
-        case .navigationActionReceived:
-            // already received
-            break
-        case .approved, .responseReceived, .finished, .failed, .willPerformClientRedirect, .redirected:
+        case .navigationActionReceived, .approved, .responseReceived, .finished, .failed, .willPerformClientRedirect, .redirected:
             assertionFailure("unexpected state \(self.state)")
         }
     }

--- a/Sources/Navigation/Navigation.swift
+++ b/Sources/Navigation/Navigation.swift
@@ -94,7 +94,7 @@ public protocol NavigationProtocol: AnyObject {
 extension Navigation: NavigationProtocol {}
 
 @MainActor
-public extension NavigationProtocol {
+public extension NavigationProtocol { // Navigation or ExpectedNavigation
 
     /** override responder chain for Navigation Events with defined ownership and nullability:
      ```

--- a/Sources/Navigation/Navigation.swift
+++ b/Sources/Navigation/Navigation.swift
@@ -399,7 +399,7 @@ final class WKNavigationLifetimeTracker: NSObject {
 
 extension Navigation: CustomDebugStringConvertible {
     public var debugDescription: String {
-        "<\(identity) #\(navigationAction.identifier): url:\(url.absoluteString) state:\(state)\(isCommitted ? "(committed)" : "") type:\(navigationAction.navigationType)>"
+        "<\(identity) #\(navigationAction.identifier): url:\(url.absoluteString) state:\(state)\(isCommitted ? "(committed)" : "") type:\(navigationActions.last?.navigationType.debugDescription ?? "<nil>")>"
     }
 }
 

--- a/Sources/Navigation/NavigationAction.swift
+++ b/Sources/Navigation/NavigationAction.swift
@@ -33,6 +33,7 @@ public struct NavigationAction {
     static func resetIdentifier() { maxIdentifier = 0 }
 #endif
 
+    /// auto-incremented id
     public var identifier: UInt64 = {
         Self.maxIdentifier += 1
         return Self.maxIdentifier
@@ -42,10 +43,12 @@ public struct NavigationAction {
 
     public let navigationType: NavigationType
 #if os(macOS)
+    /// keyboard modifiers for `linkActivated` NavigationType
     public internal(set) var modifierFlags: NSEvent.ModifierFlags = []
 #endif
 
 #if _IS_USER_INITIATED_ENABLED
+    /// if navigation was initiated by user action on a web page
     public let isUserInitiated: Bool
 #endif
     public let shouldDownload: Bool
@@ -70,7 +73,8 @@ public struct NavigationAction {
     /// Actual `BackForwardListItem` identity before the NavigationAction had started
     public let fromHistoryItemIdentity: HistoryItemIdentity?
 #endif
-    /// Previous Navigation Actions received during current logical `Navigation`, zero-based, most recent is the last
+    /// Previous Navigation Actions received during current logical `Navigation`, includes .server, .client and .developer redirects
+    /// zero-based, most recent is the last redirect
     public let redirectHistory: [NavigationAction]?
 
     public init(request: URLRequest, navigationType: NavigationType, currentHistoryItemIdentity: HistoryItemIdentity?, redirectHistory: [NavigationAction]?, isUserInitiated: Bool?, sourceFrame: FrameInfo, targetFrame: FrameInfo?, shouldDownload: Bool, mainFrameNavigation: Navigation?) {
@@ -158,6 +162,7 @@ public extension NavigationAction {
         targetFrame?.isMainFrame == true
     }
 
+    /// if another WebView initiated the navigation
     var isTargetingNewWindow: Bool {
         assert(sourceFrame.webView != nil || targetFrame?.webView != nil)
         return sourceFrame.webView != targetFrame?.webView || targetFrame?.webView == nil

--- a/Sources/Navigation/NavigationType.swift
+++ b/Sources/Navigation/NavigationType.swift
@@ -43,7 +43,7 @@ public enum NavigationType: Equatable {
 
     case other
 
-    /// developer-defined, set using `DistributedNavigationDelegate.setExpectedNavigationType(_:matching:)`
+    /// developer-defined, set using `WebView.navigator().load(..., withExpectedNavigationType: .custom(.someType))`
     case custom(CustomNavigationType)
 
     public init(_ navigationAction: WebViewNavigationAction, currentHistoryItemIdentity: HistoryItemIdentity?) {

--- a/Sources/Networking/APIRequest.swift
+++ b/Sources/Networking/APIRequest.swift
@@ -17,8 +17,8 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
-import os.log
 
 public typealias APIResponse = (data: Data?, response: HTTPURLResponse)
 public typealias APIRequestCompletion = (APIResponse?, APIRequest.Error?) -> Void
@@ -76,11 +76,11 @@ public struct APIRequest {
     private func validateAndUnwrap(data: Data?, response: URLResponse) throws -> APIResponse {
         let httpResponse = try response.asHTTPURLResponse()
 
-        os_log("Request for %s completed with response code: %s and headers %s",
+        os_log("Request for %s completed with response code: %d and headers %s",
                log: log,
                type: .debug,
                request.url?.absoluteString ?? "",
-               String(describing: httpResponse.statusCode),
+               httpResponse.statusCode,
                String(describing: httpResponse.allHeaderFields))
         
         var data = data

--- a/Sources/Persistence/CoreDataDatabase.swift
+++ b/Sources/Persistence/CoreDataDatabase.swift
@@ -19,7 +19,6 @@
 import Foundation
 import CoreData
 import Common
-import OSLog
 
 public protocol ManagedObjectContextFactory {
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200541656900018/1204359032555835/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1638
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1120
What kind of version bump will this require?: Minor

**Description**:
- fixed the navigation flow when fragment Navigation could end-up without a NavigationAction assigned
- introduced os_log wrapper in BSK to accept message arguments as autoclosures i.e. computed only if valid log and log level are passed


<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate that every Navigation appearing in willStart and didStart NavigationResponder calls has a NavigationAction assigned (DistributedNavigationDelegate.swift:279) - only actual for macOS now
2. Validate `os_log` calls across the codebase don‘t need changing (only need to replace `replace import` os with `import Common`), arguments passed as %s and %d parameters are printed correctly, to the right log and with correct log level. Validate interpolated string passed to `os_log` works (`os_log("interpolated \(string)")`)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [x] iOS
* [x] macOS
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
