### PR TITLE
sync remove device

### DIFF
--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -99,15 +99,15 @@ public class DDGSync: DDGSyncing {
             throw SyncError.accountNotFound
         }
         try await disconnect(deviceId: deviceId)
+        try dependencies.secureStore.removeAccount()
+        updateIsAuthenticated()
     }
 
     public func disconnect(deviceId: String) async throws {
         guard let token = try dependencies.secureStore.account()?.token else {
             throw SyncError.noToken
         }
-        try dependencies.secureStore.removeAccount()
         try await dependencies.account.logout(deviceId: deviceId, token: token)
-        updateIsAuthenticated()
     }
 
     public func fetchDevices() async throws -> [RegisteredDevice] {

--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -78,7 +78,11 @@ public class DDGSync: DDGSyncing {
             throw SyncError.accountNotFound
         }
 
-        try await dependencies.createRecoveryKeyTransmitter().send(connectCode)
+        do {
+            try await dependencies.createRecoveryKeyTransmitter().send(connectCode)
+        } catch {
+            try handleUnauthenticated(error)
+        }
     }
 
     public func sender() throws -> UpdatesSending {
@@ -98,8 +102,12 @@ public class DDGSync: DDGSyncing {
         guard let deviceId = try dependencies.secureStore.account()?.deviceId else {
             throw SyncError.accountNotFound
         }
-        try await disconnect(deviceId: deviceId)
-        try dependencies.secureStore.removeAccount()
+        do {
+            try await disconnect(deviceId: deviceId)
+            try dependencies.secureStore.removeAccount()
+        } catch {
+            try handleUnauthenticated(error)
+        }
         updateIsAuthenticated()
     }
 
@@ -107,7 +115,11 @@ public class DDGSync: DDGSyncing {
         guard let token = try dependencies.secureStore.account()?.token else {
             throw SyncError.noToken
         }
-        try await dependencies.account.logout(deviceId: deviceId, token: token)
+        do {
+            try await dependencies.account.logout(deviceId: deviceId, token: token)
+        } catch {
+            try handleUnauthenticated(error)
+        }
     }
 
     public func fetchDevices() async throws -> [RegisteredDevice] {
@@ -115,7 +127,13 @@ public class DDGSync: DDGSyncing {
             throw SyncError.accountNotFound
         }
 
-        return try await dependencies.account.fetchDevicesForAccount(account)
+        do {
+            return try await dependencies.account.fetchDevicesForAccount(account)
+        } catch {
+            try handleUnauthenticated(error)
+        }
+
+        return []
     }
 
     public func updateDeviceName(_ name: String) async throws -> [RegisteredDevice] {
@@ -123,9 +141,15 @@ public class DDGSync: DDGSyncing {
             throw SyncError.accountNotFound
         }
 
-        let result = try await dependencies.account.refreshToken(account, deviceName: name)
-        try dependencies.secureStore.persistAccount(result.account)
-        return result.devices
+        do {
+            let result = try await dependencies.account.refreshToken(account, deviceName: name)
+            try dependencies.secureStore.persistAccount(result.account)
+            return result.devices
+        } catch {
+            try handleUnauthenticated(error)
+        }
+
+        return []
     }
 
     // MARK: -
@@ -141,5 +165,22 @@ public class DDGSync: DDGSyncing {
 
     private func updateIsAuthenticated() {
         isAuthenticated = (try? dependencies.secureStore.account()?.token) != nil
+    }
+
+    private func handleUnauthenticated(_ error: Error) throws {
+        guard let syncError = error as? SyncError,
+              case .unexpectedStatusCode(let statusCode) = syncError,
+                statusCode == 401 else {
+            throw error
+        }
+
+        do {
+            try self.dependencies.secureStore.removeAccount()
+        } catch {
+            // We should probably log this, maybe fire a pixel
+            print(error)
+        }
+        updateIsAuthenticated()
+        return
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/392891325557410/1204383167189823
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

Fixes logic regarding disconnecting devices:

* The endpoint is called first, then local account is removed,

Also fixes a bug that would log out the current device when specifying a different device ID.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See https://github.com/duckduckgo/iOS/pull/1677
1. See https://github.com/duckduckgo/macos-browser/pull/1160

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
