### PR TITLE
Remove Origin when using Bitwarden

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -173,7 +173,9 @@ extension AutofillUserScript {
             self.id = id
             self.username = username
             self.credentialsProvider = credentialsProvider
-            self.origin = origin
+            // Bitwarden does not include URLs with Creds, so remove any origin we might have
+            // https://app.asana.com/0/0/1204431865163371/
+            self.origin = credentialsProvider == SecureVaultModels.CredentialsProvider.Name.bitwarden.rawValue ? nil : origin
         }
     }
     


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/0/1204431865163371/f

**Description**:
Remove any domains from Bitwarden provided credentials.  Since BW does not provide domains as part of their API response, we add the current domain by default, which causes issues with presentation on new TLD support.  (Duplicate 'From this website', even if you have logins from multiple subdomains.

<img width="359" alt="Screenshot 2023-04-21 at 3 14 59 PM" src="https://user-images.githubusercontent.com/1156669/233645193-38ef4f40-57c3-4c4c-b724-0fba150de0c7.png">

This removes the 'origin' param sent to the script, to fall back to pre-tld support style:

<img width="526" alt="Screenshot 2023-04-21 at 3 05 41 PM" src="https://user-images.githubusercontent.com/1156669/233644898-3c56456e-3b61-4878-be03-4e1696ce0078.png">

**Steps to test this PR**:
- Point your macOS app BSK to this branch
- Add a few logins to Bitwarden using the same parent domain TLD (ie. netflix.com, www.netflix.com, signin.netflix.com)
- Visit netflix.com and observe logins are presented as shown above.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
