### PR TITLE
Adds a different hash Account per each macOS build kind

### DIFF
--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultCryptoProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultCryptoProvider.swift
@@ -43,7 +43,7 @@ final class DefaultCryptoProvider: SecureVaultCryptoProvider {
         #if os(iOS)
             static let hashAccount = "com.duckduckgo.mobile.ios"
         #else
-            static let hashAccount = "com.duckduckgo.macos.browser"
+            static let hashAccount = Bundle.main.bundleIdentifier ?? "com.duckduckgo.macos.browser"
         #endif
         static let hashService = "DuckDuckGo Privacy Browser"
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: N/A
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Major

**Description**:
Uses the bundle identifier to create a unique hash key for each build tupe.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the PR
2. You should have a password item in the keychain named `com.duckduckgo.macos.browser.debug`
 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
