### PR TITLE
Update autofill to 6.5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
-        "version" : "6.4.3"
+        "revision" : "4648da359313c218ec130cc4f63364b095e2e064",
+        "version" : "6.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .library(name: "Navigation", targets: ["Navigation"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "6.4.3"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "6.5.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.1.1"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1204530982219497/f
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.0


## Description
Updates Autofill to version [6.5.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.0).

### Autofill 6.5.0 release notes
## What's Changed
* Improve debugging by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/293
* Reduce the calls on check position when there are many mutations by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/288
* Window release fetch tags before checkout by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/296
* Autofill compare generated test suites by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/283
* Update release scripts with latest Apple tooling by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/299
* Add temporary incontext_eligible pixel by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/304
* Fix double-click issue by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/306
* Fix a whole bunch of existing failing test cases by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/308

## New Contributors
* @greyivy made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/283

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.4.3...6.5.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).