### PR TITLE
Support added for new remote message image

### DIFF
--- a/Sources/BrowserServicesKit/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/Sources/BrowserServicesKit/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -165,6 +165,8 @@ struct JsonToRemoteMessageModelMapper {
             return .ddgAnnounce
         case .criticalUpdate:
             return .criticalUpdate
+        case .macComputer:
+            return .macComputer
         case .none:
             return .announce
         }

--- a/Sources/BrowserServicesKit/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
+++ b/Sources/BrowserServicesKit/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
@@ -84,6 +84,7 @@ public enum RemoteMessageResponse {
         case ddgAnnounce = "DDGAnnounce"
         case criticalUpdate = "CriticalUpdate"
         case appUpdate = "AppUpdate"
+        case macComputer = "MacComputer"
     }
 
     public enum StatusError: Error {

--- a/Sources/BrowserServicesKit/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/Sources/BrowserServicesKit/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -126,4 +126,5 @@ public enum RemotePlaceholder: String, Codable {
     case ddgAnnounce = "RemoteMessageDDGAnnouncement"
     case criticalUpdate = "RemoteMessageCriticalAppUpdate"
     case appUpdate = "RemoteMessageAppUpdate"
+    case macComputer = "RemoteMessageMacComputer"
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1204559401135163/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1714 
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1194
What kind of version bump will this require?: Minor

**Description**:
Adds support for new MacComputer image

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Test steps are in the client PRs


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
