### PR TITLE
Fix test failing on 13.3

### DIFF
--- a/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
+++ b/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
@@ -798,7 +798,7 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         waitForExpectations(timeout: 5)
 
         assertHistory(ofResponderAt: 0, equalsTo: [
-            .navigationAction(req(urls.local, defaultHeaders + ["Upgrade-Insecure-Requests": "1"], cachePolicy: .reloadIgnoringLocalCacheData), .reload, from: history[1], src: main(urls.local)),
+            .navigationAction(req(urls.local, defaultHeaders.allowingExtraKeys, cachePolicy: .reloadIgnoringLocalCacheData), .reload, from: history[1], src: main(urls.local)),
             .willStart(Nav(action: navAct(2), .approved, isCurrent: false)),
             .didStart( Nav(action: navAct(2), .started)),
             .response(Nav(action: navAct(2), .responseReceived, resp: .resp(urls.local, data.html.count, headers: .default + ["Content-Type": "text/html"]))),
@@ -830,7 +830,7 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         waitForExpectations(timeout: 5)
 
         assertHistory(ofResponderAt: 0, equalsTo: [
-            .navigationAction(req(urls.local, defaultHeaders + ["Upgrade-Insecure-Requests": "1"], cachePolicy: .reloadIgnoringLocalCacheData), .reload, from: history[1], src: main(urls.local)),
+            .navigationAction(req(urls.local, defaultHeaders.allowingExtraKeys, cachePolicy: .reloadIgnoringLocalCacheData), .reload, from: history[1], src: main(urls.local)),
             .willStart(Nav(action: navAct(2), .approved, isCurrent: false)),
             .didStart( Nav(action: navAct(2), .started)),
             .response(Nav(action: navAct(2), .responseReceived, resp: .resp(urls.local, data.html.count, headers: .default + ["Content-Type": "text/html"]))),
@@ -915,7 +915,7 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         waitForExpectations(timeout: 5)
 
         assertHistory(ofResponderAt: 0, equalsTo: [
-            .navigationAction(NavAction(req(urls.localHashed1, defaultHeaders + ["Upgrade-Insecure-Requests": "1"], cachePolicy: .reloadIgnoringLocalCacheData), .reload, from: history[2], src: main(urls.localHashed1))),
+            .navigationAction(NavAction(req(urls.localHashed1, defaultHeaders.allowingExtraKeys, cachePolicy: .reloadIgnoringLocalCacheData), .reload, from: history[2], src: main(urls.localHashed1))),
             .willStart(Nav(action: navAct(3), .approved, isCurrent: false)),
             .didStart( Nav(action: navAct(3), .started)),
             .response(Nav(action: navAct(3), .responseReceived, resp: .resp(urls.localHashed1, data.html.count, headers: .default + ["Content-Type": "text/html"]))),
@@ -1547,7 +1547,7 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
             .navigationAction(req(urls.local), .other, src: main()),
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
-            .navigationAction(req(urls.local2, defaultHeaders + ["Accept-Encoding": "gzip, deflate", "Accept-Language": "en-XX,en;q=0.9", "Upgrade-Insecure-Requests": "1"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
 
             .navigationAction(req(urls.local3), .other, src: main()),
             .willStart(Nav(action: navAct(3), .approved, isCurrent: false)),

--- a/Tests/NavigationTests/NavigationBackForwardTests.swift
+++ b/Tests/NavigationTests/NavigationBackForwardTests.swift
@@ -86,14 +86,14 @@ class NavigationBackForwardTests: DistributedNavigationDelegateTestsBase {
             .didFinish(Nav(action: navAct(2), .finished, resp: resp(1), .committed)),
 
             // #2 -> #1 back
-            .navigationAction(req(urls.local, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .backForw(-1), from: history[2], src: main(urls.local1)),
+            .navigationAction(req(urls.local, defaultHeaders.allowingExtraKeys), .backForw(-1), from: history[2], src: main(urls.local1)),
             .willStart(Nav(action: navAct(3), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(3), .started)),
             .didCommit(Nav(action: navAct(3), .started, .committed)),
             .didFinish(Nav(action: navAct(3), .finished, .committed)),
 
             // #1 -> #2 forward
-            .navigationAction(req(urls.local1, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .backForw(1), from: history[1], src: main(urls.local)),
+            .navigationAction(req(urls.local1, defaultHeaders.allowingExtraKeys), .backForw(1), from: history[1], src: main(urls.local)),
             .willStart(Nav(action: navAct(4), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(4), .started)),
             .didCommit(Nav(action: navAct(4), .started, .committed)),
@@ -153,14 +153,14 @@ class NavigationBackForwardTests: DistributedNavigationDelegateTestsBase {
             .didFinish(Nav(action: navAct(2), .finished, resp: resp(1), .committed)),
 
             // #2 -> #1 back
-            .navigationAction(req(urls.local, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .backForw(-1), from: history[2], src: main(urls.local1)),
+            .navigationAction(req(urls.local, defaultHeaders.allowingExtraKeys), .backForw(-1), from: history[2], src: main(urls.local1)),
             .willStart(Nav(action: navAct(3), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(3), .started)),
             .didCommit(Nav(action: navAct(3), .started, .committed)),
             .didFinish(Nav(action: navAct(3), .finished, .committed)),
 
             // #1 -> #2 forward
-            .navigationAction(req(urls.local1, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .backForw(1), from: history[1], src: main(urls.local)),
+            .navigationAction(req(urls.local1, defaultHeaders.allowingExtraKeys), .backForw(1), from: history[1], src: main(urls.local)),
             .willStart(Nav(action: navAct(4), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(4), .started)),
             .didCommit(Nav(action: navAct(4), .started, .committed)),
@@ -209,7 +209,7 @@ class NavigationBackForwardTests: DistributedNavigationDelegateTestsBase {
             .didCommit(Nav(action: navAct(6), .responseReceived, resp: resp(1), .committed)),
             .didFinish(Nav(action: navAct(6), .finished, resp: resp(1), .committed)),
 
-            .navigationAction(req(urls.local4, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .backForw(3), from: history[2], src: main(urls.local1)),
+            .navigationAction(req(urls.local4, defaultHeaders.allowingExtraKeys), .backForw(3), from: history[2], src: main(urls.local1)),
             .willStart(Nav(action: navAct(7), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(7), .started)),
             .didCommit(Nav(action: navAct(7), .started, .committed)),
@@ -519,9 +519,9 @@ class NavigationBackForwardTests: DistributedNavigationDelegateTestsBase {
 
             // history items replaced due to WebKit bug
             // #7 go back to URL#
-            .willStart(Nav(action: NavAction(req(urls.localHashed, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .backForw(-1), from: history[6], src: main(urls.local)), .approved, isCurrent: false)),
+            .willStart(Nav(action: NavAction(req(urls.localHashed, defaultHeaders.allowingExtraKeys), .backForw(-1), from: history[6], src: main(urls.local)), .approved, isCurrent: false)),
             // #8 go back to URL#namedlink
-            .willStart(Nav(action: NavAction(req(urls.localHashed, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .backForw(-1), from: history[7], src: main(urls.localHashed)), .approved, isCurrent: false))
+            .willStart(Nav(action: NavAction(req(urls.localHashed, defaultHeaders.allowingExtraKeys), .backForw(-1), from: history[7], src: main(urls.localHashed)), .approved, isCurrent: false))
         ])
     }
 

--- a/Tests/NavigationTests/NavigationDownloadsTests.swift
+++ b/Tests/NavigationTests/NavigationDownloadsTests.swift
@@ -148,7 +148,7 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
             .navigationAction(req(urls.local), .other, src: main()),
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
-            .navigationAction(req(urls.local2, defaultHeaders + ["Accept-Encoding": "gzip, deflate", "Accept-Language": "en-XX,en;q=0.9", "Upgrade-Insecure-Requests": "1"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
             .didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1)], .started)),
             .response(Nav(action: navAct(2), redirects: [navAct(1)], .responseReceived, resp: .resp(urls.local2, mime: "application/zip", data.html.count, headers: .default + ["Content-Type": "application/zip"], nil, .cantShow))),
             .navResponseWillBecomeDownload(0),

--- a/Tests/NavigationTests/NavigationRedirectsTests.swift
+++ b/Tests/NavigationTests/NavigationRedirectsTests.swift
@@ -152,10 +152,10 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
 
-            .navigationAction(req(urls.local2, defaultHeaders + ["Upgrade-Insecure-Requests": "1", "Accept-Encoding": "gzip, deflate", "Accept-Language": "en-XX,en;q=0.9"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
             .didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1)], .started)),
 
-            .navigationAction(req(urls.local3, defaultHeaders + ["Accept-Encoding": "gzip, deflate", "Accept-Language": "en-GB,en;q=0.9", "Upgrade-Insecure-Requests": "1"]), .redirect(.server), redirects: [navAct(1), navAct(2)], src: main()),
+            .navigationAction(req(urls.local3, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1), navAct(2)], src: main()),
             .didReceiveRedirect(Nav(action: navAct(3), redirects: [navAct(1), navAct(2)], .started)),
 
             .response(Nav(action: navAct(3), redirects: [navAct(1), navAct(2)], .responseReceived, resp: .resp(urls.local3, status: 200, data.html.count))),
@@ -206,7 +206,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(2), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(2), .started)),
 
-            .navigationAction(NavAction(req(urls.localHashed, defaultHeaders + ["Accept-Encoding": "gzip, deflate", "Accept-Language": "en-XX,en;q=0.9", "Upgrade-Insecure-Requests": "1"], cachePolicy: .reloadIgnoringLocalCacheData), .redirect(.server), from: history[1], redirects: [navAct(2)], src: main(urls.local))),
+            .navigationAction(NavAction(req(urls.localHashed, defaultHeaders.allowingExtraKeys, cachePolicy: .reloadIgnoringLocalCacheData), .redirect(.server), from: history[1], redirects: [navAct(2)], src: main(urls.local))),
             .didReceiveRedirect(Nav(action: navAct(3), redirects: [navAct(2)], .started)),
             .response(Nav(action: navAct(3), redirects: [navAct(2)], .responseReceived, resp: .resp(urls.localHashed, data.html.count))),
             .didCommit(Nav(action: navAct(3), redirects: [navAct(2)], .responseReceived, resp: resp(1), .committed)),
@@ -297,7 +297,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
 
-            .navigationAction(req(urls.local2, defaultHeaders + ["Accept-Language": "en-XX,en;q=0.9", "Upgrade-Insecure-Requests": "1", "Accept-Encoding": "gzip, deflate"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
             .didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1)], .started)),
 
             .response(Nav(action: navAct(2), redirects: [navAct(1)], .responseReceived, resp: .resp(urls.local2, data.metaRedirect.count))),
@@ -310,7 +310,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(3), redirects: [navAct(1), navAct(2)], .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(3), redirects: [navAct(1), navAct(2)], .started)),
 
-            .navigationAction(req(urls.local4, defaultHeaders + ["Accept-Encoding": "gzip, deflate", "Upgrade-Insecure-Requests": "1", "Accept-Language": "en-GB,en;q=0.9", "Referer": urls.local2.string]), .redirect(.server), from: history[2], redirects: [navAct(1), navAct(2), navAct(3)], src: main(urls.local2)),
+            .navigationAction(req(urls.local4, defaultHeaders.allowingExtraKeys + ["Referer": urls.local2.string]), .redirect(.server), from: history[2], redirects: [navAct(1), navAct(2), navAct(3)], src: main(urls.local2)),
             .didReceiveRedirect(Nav(action: navAct(4), redirects: [navAct(1), navAct(2), navAct(3)], .started)),
 
             .response(Nav(action: navAct(4), redirects: [navAct(1), navAct(2), navAct(3)], .responseReceived, resp: .resp(urls.local4, data.html.count))),
@@ -424,7 +424,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
 
-            .navigationAction(req(urls.local2, defaultHeaders + ["Accept-Language": "en-GB,en;q=0.9", "Upgrade-Insecure-Requests": "1", "Accept-Encoding": "gzip, deflate"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
             .didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1)], .started)),
 
             .response(Nav(action: navAct(2), redirects: [navAct(1)], .responseReceived, resp: .resp(urls.local2, data.metaRedirect.count))),
@@ -437,7 +437,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(3), redirects: [navAct(1), navAct(2)], .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(3), redirects: [navAct(1), navAct(2)], .started)),
 
-            .navigationAction(req(urls.local4, defaultHeaders + ["Accept-Encoding": "gzip, deflate", "Upgrade-Insecure-Requests": "1", "Accept-Language": "en-GB,en;q=0.9", "Referer": urls.local2.string]), .redirect(.server), from: history[2], redirects: [navAct(1), navAct(2), navAct(3)], src: main(urls.local2)),
+            .navigationAction(req(urls.local4, defaultHeaders.allowingExtraKeys + ["Referer": urls.local2.string]), .redirect(.server), from: history[2], redirects: [navAct(1), navAct(2), navAct(3)], src: main(urls.local2)),
             .didReceiveRedirect(Nav(action: navAct(4), redirects: [navAct(1), navAct(2), navAct(3)], .started)),
 
             .response(Nav(action: navAct(4), redirects: [navAct(1), navAct(2), navAct(3)], .responseReceived, resp: .resp(urls.local4, data.html.count))),
@@ -485,7 +485,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
 
-            .navigationAction(req(urls.local2, defaultHeaders + ["Accept-Language": "en-GB,en;q=0.9", "Upgrade-Insecure-Requests": "1", "Accept-Encoding": "gzip, deflate"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
             .didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1)], .started)),
 
             .response(Nav(action: navAct(2), redirects: [navAct(1)], .responseReceived, resp: .resp(urls.local2, data.metaRedirect.count))),
@@ -498,7 +498,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
 
             .didStart(Nav(action: navAct(3), redirects: [navAct(1), navAct(2)], .started)),
 
-            .navigationAction(req(urls.local4, defaultHeaders + ["Accept-Encoding": "gzip, deflate", "Upgrade-Insecure-Requests": "1", "Accept-Language": "en-GB,en;q=0.9", "Referer": urls.local2.string]), .redirect(.server), from: history[2], redirects: [navAct(1), navAct(2), navAct(3)], src: main(urls.local2)),
+            .navigationAction(req(urls.local4, defaultHeaders.allowingExtraKeys + ["Referer": urls.local2.string]), .redirect(.server), from: history[2], redirects: [navAct(1), navAct(2), navAct(3)], src: main(urls.local2)),
             .didReceiveRedirect(Nav(action: navAct(4), redirects: [navAct(1), navAct(2), navAct(3)], .started)),
 
             .response(Nav(action: navAct(4), redirects: [navAct(1), navAct(2), navAct(3)], .responseReceived, resp: .resp(urls.local4, data.html.count))),
@@ -685,7 +685,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
 
-            .navigationAction(req(urls.local2, defaultHeaders + ["Accept-Encoding": "gzip, deflate", "Accept-Language": "en-XX,en;q=0.9", "Upgrade-Insecure-Requests": "1"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
             .didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1)], .started)),
             .response(Nav(action: navAct(2), redirects: [navAct(1)], .responseReceived, resp: .resp(urls.local2, data.metaRedirect.count))),
             .didCommit(Nav(action: navAct(2), redirects: [navAct(1)], .responseReceived, resp: resp(0), .committed)),
@@ -696,7 +696,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .didStart(Nav(action: navAct(3), redirects: [navAct(1), navAct(2)], .started)),
             .didFinish(Nav(action: navAct(2), redirects: [navAct(1)], .finished, resp: resp(0), .committed, isCurrent: false)),
 
-            .navigationAction(req(urls.local4, defaultHeaders + ["Upgrade-Insecure-Requests": "1", "Accept-Language": "en-XX,en;q=0.9", "Accept-Encoding": "gzip, deflate", "Referer": urls.local2.string]), .redirect(.server), from: history[2], redirects: [navAct(1), navAct(2), navAct(3)], src: main(urls.local2)),
+            .navigationAction(req(urls.local4, defaultHeaders.allowingExtraKeys + ["Referer": urls.local2.string]), .redirect(.server), from: history[2], redirects: [navAct(1), navAct(2), navAct(3)], src: main(urls.local2)),
             .didReceiveRedirect(Nav(action: navAct(4), redirects: [navAct(1), navAct(2), navAct(3)], .started)),
             .response(Nav(action: navAct(4), redirects: [navAct(1), navAct(2), navAct(3)], .responseReceived, resp: .resp(urls.local4, data.html.count))),
             .didCommit(Nav(action: navAct(4), redirects: [navAct(1), navAct(2), navAct(3)], .responseReceived, resp: resp(1), .committed)),
@@ -733,7 +733,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .navigationAction(req(urls.local), .other, src: main()),
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
-            .navigationAction(req(urls.local2, defaultHeaders + ["Accept-Language": "en-GB,en;q=0.9", "Upgrade-Insecure-Requests": "1", "Accept-Encoding": "gzip, deflate"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
             .didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1)], .started)),
             // .didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1), navAct(2)...], .started)),
 
@@ -781,7 +781,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
 
-            .navigationAction(req(urls.local2, defaultHeaders + ["Accept-Language": "en-GB,en;q=0.9", "Upgrade-Insecure-Requests": "1", "Accept-Encoding": "gzip, deflate"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
             .didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1)], .started)),
             // ...didReceiveRedirect(Nav(action: navAct(2), redirects: [navAct(1), navAct(2)...], .started)
 
@@ -1040,9 +1040,9 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .navigationAction(NavAction(req(urls.local), .other, from: history[2], src: main(urls.local2))),
             .didCancel(navAct(3), expected: 2),
             
-            // .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .redirect(.developer), from: history[2], src: main(urls.local2))),
+            // .navigationAction(NavAction(req(urls.local4, defaultHeaders.allowingExtraKeys), .redirect(.developer), from: history[2], src: main(urls.local2))),
             // .willStart(Nav(action: navAct(4), redirects: [navAct(3)], .approved, isCurrent: false)),
-            // .didFail(Nav(action: NavAction(req(urls.local4, defaultHeaders + ["Upgrade-Insecure-Requests": "1"]), .redirect(.developer), from: history[2], src: main(urls.local2)), redirects: [navAct(3)], .failed(WKError(NSURLErrorCancelled)), isCurrent: false), NSURLErrorCancelled),
+            // .didFail(Nav(action: NavAction(req(urls.local4, defaultHeaders.allowingExtraKeys), .redirect(.developer), from: history[2], src: main(urls.local2)), redirects: [navAct(3)], .failed(WKError(NSURLErrorCancelled)), isCurrent: false), NSURLErrorCancelled),
 
             .navigationAction(NavAction(req(urls.local3), .custom(.init(rawValue: "redir")), from: history[2], src: main(urls.local2))),
             .willStart(Nav(action: navAct(5), redirects: [navAct(3)], .approved, isCurrent: false)),
@@ -1089,7 +1089,7 @@ class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
 
-            .navigationAction(req(urls.local2, defaultHeaders + ["Accept-Language": "en-XX,en;q=0.9", "Accept-Encoding": "gzip, deflate", "Upgrade-Insecure-Requests": "1"]), .redirect(.server), redirects: [navAct(1)], src: main()),
+            .navigationAction(req(urls.local2, defaultHeaders.allowingExtraKeys), .redirect(.server), redirects: [navAct(1)], src: main()),
 
             .didFail(Nav(action: navAct(2), redirects: [navAct(1)], .failed(WKError(.frameLoadInterruptedByPolicyChange))), WKError.Code.frameLoadInterruptedByPolicyChange.rawValue)
         ])


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200194497630846/1204339873139665/f
What kind of version bump will this require?: –

**Description**:
- allow arbitrary extra headers in Navigation tests

**Steps to test this PR**:
1. Validate tests work on macOS 13.3

