### PR TITLE
Make sure user agent is always provided in api requests

### DIFF
--- a/Sources/Configuration/ConfigurationFetching.swift
+++ b/Sources/Configuration/ConfigurationFetching.swift
@@ -131,7 +131,7 @@ public final class ConfigurationFetcher: ConfigurationFetching {
     
     private func fetch(from url: URL, withEtag etag: String?, requirements: APIResponseRequirements) async throws -> ConfigurationFetchResult {
         let configuration = APIRequest.Configuration(url: url,
-                                                     headers: APIRequest.Headers().default(with: etag),
+                                                     headers: APIRequest.Headers(etag: etag),
                                                      cachePolicy: .reloadIgnoringLocalCacheData)
         let log = log
         let request = APIRequest(configuration: configuration, requirements: requirements, urlSession: urlSession, log: log)

--- a/Sources/DDGSync/internal/RemoteAPIRequestCreator.swift
+++ b/Sources/DDGSync/internal/RemoteAPIRequestCreator.swift
@@ -26,19 +26,23 @@ struct RemoteAPIRequestCreator: RemoteAPIRequestCreating {
     public func createRequest(
         url: URL,
         method: HTTPRequestMethod,
-        headers: [String: String],
+        headers: HTTPHeaders,
         parameters: [String: String],
         body: Data?,
         contentType: String?
     ) -> HTTPRequesting {
 
-        var requestHeaders = APIRequest.Headers().default
-        requestHeaders.merge(headers, uniquingKeysWith: { $1 })
+        var requestHeaders = headers
         if let contentType {
             requestHeaders["Content-Type"] = contentType
         }
 
-        let configuration = APIRequest.Configuration(url: url, method: .init(method), queryParameters: parameters, headers: requestHeaders, body: body)
+        let headers = APIRequest.Headers(additionalHeaders: requestHeaders)
+        let configuration = APIRequest.Configuration(url: url,
+                                                     method: .init(method),
+                                                     queryParameters: parameters,
+                                                     headers: headers,
+                                                     body: body)
 
         return APIRequest(configuration: configuration)
     }

--- a/Sources/DDGSync/internal/RemoteConnector.swift
+++ b/Sources/DDGSync/internal/RemoteConnector.swift
@@ -83,11 +83,12 @@ class RemoteConnector: RemoteConnecting {
     private func fetchEncryptedRecoveryKey() async throws -> Data? {
         let url = endpoints.connect.appendingPathComponent(connectInfo.deviceID)
 
-        let request = api.createRequest(url: url, method: .GET,
-                              headers: [:],
-                              parameters: [:],
-                              body: nil,
-                              contentType: nil)
+        let request = api.createRequest(url: url,
+                                        method: .GET,
+                                        headers: [:],
+                                        parameters: [:],
+                                        body: nil,
+                                        contentType: nil)
 
         do {
             let result = try await request.execute()

--- a/Sources/Networking/APIRequestConfiguration.swift
+++ b/Sources/Networking/APIRequestConfiguration.swift
@@ -38,7 +38,7 @@ extension APIRequest {
                     method: HTTPMethod = .get,
                     queryParameters: QueryParams = [],
                     allowedQueryReservedCharacters: CharacterSet? = nil,
-                    headers: HTTPHeaders = APIRequest.Headers().default,
+                    headers: APIRequest.Headers = APIRequest.Headers(),
                     body: Data? = nil,
                     timeoutInterval: TimeInterval = 60.0,
                     attribution: URLRequestAttribution? = .developer,
@@ -47,7 +47,7 @@ extension APIRequest {
             self.method = method
             self.queryParameters = queryParameters
             self.allowedQueryReservedCharacters = allowedQueryReservedCharacters
-            self.headers = headers
+            self.headers = headers.httpHeaders
             self.body = body
             self.timeoutInterval = timeoutInterval
             self.attribution = attribution


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1204258831104817/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1706
macOS PR: 
What kind of version bump will this require?: Major

**Description**:
- fix assertion failure
- make APIRequest.Headers API more strict

**Steps to test this PR**:
1. Make sure both clients compile.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
