### PR TITLE
Update autofill to 6.6.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "8f403fad4f6ccf18a3900fc560f43067a527ac9f",
-        "version" : "6.5.1"
+        "revision" : "466e3695cdc7839dcd74c45acda8b471a3e68fd5",
+        "version" : "6.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .library(name: "Navigation", targets: ["Navigation"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "6.5.1"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "6.6.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.1.1"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204572551106233/1204572551106233
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.6.0


## Description
Updates Autofill to version [6.6.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.6.0).

### Autofill 6.6.0 release notes
## What's Changed
* Ema/fix release again by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/311
* Update Dax logo by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/312
* New subdomain matching rules by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/297
* Update release workflow by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/313


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.5.1...6.6.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).