### PR TITLE
add fetching of devices to sync

### DIFF
--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -110,6 +110,14 @@ public class DDGSync: DDGSyncing {
         updateIsAuthenticated()
     }
 
+    public func fetchDevices() async throws -> [RegisteredDevice] {
+        guard let account = try dependencies.secureStore.account() else {
+            throw SyncError.accountNotFound
+        }
+
+        return try await dependencies.account.fetchDevicesForAccount(account)
+    }
+
     // MARK: -
 
     let persistence: LocalDataPersisting

--- a/Sources/DDGSync/DDGSyncing.swift
+++ b/Sources/DDGSync/DDGSyncing.swift
@@ -94,6 +94,9 @@ public protocol DDGSyncing {
      @param deviceId ID of the device to be disconnected.
     */
     func disconnect(deviceId: String) async throws
+
+    func fetchDevices() async throws -> [RegisteredDevice]
+
 }
 
 public protocol UpdatesSending {

--- a/Sources/DDGSync/SyncModels.swift
+++ b/Sources/DDGSync/SyncModels.swift
@@ -41,9 +41,18 @@ public struct SyncAccount: Codable, Sendable {
 }
 
 public struct RegisteredDevice: Codable, Sendable {
+
     public let id: String
     public let name: String
     public let type: String
+
+    // Remove this when the server change is made to remove the device_ prefix
+    enum CodingKeys: String, CodingKey {
+        case id = "deviceId"
+        case name = "deviceName"
+        case type = "deviceType"
+    }
+
 }
 
 public struct AccountCreationKeys {

--- a/Sources/DDGSync/internal/RemoteAPIRequestCreatingExtensions.swift
+++ b/Sources/DDGSync/internal/RemoteAPIRequestCreatingExtensions.swift
@@ -1,0 +1,61 @@
+//
+//  RemoteAPIRequestCreating.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension RemoteAPIRequestCreating {
+
+    func createAuthenticatedGetRequest(url: URL, authToken: String, headers: [String: String] = [:], parameters: [String: String] = [:]) -> HTTPRequesting {
+        var headers = headers
+        headers["Authorization"] = "Bearer \(authToken)"
+        return createRequest(
+            url: url,
+            method: .GET,
+            headers: headers,
+            parameters: parameters,
+            body: nil,
+            contentType: nil
+        )
+    }
+
+    func createAuthenticatedJSONRequest(url: URL, method: HTTPRequestMethod, authToken: String, json: Data, headers: [String: String] = [:], parameters: [String: String] = [:]) -> HTTPRequesting {
+        var headers = headers
+        headers["Authorization"] = "Bearer \(authToken)"
+        return createRequest(
+            url: url,
+            method: method,
+            headers: headers,
+            parameters: parameters,
+            body: json,
+            contentType: "application/json"
+        )
+    }
+
+    func createUnauthenticatedJSONRequest(url: URL, method: HTTPRequestMethod, json: Data, headers: [String: String] = [:], parameters: [String: String] = [:]) -> HTTPRequesting {
+         return createRequest(
+            url: url,
+            method: method,
+            headers: headers,
+            parameters: parameters,
+            body: json,
+            contentType: "application/json"
+        )
+    }
+
+}

--- a/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/Sources/DDGSync/internal/SyncDependencies.swift
@@ -43,6 +43,8 @@ protocol AccountManaging {
 
     func logout(deviceId: String, token: String) async throws
 
+    func fetchDevicesForAccount(_ account: SyncAccount) async throws -> [RegisteredDevice]
+
 }
 
 protocol SecureStoring {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/392891325557410/1204428395509442
iOS PR: n/a
macOS PR: n/a 
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL:
CC:

**Description**:

Adds ability to fetch devices registered for sync.  This is a none-breaking change so macOS and iOS PRs to follow.

Also extracted some common API functions into an extension. cc @samsymons 

**Steps to test this PR**:
1. Drop in to corresponding macOS branch
1. Open sync preferences 
2. Devices should load
3. Add extra device 
4. Re-open sync preferences
5. Devices should update
6. Drop into iOS develop branch, should compile and run.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
