### PR TITLE
Update autofill to 7.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "d1558f7757b26f64364dd23d02d235c113d558ae",
-        "version" : "7.1.0"
+        "revision" : "44cd844b6bb5d8ccfefbd6e025817d800c26ad76",
+        "version" : "7.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .library(name: "SyncDataProviders", targets: ["SyncDataProviders"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "7.1.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "7.2.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.1.1"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204742406448900/1204742406448900
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/7.2.0


## Description
Updates Autofill to version [7.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/7.2.0).

### Autofill 7.2.0 release notes
## What's Changed
* Fix Windows UI line bug by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/325
* Remove separator above Duck Address whenever it's first item by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/329
* macOS support for in-context signup by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/317
* Other minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/328


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/7.1.0...7.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).