### PR TITLE
fix bug in parsing recovery code to align with android

### DIFF
--- a/Sources/DDGSync/internal/RecoveryKeyTransmitter.swift
+++ b/Sources/DDGSync/internal/RecoveryKeyTransmitter.swift
@@ -36,7 +36,7 @@ struct RecoveryKeyTransmitter: RecoveryKeyTransmitting {
         }
 
         let recoveryKey = try JSONEncoder.snakeCaseKeys.encode(
-            SyncCode.RecoveryKey(userId: account.userId, primaryKey: account.primaryKey)
+            SyncCode(recovery: SyncCode.RecoveryKey(userId: account.userId, primaryKey: account.primaryKey))
         )
 
         let encryptedRecoveryKey = try crypter.seal(recoveryKey, secretKey: code.secretKey)

--- a/Sources/DDGSync/internal/RemoteConnector.swift
+++ b/Sources/DDGSync/internal/RemoteConnector.swift
@@ -69,10 +69,15 @@ class RemoteConnector: RemoteConnecting {
     }
 
     private func decryptEncryptedRecoveryKey(_ encryptedRecoveryKey: Data) throws -> SyncCode.RecoveryKey {
-        let recoveryKey = try crypter.unseal(encryptedData: encryptedRecoveryKey,
-                                             publicKey: connectInfo.publicKey,
-                                             secretKey: connectInfo.secretKey)
-        return try JSONDecoder.snakeCaseKeys.decode(SyncCode.RecoveryKey.self, from: recoveryKey)
+        let data = try crypter.unseal(encryptedData: encryptedRecoveryKey,
+                                      publicKey: connectInfo.publicKey,
+                                      secretKey: connectInfo.secretKey)
+
+        guard let recoveryKey = try JSONDecoder.snakeCaseKeys.decode(SyncCode.self, from: data).recovery else {
+            throw SyncError.failedToDecryptValue("Invalid recovery key in connect response")
+        }
+
+        return recoveryKey
     }
 
     private func fetchEncryptedRecoveryKey() async throws -> Data? {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL:  https://app.asana.com/0/0/1204488565514380/f
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC: @cmonfortep 

**Description**:

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Drag in to iOS or macOS code base
1. Perform "connect" flow for sync
2. Ideally test with Android device too, if available

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
