### PR TITLE
adjust os_log parameter naming

### DIFF
--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -136,7 +136,8 @@ public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogTy
 }
 
 @inlinable
-public func os_log(message: @autoclosure () -> String, log: OSLog = .default, type: OSLogType = .default) {
+@_disfavoredOverload
+public func os_log(_ message: @autoclosure () -> String, log: OSLog = .default, type: OSLogType = .default) {
     guard log != .disabled else { return }
     os_log("%s", log: log, type: type, message())
 }
@@ -189,7 +190,8 @@ public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ messag
 }
 
 @inlinable
-public func os_log(_ type: OSLogType = .default, log: OSLog = .default, message: @autoclosure () -> String) {
+@_disfavoredOverload
+public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: @autoclosure () -> String) {
     guard log != .disabled else { return }
     os_log("%s", log: log, type: type, message())
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1204568880446357/f
iOS PR: not needed
macOS PR: not needed
What kind of version bump will this require?: not needed

**Description**:
- os_log with interpolated string `message` argument aligned to remove explicit argument name 
- added @_disfavoredOverload modifier to disambiguate StaticString vs. Interpolated String calls

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate that `os_log("some message")` calls os_log wrapper variant with StaticString argument
2. Validate `os_log("message with \(someArgument)")` works and calls the autoclosured argument only if log is not `.disabled`
