### PR TITLE
Update autofill to 6.5.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "4648da359313c218ec130cc4f63364b095e2e064",
-        "version" : "6.5.0"
+        "revision" : "8f403fad4f6ccf18a3900fc560f43067a527ac9f",
+        "version" : "6.5.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .library(name: "Navigation", targets: ["Navigation"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "6.5.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "6.5.1"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.1.1"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204538113123465/1204538113123465
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.1


## Description
Updates Autofill to version [6.5.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.1).

### Autofill 6.5.1 release notes
## What's Changed
* Disable pixel for all platforms but extension by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/309
* Fix release script for BSK by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/310

Included in 6.5.0:
- Improve debugging by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/293
- Reduce the calls on check position when there are many mutations by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/288
- Window release fetch tags before checkout by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/296
- Autofill compare generated test suites by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/283
- Update release scripts with latest Apple tooling by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/299
- Add temporary incontext_eligible pixel by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/304
- Fix double-click issue by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/306
- Fix a whole bunch of existing failing test cases by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/308


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.5.0...6.5.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).