### PR TITLE
Private Email Status, Activation & Deactivation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "260329ad8021115235d64ddd76c24629f93a7212",
-        "version" : "4.21.1"
+        "revision" : "1b5548805ed1d5af4bb6432ea23890797540fbdd",
+        "version" : "4.22.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "1b5548805ed1d5af4bb6432ea23890797540fbdd",
-        "version" : "4.22.1"
+        "revision" : "63f77323f119ac61fdb483f9c25f02d5d09f49ba",
+        "version" : "4.22.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.22.1"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.22.3"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "1.4.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.21.1"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.22.1"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "1.4.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
     ],

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesIdentifier.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesIdentifier.swift
@@ -23,12 +23,12 @@ public class ContentBlockerRulesIdentifier: Equatable, Codable {
     
     let name: String
     let tdsEtag: String
-    let tempListEtag: String
-    let allowListEtag: String
+    let tempListId: String
+    let allowListId: String
     let unprotectedSitesHash: String
     
     public var stringValue: String {
-        return name + tdsEtag + tempListEtag + unprotectedSitesHash
+        return name + tdsEtag + tempListId + allowListId + unprotectedSitesHash
     }
     
     public struct Difference: OptionSet {
@@ -39,11 +39,11 @@ public class ContentBlockerRulesIdentifier: Equatable, Codable {
         }
         
         public static let tdsEtag = Difference(rawValue: 1 << 0)
-        public static let tempListEtag = Difference(rawValue: 1 << 1)
-        public static let allowListEtag = Difference(rawValue: 1 << 2)
+        public static let tempListId = Difference(rawValue: 1 << 1)
+        public static let allowListId = Difference(rawValue: 1 << 2)
         public static let unprotectedSites = Difference(rawValue: 1 << 3)
         
-        public static let all: Difference = [.tdsEtag, .tempListEtag, .allowListEtag, .unprotectedSites]
+        public static let all: Difference = [.tdsEtag, .tempListId, .allowListId, .unprotectedSites]
     }
     
     private class func normalize(identifier: String?) -> String {
@@ -71,12 +71,12 @@ public class ContentBlockerRulesIdentifier: Equatable, Codable {
         return domains.joined().sha1
     }
     
-    public init(name: String, tdsEtag: String, tempListEtag: String?, allowListEtag: String?, unprotectedSitesHash: String?) {
+    public init(name: String, tdsEtag: String, tempListId: String?, allowListId: String?, unprotectedSitesHash: String?) {
         
         self.name = Self.normalize(identifier: name)
         self.tdsEtag = Self.normalize(identifier: tdsEtag)
-        self.tempListEtag = Self.normalize(identifier: tempListEtag)
-        self.allowListEtag = Self.normalize(identifier: allowListEtag)
+        self.tempListId = Self.normalize(identifier: tempListId)
+        self.allowListId = Self.normalize(identifier: allowListId)
         self.unprotectedSitesHash = Self.normalize(identifier: unprotectedSitesHash)
     }
     
@@ -86,11 +86,11 @@ public class ContentBlockerRulesIdentifier: Equatable, Codable {
         if tdsEtag != id.tdsEtag {
             result.insert(.tdsEtag)
         }
-        if tempListEtag != id.tempListEtag {
-            result.insert(.tempListEtag)
+        if tempListId != id.tempListId {
+            result.insert(.tempListId)
         }
-        if allowListEtag != id.allowListEtag {
-            result.insert(.allowListEtag)
+        if allowListId != id.allowListId {
+            result.insert(.allowListId)
         }
         if unprotectedSitesHash != id.unprotectedSitesHash {
             result.insert(.unprotectedSites)

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -345,8 +345,8 @@ public class ContentBlockerRulesManager: CompiledRuleListsSource {
             } else {
                 diff = result.model.rulesIdentifier.compare(with: ContentBlockerRulesIdentifier(name: task.rulesList.name,
                                                                                                 tdsEtag: "",
-                                                                                                tempListEtag: nil,
-                                                                                                allowListEtag: nil,
+                                                                                                tempListId: nil,
+                                                                                                allowListId: nil,
                                                                                                 unprotectedSitesHash: nil))
             }
 

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
@@ -33,9 +33,9 @@ public protocol ContentBlockerRulesListsSource {
  */
 public protocol ContentBlockerRulesExceptionsSource {
 
-    var tempListEtag: String { get }
+    var tempListId: String { get }
     var tempList: [String] { get }
-    var allowListEtag: String { get }
+    var allowListId: String { get }
     var allowList: [TrackerException] { get }
     var unprotectedSites: [String] { get }
 }
@@ -93,8 +93,8 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
         self.privacyConfigManager = privacyConfigManager
     }
 
-    public var tempListEtag: String {
-        return privacyConfigManager.privacyConfig.identifier
+    public var tempListId: String {
+        return ContentBlockerRulesIdentifier.hash(domains: tempList)
     }
 
     public var tempList: [String] {
@@ -104,12 +104,12 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
         return tempUnprotected
     }
 
-    public var allowListEtag: String {
-        return privacyConfigManager.privacyConfig.identifier
+    public var allowListId: String {
+        return privacyConfigManager.privacyConfig.trackerAllowlist.hash ?? privacyConfigManager.privacyConfig.identifier
     }
 
     public var allowList: [TrackerException] {
-        return Self.transform(allowList: privacyConfigManager.privacyConfig.trackerAllowlist)
+        return Self.transform(allowList: privacyConfigManager.privacyConfig.trackerAllowlist.entries)
     }
 
     public var unprotectedSites: [String] {

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSourceManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSourceManager.swift
@@ -43,8 +43,8 @@ public class ContentBlockerRulesSourceIdentifiers {
     public var rulesIdentifier: ContentBlockerRulesIdentifier {
         ContentBlockerRulesIdentifier(name: name,
                                       tdsEtag: tdsIdentifier,
-                                      tempListEtag: tempListIdentifier,
-                                      allowListEtag: allowListIdentifier,
+                                      tempListId: tempListIdentifier,
+                                      allowListId: allowListIdentifier,
                                       unprotectedSitesHash: unprotectedSitesIdentifier)
     }
 }
@@ -122,8 +122,8 @@ public class ContentBlockerRulesSourceManager {
         }
 
         // Fetch identifiers up-front
-        let tempListIdentifier = exceptionsSource.tempListEtag
-        let allowListIdentifier = exceptionsSource.allowListEtag
+        let tempListIdentifier = exceptionsSource.tempListId
+        let allowListIdentifier = exceptionsSource.allowListId
         let unprotectedSites = exceptionsSource.unprotectedSites
         let unprotectedSitesIdentifier = ContentBlockerRulesIdentifier.hash(domains: unprotectedSites)
 

--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/ContentBlockerRulesUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/ContentBlockerRulesUserScript.swift
@@ -206,7 +206,7 @@ open class ContentBlockerRulesUserScript: NSObject, UserScript {
         return ContentBlockerRulesUserScript.loadJS("contentblockerrules", from: Bundle.module, withReplacements: [
             "$TEMP_UNPROTECTED_DOMAINS$": remoteUnprotectedDomains,
             "$USER_UNPROTECTED_DOMAINS$": privacyConfiguration.userUnprotectedDomains.joined(separator: "\n"),
-            "$TRACKER_ALLOWLIST_ENTRIES$": TrackerAllowlistInjection.prepareForInjection(allowlist: privacyConfiguration.trackerAllowlist)
+            "$TRACKER_ALLOWLIST_ENTRIES$": TrackerAllowlistInjection.prepareForInjection(allowlist: privacyConfiguration.trackerAllowlist.entries)
         ])
     }
 }

--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/SurrogatesUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/SurrogatesUserScript.swift
@@ -190,7 +190,7 @@ open class SurrogatesUserScript: NSObject, UserScript {
             "$IS_DEBUG$": isDebugBuild ? "true" : "false",
             "$TEMP_UNPROTECTED_DOMAINS$": remoteUnprotectedDomains,
             "$USER_UNPROTECTED_DOMAINS$": privacyConfiguration.userUnprotectedDomains.joined(separator: "\n"),
-            "$TRACKER_ALLOWLIST_ENTRIES$": TrackerAllowlistInjection.prepareForInjection(allowlist: privacyConfiguration.trackerAllowlist),
+            "$TRACKER_ALLOWLIST_ENTRIES$": TrackerAllowlistInjection.prepareForInjection(allowlist: privacyConfiguration.trackerAllowlist.entries),
             "$TRACKER_DATA$": trackerData,
             "$SURROGATES$": createSurrogateFunctions(surrogates),
             "$BLOCKING_ENABLED$": privacyConfiguration.isEnabled(featureKey: .contentBlocking) ? "true" : "false"

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -126,7 +126,7 @@ public enum AliasRequestError: Error {
 
 public struct EmailUrls {
     struct Url {
-        static let emailAlias = "https://duckduckgo.com/api/email/addresses"        
+        static let emailAlias = "https://quack.duckduckgo.com/api/email/addresses"        
     }
 
     var emailAliasAPI: URL {

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -126,7 +126,7 @@ public enum AliasRequestError: Error {
 
 public struct EmailUrls {
     struct Url {
-        static let emailAlias = "https://quack.duckduckgo.com/api/email/addresses"        
+        static let emailAlias = "https://duckduckgo.com/api/email/addresses"        
     }
 
     var emailAliasAPI: URL {

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -113,6 +113,7 @@ public enum AliasRequestError: Error {
     case invalidResponse
     case userRefused
     case permissionDelegateNil
+    case invalidToken
 }
 
 public struct EmailUrls {
@@ -287,6 +288,10 @@ public class EmailManager {
         return alias + "@" + Self.emailDomain
     }
 
+    public func aliasFor(_ email: String) -> String {
+        return email.replacingOccurrences(of: "@" + Self.emailDomain, with: "")
+    }
+
     public func getAliasIfNeededAndConsume(timeoutInterval: TimeInterval = 4.0, completionHandler: @escaping AliasCompletion) {
         getAliasIfNeeded(timeoutInterval: timeoutInterval) { [weak self] newAlias, error in
             completionHandler(newAlias, error)
@@ -299,6 +304,24 @@ public class EmailManager {
     public func resetEmailProtectionInContextPrompt() {
         UserDefaults().setValue(nil, forKey: Self.inContextEmailSignupPromptDismissedPermanentlyAtKey)
     }
+    public func getStatusFor(email: String, timeoutInterval: TimeInterval = 4.0) async throws -> Bool {
+        do {
+            return try await fetchStatusFor(alias: aliasFor(email), timeoutInterval: timeoutInterval)
+        }
+        catch {
+            throw error
+        }
+    }
+
+    public func setStatusFor(email: String, active: Bool, timeoutInterval: TimeInterval = 4.0) async throws -> Bool {
+        do {
+            return try await setStatusFor(alias: aliasFor(email), active: active)
+        }
+        catch {
+            throw error
+        }
+    }
+
 }
 
 extension EmailManager: AutofillEmailDelegate {
@@ -431,9 +454,26 @@ private extension EmailManager {
 // MARK: - Alias Management
 
 private extension EmailManager {
-    
+
+    enum Constants {
+
+        enum RequestMethods {
+            static let put = "PUT"
+            static let post = "POST"
+        }
+
+        enum RequestParameters {
+            static let token = "token"
+            static let status = "active"
+        }
+    }
+
     struct EmailAliasResponse: Decodable {
         let address: String
+    }
+
+    struct EmailAliasStatusResponse: Decodable {
+        let active: Bool
     }
     
     typealias HTTPHeaders = [String: String]
@@ -512,7 +552,7 @@ private extension EmailManager {
             do {
                 let data = try await requestDelegate.emailManager(self,
                                                                   requested: aliasAPIURL,
-                                                                  method: "POST",
+                                                                  method: Constants.RequestMethods.post,
                                                                   headers: emailHeaders,
                                                                   parameters: [:],
                                                                   httpBody: nil,
@@ -535,6 +575,57 @@ private extension EmailManager {
                     completionHandler?(nil, error)
                 }
             }
+        }
+    }
+
+    func fetchStatusFor(alias: String, timeoutInterval: TimeInterval = 5.0) async throws -> Bool {
+        guard isSignedIn,
+              let requestDelegate else {
+            throw AliasRequestError.signedOut
+        }
+
+        let data: Data
+
+        do {
+            let requestBody: [String: Any] = ["address": alias]
+            let body = try JSONSerialization.data(withJSONObject: requestBody, options: [])
+            data = try await requestDelegate.emailManager(self,
+                                                          requested: aliasAPIURL,
+                                                          method: Constants.RequestMethods.post,
+                                                          headers: emailHeaders,
+                                                          parameters: [:],
+                                                          httpBody: body,
+                                                          timeoutInterval: timeoutInterval)
+            let response: EmailAliasStatusResponse = try JSONDecoder().decode(EmailAliasStatusResponse.self, from: data)
+            return response.active
+        } catch {
+            throw AliasRequestError.invalidResponse
+        }
+    }
+
+    func setStatusFor(alias: String, active: Bool, timeoutInterval: TimeInterval = 5.0) async throws -> Bool {
+        guard isSignedIn,
+              let requestDelegate else {
+            throw AliasRequestError.signedOut
+        }
+
+        guard let token else {
+            throw AliasRequestError.invalidToken
+        }
+
+        do {            
+            let url = aliasAPIURL.appendingPathComponent(alias)
+            let data = try await requestDelegate.emailManager(self,
+                                                              requested: url,
+                                                              method: Constants.RequestMethods.put,
+                                                              headers: emailHeaders,
+                                                              parameters: [Constants.RequestParameters.token: "\(token)", Constants.RequestParameters.status: "\(active)"],
+                                                              httpBody: nil,
+                                                              timeoutInterval: timeoutInterval)
+            let response: EmailAliasStatusResponse = try JSONDecoder().decode(EmailAliasStatusResponse.self, from: data)
+            return response.active
+        } catch {
+            throw AliasRequestError.invalidResponse
         }
     }
 

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -337,7 +337,7 @@ public class EmailManager {
         }
     }
 
-    public func setStatusFor(email: String, active: Bool, timeoutInterval: TimeInterval = 4.0) async throws -> Bool {
+    public func setStatusFor(email: String, active: Bool, timeoutInterval: TimeInterval = 4.0) async throws -> EmailAliasStatus {
         do {
             return try await setStatusFor(alias: aliasFor(email), active: active)
         }
@@ -637,7 +637,7 @@ private extension EmailManager {
         }
     }
 
-    func setStatusFor(alias: String, active: Bool, timeoutInterval: TimeInterval = 5.0) async throws -> Bool {
+    func setStatusFor(alias: String, active: Bool, timeoutInterval: TimeInterval = 5.0) async throws -> EmailAliasStatus {
         guard isSignedIn,
               let requestDelegate else {
             throw AliasRequestError.signedOut
@@ -657,9 +657,19 @@ private extension EmailManager {
                                                               httpBody: nil,
                                                               timeoutInterval: timeoutInterval)
             let response: EmailAliasStatusResponse = try JSONDecoder().decode(EmailAliasStatusResponse.self, from: data)
-            return response.active
-        } catch {
-            throw AliasRequestError.invalidResponse
+            return response.active ? .active : .inactive
+        } catch let error {
+            switch error {
+                case EmailManagerRequestDelegateError.serverError(let code):
+                    switch code {
+                        case 404:
+                            return .notFound
+                        default:
+                            return .error
+                    }
+                default:
+                    return .error
+            }
         }
     }
 

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -309,7 +309,7 @@ public class EmailManager {
     }
 
     public func isPrivateEmail(email: String) -> Bool {
-        if email != userEmail && email.hasSuffix(Self.emailDomain) {
+        if email != userEmail?.lowercased() && email.hasSuffix(Self.emailDomain) {
             return true
         }
         return false

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -126,7 +126,8 @@ public enum AliasRequestError: Error {
 
 public struct EmailUrls {
     struct Url {
-        static let emailAlias = "https://quack.duckduckgo.com/api/email/addresses"
+        //static let emailAlias = "https://quack.duckduckgo.com/api/email/addresses"
+        static let emailAlias = "https://quackdev.duckduckgo.com/api/email/addresses"
     }
 
     var emailAliasAPI: URL {
@@ -482,6 +483,7 @@ private extension EmailManager {
     enum Constants {
 
         enum RequestMethods {
+            static let get = "GET"
             static let put = "PUT"
             static let post = "POST"
         }
@@ -496,8 +498,27 @@ private extension EmailManager {
         let address: String
     }
 
+    // TODO: The API responds either true|false or 1|0 so we need to account for both scenarios
     struct EmailAliasStatusResponse: Decodable {
         let active: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case active
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let boolValue = try? container.decode(Bool.self, forKey: .active) {
+                // If the value is in the format { "active": true }
+                active = boolValue
+            } else if let intValue = try? container.decode(Int.self, forKey: .active) {
+                // If the value is in the format { "active": 1 }
+                active = (intValue != 0)
+            } else {
+                // If the value cannot be decoded as a Bool or Int
+                throw DecodingError.dataCorruptedError(forKey: .active, in: container, debugDescription: "Invalid value for 'active'")
+            }
+        }
     }
     
     typealias HTTPHeaders = [String: String]
@@ -611,14 +632,13 @@ private extension EmailManager {
         let data: Data
 
         do {
-            let requestBody: [String: Any] = ["address": alias]
-            let body = try JSONSerialization.data(withJSONObject: requestBody, options: [])
+            let url = aliasAPIURL.appendingPathComponent(alias)
             data = try await requestDelegate.emailManager(self,
-                                                          requested: aliasAPIURL,
-                                                          method: Constants.RequestMethods.post,
+                                                          requested: url,
+                                                          method: Constants.RequestMethods.get,
                                                           headers: emailHeaders,
                                                           parameters: [:],
-                                                          httpBody: body,
+                                                          httpBody: nil,
                                                           timeoutInterval: timeoutInterval)
             let response: EmailAliasStatusResponse = try JSONDecoder().decode(EmailAliasStatusResponse.self, from: data)
             return response.active ? .active : .inactive
@@ -643,17 +663,13 @@ private extension EmailManager {
             throw AliasRequestError.signedOut
         }
 
-        guard let token else {
-            throw AliasRequestError.invalidToken
-        }
-
-        do {            
+        do {
             let url = aliasAPIURL.appendingPathComponent(alias)
             let data = try await requestDelegate.emailManager(self,
                                                               requested: url,
                                                               method: Constants.RequestMethods.put,
                                                               headers: emailHeaders,
-                                                              parameters: [Constants.RequestParameters.token: "\(token)", Constants.RequestParameters.status: "\(active)"],
+                                                              parameters: [Constants.RequestParameters.status: "\(active)"],
                                                               httpBody: nil,
                                                               timeoutInterval: timeoutInterval)
             let response: EmailAliasStatusResponse = try JSONDecoder().decode(EmailAliasStatusResponse.self, from: data)

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -126,8 +126,7 @@ public enum AliasRequestError: Error {
 
 public struct EmailUrls {
     struct Url {
-        //static let emailAlias = "https://quack.duckduckgo.com/api/email/addresses"
-        static let emailAlias = "https://quackdev.duckduckgo.com/api/email/addresses"
+        static let emailAlias = "https://quack.duckduckgo.com/api/email/addresses"        
     }
 
     var emailAliasAPI: URL {
@@ -501,24 +500,6 @@ private extension EmailManager {
     // TODO: The API responds either true|false or 1|0 so we need to account for both scenarios
     struct EmailAliasStatusResponse: Decodable {
         let active: Bool
-
-        private enum CodingKeys: String, CodingKey {
-            case active
-        }
-
-        init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            if let boolValue = try? container.decode(Bool.self, forKey: .active) {
-                // If the value is in the format { "active": true }
-                active = boolValue
-            } else if let intValue = try? container.decode(Int.self, forKey: .active) {
-                // If the value is in the format { "active": 1 }
-                active = (intValue != 0)
-            } else {
-                // If the value cannot be decoded as a Bool or Int
-                throw DecodingError.dataCorruptedError(forKey: .active, in: container, debugDescription: "Invalid value for 'active'")
-            }
-        }
     }
     
     typealias HTTPHeaders = [String: String]

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -86,6 +86,8 @@ public protocol EmailManagerAliasPermissionDelegate: AnyObject {
 // swiftlint:disable function_parameter_count
 public protocol EmailManagerRequestDelegate: AnyObject {
 
+    var activeTask: URLSessionTask? { get set }
+
     func emailManager(_ emailManager: EmailManager,
                       requested url: URL,
                       method: String,
@@ -114,6 +116,7 @@ public enum AliasRequestError: Error {
     case userRefused
     case permissionDelegateNil
     case invalidToken
+    case notFound
 }
 
 public struct EmailUrls {
@@ -290,6 +293,13 @@ public class EmailManager {
 
     public func aliasFor(_ email: String) -> String {
         return email.replacingOccurrences(of: "@" + Self.emailDomain, with: "")
+    }
+
+    public func isPrivateEmail(email: String) -> Bool {
+        if email != userEmail && email.hasSuffix(Self.emailDomain) {
+            return true
+        }
+        return false
     }
 
     public func getAliasIfNeededAndConsume(timeoutInterval: TimeInterval = 4.0, completionHandler: @escaping AliasCompletion) {

--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -83,6 +83,11 @@ public protocol EmailManagerAliasPermissionDelegate: AnyObject {
 }
 // swiftlint:enable identifier_name
 
+public enum EmailManagerRequestDelegateError: Error {
+    case serverError(statusCode: Int)
+    case decodingError
+}
+
 // swiftlint:disable function_parameter_count
 public protocol EmailManagerRequestDelegate: AnyObject {
 
@@ -135,6 +140,14 @@ public typealias AliasCompletion = (String?, AliasRequestError?) -> Void
 public typealias UsernameAndAliasCompletion = (_ username: String?, _ alias: String?, AliasRequestError?) -> Void
 public typealias UserDataCompletion = (_ username: String?, _ alias: String?, _ token: String?, AliasRequestError?) -> Void
 
+public enum EmailAliasStatus {
+    case active
+    case inactive
+    case notFound
+    case error
+    case unknown
+}
+
 public class EmailManager {
     
     private static let emailDomain = "duck.com"
@@ -147,7 +160,7 @@ public class EmailManager {
     public enum NotificationParameter {
         public static let cohort = "cohort"
     }
-    
+
     private lazy var emailUrls = EmailUrls()
     private lazy var aliasAPIURL = emailUrls.emailAliasAPI
 
@@ -315,6 +328,7 @@ public class EmailManager {
         UserDefaults().setValue(nil, forKey: Self.inContextEmailSignupPromptDismissedPermanentlyAtKey)
     }
     public func getStatusFor(email: String, timeoutInterval: TimeInterval = 4.0) async throws -> Bool {
+    public func getStatusFor(email: String, timeoutInterval: TimeInterval = 4.0) async throws -> EmailAliasStatus {
         do {
             return try await fetchStatusFor(alias: aliasFor(email), timeoutInterval: timeoutInterval)
         }
@@ -588,7 +602,7 @@ private extension EmailManager {
         }
     }
 
-    func fetchStatusFor(alias: String, timeoutInterval: TimeInterval = 5.0) async throws -> Bool {
+    func fetchStatusFor(alias: String, timeoutInterval: TimeInterval = 5.0) async throws -> EmailAliasStatus {
         guard isSignedIn,
               let requestDelegate else {
             throw AliasRequestError.signedOut
@@ -607,9 +621,19 @@ private extension EmailManager {
                                                           httpBody: body,
                                                           timeoutInterval: timeoutInterval)
             let response: EmailAliasStatusResponse = try JSONDecoder().decode(EmailAliasStatusResponse.self, from: data)
-            return response.active
-        } catch {
-            throw AliasRequestError.invalidResponse
+            return response.active ? .active : .inactive
+        } catch let error {
+            switch error {
+                case EmailManagerRequestDelegateError.serverError(let code):
+                    switch code {
+                        case 404:
+                            return .notFound
+                        default:
+                            return .error
+                    }
+                default:
+                    return .error
+            }
         }
     }
 

--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -46,12 +46,8 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         return data.unprotectedTemporary.map { $0.domain }.normalizedDomainsForContentBlocking()
     }
 
-    public var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlistData {
-        switch data.trackerAllowlist.state {
-        case PrivacyConfigurationData.State.enabled: return data.trackerAllowlist.entries
-        case PrivacyConfigurationData.State.internal: return internalUserDecider.isInternalUser ? data.trackerAllowlist.entries : [:]
-        default: return [:]
-        }
+    public var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlist {
+        return data.trackerAllowlist
     }
     
     func parse(versionString: String) -> [Int] {

--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
@@ -35,7 +35,7 @@ public protocol PrivacyConfiguration {
     var tempUnprotectedDomains: [String] { get }
 
     /// Trackers that has been allow listed because of site breakage
-    var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlistData { get }
+    var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlist { get }
 
     func isEnabled(featureKey: PrivacyFeature, versionProvider: AppVersionProvider) -> Bool
 

--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
@@ -59,7 +59,7 @@ public struct PrivacyConfigurationData {
         if var featuresData = json[CodingKeys.features.rawValue] as? [String: Any] {
             var features = [FeatureName: PrivacyFeature]()
 
-            // Allowlist entry does not follow the ususal feature structure - procss it first
+            // Allowlist entry does not follow the usual feature structure - process it first
             if let allowlistEntry = featuresData[CodingKeys.trackerAllowlist.rawValue] as? [String: Any] {
                 if let allowlist = TrackerAllowlist(json: allowlistEntry) {
                     self.trackerAllowlist = allowlist
@@ -105,6 +105,7 @@ public struct PrivacyConfigurationData {
             case settings
             case features
             case minSupportedVersion
+            case hash
         }
 
         public struct Feature {
@@ -128,6 +129,7 @@ public struct PrivacyConfigurationData {
         public let settings: FeatureSettings
         public let features: Features
         public let minSupportedVersion: FeatureSupportedVersion?
+        public let hash: String?
 
         public init?(json: [String: Any]) {
             guard let state = json[CodingKeys.state.rawValue] as? String else { return nil }
@@ -149,14 +151,16 @@ public struct PrivacyConfigurationData {
             }
             self.features = features
             self.minSupportedVersion = json[CodingKeys.minSupportedVersion.rawValue] as? String
+            self.hash = json[CodingKeys.hash.rawValue] as? String
         }
 
-        public init(state: FeatureState, exceptions: [ExceptionEntry], settings: [String: Any] = [:], features: Features = [:], minSupportedVersion: String? = nil) {
+        public init(state: FeatureState, exceptions: [ExceptionEntry], settings: [String: Any] = [:], features: Features = [:], minSupportedVersion: String? = nil, hash: String? = nil) {
             self.state = state
             self.exceptions = exceptions
             self.settings = settings
             self.minSupportedVersion = minSupportedVersion
             self.features = features
+            self.hash = hash
         }
     }
 
@@ -173,12 +177,18 @@ public struct PrivacyConfigurationData {
             }
         }
 
-        public let entries: TrackerAllowlistData
+        public private(set) var entries: TrackerAllowlistData
 
         public override init?(json: [String: Any]) {
-            let settings = (json[PrivacyFeature.CodingKeys.settings.rawValue] as? [String: Any]) ?? [:]
+            self.entries = [:]
+            super.init(json: json)
+
+            guard self.state != State.disabled else { return }
 
             var entries = [String: [Entry]]()
+
+            let settings = (json[PrivacyFeature.CodingKeys.settings.rawValue] as? [String: Any]) ?? [:]
+
             if let trackers = settings["allowlistedTrackers"] as? [String: [String: [Any]]] {
                 for (trackerDomain, trackerRules) in trackers {
                     if let rules = trackerRules["rules"] as? [ [String: Any] ] {
@@ -192,8 +202,6 @@ public struct PrivacyConfigurationData {
             }
 
             self.entries = entries
-
-            super.init(json: json)
         }
 
         public init(entries: [String: [Entry]], state: FeatureState) {

--- a/Sources/BrowserServicesKit/ReferrerTrimming/ReferrerTrimming.swift
+++ b/Sources/BrowserServicesKit/ReferrerTrimming/ReferrerTrimming.swift
@@ -100,8 +100,10 @@ public class ReferrerTrimming {
             newReferrer = "\(referrerScheme)://\(referrerHost)/"
         }
 
-        if trackerData.findTracker(forUrl: destUrl.absoluteString) != nil && !isSameEntity(a: referEntity, b: destEntity) {
-            newReferrer = "\(referrerScheme)://\(tld.eTLDplus1(referrerHost) ?? referrerHost)/"
+        if let tracker = trackerData.findTracker(forUrl: destUrl.absoluteString),
+           tracker.defaultAction == .block,
+           !isSameEntity(a: referEntity, b: destEntity) {
+            newReferrer = "\(referrerScheme)://\(referrerHost)/"
         }
         
         if newReferrer == referrerUrl.absoluteString {

--- a/Sources/SyncDataProviders/Bookmarks/internal/Syncable+Bookmarks.swift
+++ b/Sources/SyncDataProviders/Bookmarks/internal/Syncable+Bookmarks.swift
@@ -23,6 +23,10 @@ import Foundation
 
 extension Syncable {
 
+    enum SyncableBookmarkError: Error {
+        case bookmarkEntityMissingUUID
+    }
+
     var uuid: String? {
         payload["id"] as? String
     }
@@ -53,7 +57,12 @@ extension Syncable {
 
     init(bookmark: BookmarkEntity, encryptedWith crypter: Crypting) throws {
         var payload: [String: Any] = [:]
-        payload["id"] = bookmark.uuid!
+        guard let uuid = bookmark.uuid else {
+            throw SyncableBookmarkError.bookmarkEntityMissingUUID
+        }
+
+        payload["id"] = uuid
+
         if bookmark.isPendingDeletion {
             payload["deleted"] = ""
         } else {

--- a/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionLogicTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionLogicTests.swift
@@ -32,8 +32,8 @@ final class MockAttributionRulesProvider: AdClickAttributionRulesProviding {
     init() async {
         globalAttributionRules = await ContentBlockingRulesHelper().makeFakeRules(name: Constants.globalAttributionRulesListName,
                                                                                   tdsEtag: "tdsEtag",
-                                                                                  tempListEtag: "tempEtag",
-                                                                                  allowListEtag: nil,
+                                                                                  tempListId: "tempEtag",
+                                                                                  allowListId: nil,
                                                                                   unprotectedSitesHash: nil)
         
         XCTAssertNotNil(globalAttributionRules)

--- a/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionRulesProviderTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionRulesProviderTests.swift
@@ -62,23 +62,23 @@ class AdClickAttributionRulesProviderTests: XCTestCase {
         
         compiledRulesSource.currentMainRules = await ContentBlockingRulesHelper().makeFakeRules(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                                                                 tdsEtag: "tdsEtag",
-                                                                                                tempListEtag: "tempEtag",
-                                                                                                allowListEtag: nil,
+                                                                                                tempListId: "tempEtag",
+                                                                                                allowListId: nil,
                                                                                                 unprotectedSitesHash: nil)
         
         let attributionName = AdClickAttributionRulesSplitter.blockingAttributionRuleListName(forListNamed: compiledRulesSource.currentMainRules!.name)
         compiledRulesSource.currentAttributionRules = await ContentBlockingRulesHelper().makeFakeRules(name: attributionName,
                                                                                                        tdsEtag: "tdsEtag",
-                                                                                                       tempListEtag: "tempEtag",
-                                                                                                       allowListEtag: nil,
+                                                                                                       tempListId: "tempEtag",
+                                                                                                       allowListId: nil,
                                                                                                        unprotectedSitesHash: nil)
         XCTAssertNotNil(compiledRulesSource.currentMainRules)
         XCTAssertNotNil(compiledRulesSource.currentAttributionRules)
         
         fakeNewRules = await ContentBlockingRulesHelper().makeFakeRules(name: compiledRulesSource.currentAttributionRules!.name,
                                                                         tdsEtag: "updatedEtag",
-                                                                        tempListEtag: "updatedEtag",
-                                                                        allowListEtag: nil,
+                                                                        tempListId: "updatedEtag",
+                                                                        allowListId: nil,
                                                                         unprotectedSitesHash: nil)
         let log: OSLog = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "Test", category: "DDG Test")
         provider = AdClickAttributionRulesProvider(config: feature,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerInitialCompilationTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerInitialCompilationTests.swift
@@ -74,8 +74,8 @@ final class ContentBlockerRulesManagerInitialCompilationTests: XCTestCase {
         let mockLastCompiledRulesStore = MockLastCompiledRulesStore()
         let identifier = ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                        tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                       tempListEtag: nil,
-                                                       allowListEtag: nil,
+                                                       tempListId: nil,
+                                                       allowListId: nil,
                                                        unprotectedSitesHash: nil)
         let cachedRules = MockLastCompiledRules(name: mockRulesSource.rukeListName,
                                                 trackerData: mockRulesSource.trackerData!.tds,
@@ -128,13 +128,13 @@ final class ContentBlockerRulesManagerInitialCompilationTests: XCTestCase {
         let mockLastCompiledRulesStore = MockLastCompiledRulesStore()
         let oldIdentifier = ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                           tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                          tempListEtag: nil,
-                                                          allowListEtag: nil,
+                                                          tempListId: nil,
+                                                          allowListId: nil,
                                                           unprotectedSitesHash: nil)
         let newIdentifier = ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                           tdsEtag: mockUpdatedRulesSource.trackerData?.etag ?? "\"\"",
-                                                          tempListEtag: nil,
-                                                          allowListEtag: nil,
+                                                          tempListId: nil,
+                                                          allowListId: nil,
                                                           unprotectedSitesHash: nil)
         let cachedRules = MockLastCompiledRules(name: mockRulesSource.rukeListName,
                                                 trackerData: mockRulesSource.trackerData!.tds,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
@@ -238,8 +238,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "",
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -287,8 +287,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -297,7 +297,7 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -320,8 +320,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -330,7 +330,7 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.invalidRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -356,8 +356,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -366,7 +366,7 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = invalidTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -390,13 +390,13 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier, mockExceptionsSource.tempListEtag)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier, mockExceptionsSource.tempListId)
 
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -405,7 +405,7 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         mockExceptionsSource.unprotectedSites = ["example.com"]
         
@@ -432,8 +432,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: mockExceptionsSource.unprotectedSitesHash))
     }
 
@@ -442,9 +442,9 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = validAllowList
         mockExceptionsSource.unprotectedSites = ["example.com"]
 
@@ -473,8 +473,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: mockExceptionsSource.allowListEtag,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: mockExceptionsSource.allowListId,
                                                      unprotectedSitesHash: mockExceptionsSource.unprotectedSitesHash))
     }
 
@@ -483,9 +483,9 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = invalidAllowList
         mockExceptionsSource.unprotectedSites = ["example.com"]
 
@@ -510,15 +510,15 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
 
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier, mockExceptionsSource.allowListEtag)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier, mockExceptionsSource.allowListId)
 
         XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
 
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: mockExceptionsSource.unprotectedSitesHash))
     }
     
@@ -527,9 +527,9 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = validAllowList
         mockExceptionsSource.unprotectedSites = ["broken site Ltd. . 😉.com"]
         
@@ -584,11 +584,11 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier,
-                       mockExceptionsSource.tempListEtag)
+                       mockExceptionsSource.tempListId)
 
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier,
-                       mockExceptionsSource.allowListEtag)
+                       mockExceptionsSource.allowListId)
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier,
@@ -597,8 +597,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -607,9 +607,9 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.fakeEmbeddedDataSet,
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = validAllowList
         mockExceptionsSource.unprotectedSites = ["broken site Ltd. . 😉.com"]
         
@@ -660,11 +660,11 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier,
-                       mockExceptionsSource.tempListEtag)
+                       mockExceptionsSource.tempListId)
 
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier,
-                       mockExceptionsSource.allowListEtag)
+                       mockExceptionsSource.allowListId)
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier,
@@ -673,8 +673,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
 }
@@ -688,7 +688,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.invalidRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -707,8 +707,8 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
         
         mockRulesSource.trackerData = Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag())
@@ -727,15 +727,15 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier.stringValue,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil).stringValue)
         
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
             let diff = oldId.compare(with: newId)
             
             XCTAssert(diff.contains(.tdsEtag))
-            XCTAssertFalse(diff.contains(.tempListEtag))
+            XCTAssertFalse(diff.contains(.tempListId))
             XCTAssertFalse(diff.contains(.unprotectedSites))
         } else {
             XCTFail("Missing identifiers")
@@ -747,7 +747,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = invalidTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -766,11 +766,11 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
         
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         
         let identifier = cbrm.currentRules.first?.identifier
@@ -787,15 +787,15 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
         
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
             let diff = oldId.compare(with: newId)
             
             XCTAssert(diff.contains(.tdsEtag))
-            XCTAssert(diff.contains(.tempListEtag))
+            XCTAssert(diff.contains(.tempListId))
             XCTAssertFalse(diff.contains(.unprotectedSites))
         } else {
             XCTFail("Missing identifiers")
@@ -807,7 +807,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = invalidAllowList
 
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -826,11 +826,11 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
 
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = validAllowList
 
         let identifier = cbrm.currentRules.first?.identifier
@@ -847,15 +847,15 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: nil,
-                                                     allowListEtag: mockExceptionsSource.allowListEtag,
+                                                     tempListId: nil,
+                                                     allowListId: mockExceptionsSource.allowListId,
                                                      unprotectedSitesHash: nil))
 
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
             let diff = oldId.compare(with: newId)
 
             XCTAssert(diff.contains(.tdsEtag))
-            XCTAssert(diff.contains(.allowListEtag))
+            XCTAssert(diff.contains(.allowListId))
             XCTAssertFalse(diff.contains(.unprotectedSites))
         } else {
             XCTFail("Missing identifiers")
@@ -867,7 +867,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         mockExceptionsSource.unprotectedSites = ["broken site Ltd. . 😉.com"]
         
@@ -887,8 +887,8 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
         
         mockExceptionsSource.unprotectedSites = ["example.com"]
@@ -907,15 +907,15 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: mockExceptionsSource.unprotectedSitesHash))
         
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
             let diff = oldId.compare(with: newId)
             
             XCTAssert(diff.contains(.tdsEtag))
-            XCTAssert(diff.contains(.tempListEtag))
+            XCTAssert(diff.contains(.tempListId))
             XCTAssert(diff.contains(.unprotectedSites))
         } else {
             XCTFail("Missing identifiers")
@@ -927,7 +927,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         mockExceptionsSource.unprotectedSites = ["broken site Ltd. . 😉.com"]
 
@@ -947,11 +947,11 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil, allowListEtag: nil,
+                                                     tempListId: nil, allowListId: nil,
                                                      unprotectedSitesHash: nil))
 
         // New etag (testing update)
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
 
         let identifier = cbrm.currentRules.first?.identifier
 
@@ -967,8 +967,8 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
 
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
@@ -1142,9 +1142,9 @@ class MockSimpleContentBlockerRulesListsSource: ContentBlockerRulesListsSource {
 
 class MockContentBlockerRulesExceptionsSource: ContentBlockerRulesExceptionsSource {
 
-    var tempListEtag: String = ""
+    var tempListId: String = ""
     var tempList: [String] = []
-    var allowListEtag: String = ""
+    var allowListId: String = ""
     var allowList: [TrackerException] = []
     var unprotectedSites: [String] = []
     

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesUserScriptsTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesUserScriptsTests.swift
@@ -104,7 +104,7 @@ class ContentBlockerRulesUserScriptsTests: XCTestCase {
         var tempUnprotected = privacyConfig.tempUnprotectedDomains.filter { !$0.trimmingWhitespace().isEmpty }
         tempUnprotected.append(contentsOf: privacyConfig.exceptionsList(forFeature: .contentBlocking))
 
-        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist)
+        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist.entries)
 
         WebKitTestHelper.prepareContentBlockingRules(trackerData: trackerData,
                                                      exceptions: privacyConfig.userUnprotectedDomains,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockingRulesHelper.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockingRulesHelper.swift
@@ -52,14 +52,14 @@ final class ContentBlockingRulesHelper {
     
     func makeFakeRules(name: String,
                        tdsEtag: String,
-                       tempListEtag: String? = nil,
-                       allowListEtag: String? = nil,
+                       tempListId: String? = nil,
+                       allowListId: String? = nil,
                        unprotectedSitesHash: String? = nil) async -> ContentBlockerRulesManager.Rules? {
         
         let identifier = ContentBlockerRulesIdentifier(name: name,
                                                        tdsEtag: tdsEtag,
-                                                       tempListEtag: tempListEtag,
-                                                       allowListEtag: allowListEtag,
+                                                       tempListId: tempListId,
+                                                       allowListId: allowListId,
                                                        unprotectedSitesHash: unprotectedSitesHash)
         let tds = makeFakeTDS()
         

--- a/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesReferenceTests.swift
@@ -187,7 +187,7 @@ final class SurrogatesReferenceTests: XCTestCase {
         var tempUnprotected = privacyConfig.tempUnprotectedDomains.filter { !$0.trimmingWhitespace().isEmpty }
         tempUnprotected.append(contentsOf: privacyConfig.exceptionsList(forFeature: .contentBlocking))
         
-        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist)
+        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist.entries)
         
         WebKitTestHelper.prepareContentBlockingRules(trackerData: trackerData,
                                                      exceptions: privacyConfig.userUnprotectedDomains,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesUserScriptTests.swift
@@ -141,7 +141,7 @@ class SurrogatesUserScriptsTests: XCTestCase {
         var tempUnprotected = privacyConfig.tempUnprotectedDomains.filter { !$0.trimmingWhitespace().isEmpty }
         tempUnprotected.append(contentsOf: privacyConfig.exceptionsList(forFeature: .contentBlocking))
 
-        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist)
+        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist.entries)
 
         WebKitTestHelper.prepareContentBlockingRules(trackerData: trackerData,
                                                      exceptions: privacyConfig.userUnprotectedDomains,

--- a/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
@@ -32,7 +32,7 @@ var events = [EmailManagerTestEvent]()
 
 // swiftlint:disable type_body_length
 class EmailManagerTests: XCTestCase {
-    
+
     func getAutofillScript() -> AutofillUserScript {
         let embeddedConfig =
         """
@@ -82,12 +82,12 @@ class EmailManagerTests: XCTestCase {
     func testWhenSignOutThenDeletesAllStorage() {
         let storage = MockEmailManagerStorage()
         let emailManager = EmailManager(storage: storage)
-        
+
         let expect = expectation(description: "test")
         storage.deleteAuthenticationStateCallback = {
             expect.fulfill()
         }
-        
+
         emailManager.signOut()
         waitForExpectations(timeout: 1.0, handler: nil)
     }
@@ -97,7 +97,7 @@ class EmailManagerTests: XCTestCase {
         let emailManager = EmailManager(storage: storage)
         storage.mockUsername = "username"
         storage.mockToken = "token"
-        
+
         let userScript = getAutofillScript()
         var status = emailManager.autofillUserScriptDidRequestSignedInStatus(userScript)
         XCTAssertTrue(status)
@@ -113,7 +113,7 @@ class EmailManagerTests: XCTestCase {
     }
 
     func testWhenCallingGetAliasEmailWithAliasStoredThenAliasReturnedAndNewAliasFetched() {
-        
+
         let expect = expectation(description: "test")
         let storage = storageForGetAliasTest(signedIn: true, storedAlias: true, fulfillOnFirstStorageEvent: true, expectationToFulfill: expect)
         let emailManager = EmailManager(storage: storage)
@@ -122,7 +122,7 @@ class EmailManagerTests: XCTestCase {
         emailManager.requestDelegate = requestDelegate
 
         events.removeAll()
-        
+
         // When an alias is stored
         // should call completion with stored alias
         // then delete alias
@@ -134,19 +134,19 @@ class EmailManagerTests: XCTestCase {
             .aliasRequestMade,
             .storeAliasCalled
         ]
-                
+
         emailManager.getAliasIfNeededAndConsume { alias, _ in
             XCTAssertEqual(alias, "testAlias1")
             events.append(.getAliasCallbackCalled)
         }
-        
+
         waitForExpectations(timeout: 1.0) { _ in
             XCTAssertEqual(events, expectedEvents)
         }
     }
-    
+
     func testWhenCallingGetAliasEmailWithNoAliasStoredThenAliasFetchedAndNewAliasFetched() {
-        
+
         let expect = expectation(description: "test")
         let storage = storageForGetAliasTest(signedIn: true, storedAlias: false, fulfillOnFirstStorageEvent: false, expectationToFulfill: expect)
         let emailManager = EmailManager(storage: storage)
@@ -155,13 +155,13 @@ class EmailManagerTests: XCTestCase {
         emailManager.requestDelegate = requestDelegate
 
         events.removeAll()
-        
+
         // Test when no alias is stored
         // should make a request
         // call the callback
         // make a new request
         // and store the new alias
-        
+
         let expectedEvents: [EmailManagerTestEvent] = [
             .aliasRequestMade,
             .storeAliasCalled,
@@ -170,17 +170,17 @@ class EmailManagerTests: XCTestCase {
             .aliasRequestMade,
             .storeAliasCalled
         ]
-        
+
         emailManager.getAliasIfNeededAndConsume { alias, _ in
             XCTAssertEqual(alias, "testAlias2")
             events.append(.getAliasCallbackCalled)
         }
-        
+
         waitForExpectations(timeout: 1.0) { _ in
             XCTAssertEqual(events, expectedEvents)
         }
     }
-    
+
     func testWhenCallingGetAliasWhenSignedOutThenNoAliasReturned() {
         let expect = expectation(description: "test")
         let storage = storageForGetAliasTest(signedIn: false, storedAlias: false, fulfillOnFirstStorageEvent: false, expectationToFulfill: expect)
@@ -194,19 +194,19 @@ class EmailManagerTests: XCTestCase {
         let expectedEvents: [EmailManagerTestEvent] = [
             .getAliasCallbackCalled
         ]
-        
+
         emailManager.getAliasIfNeededAndConsume { alias, error in
             XCTAssertNil(alias)
             XCTAssertEqual(error, .signedOut)
             events.append(.getAliasCallbackCalled)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 1.0) { _ in
             XCTAssertEqual(events, expectedEvents)
         }
     }
-    
+
     func testWhenStoreTokenThenRequestForAliasMade() {
         let expect = expectation(description: "test")
         let storage = storageForGetAliasTest(signedIn: true, storedAlias: false, fulfillOnFirstStorageEvent: true, expectationToFulfill: expect)
@@ -214,7 +214,7 @@ class EmailManagerTests: XCTestCase {
         let requestDelegate = MockEmailManagerRequestDelegate()
         requestDelegate.mockAliases = ["testAlias2", "testAlias3"]
         emailManager.requestDelegate = requestDelegate
-        
+
         events.removeAll()
 
         let expectedEvents: [EmailManagerTestEvent] = [
@@ -222,11 +222,11 @@ class EmailManagerTests: XCTestCase {
             .aliasRequestMade,
             .storeAliasCalled
         ]
-        
+
         let userScript = getAutofillScript()
-        
+
         emailManager.autofillUserScript(userScript, didRequestStoreToken: "token", username: "username", cohort: "internal_beta")
-        
+
         waitForExpectations(timeout: 1.0) { _ in
             XCTAssertEqual(events, expectedEvents)
         }
@@ -246,7 +246,7 @@ class EmailManagerTests: XCTestCase {
             .aliasRequestMade,
             .storeAliasCalled
         ]
-        
+
         let userScript = getAutofillScript()
 
         emailManager.autofillUserScriptDidRequestUsernameAndAlias(userScript) { username, alias, error in
@@ -290,64 +290,30 @@ class EmailManagerTests: XCTestCase {
         }
     }
 
-    func testWhenRequestingEmailStatusThenStatusIsReturned() async {
-        let storage = storageForGetAliasTest(signedIn: true, storedAlias: false, fulfillOnFirstStorageEvent: true)
-        storage.mockToken = "token"
-        let emailManager = EmailManager(storage: storage)
-        let requestDelegate = MockEmailManagerRequestDelegate()
-        emailManager.requestDelegate = requestDelegate
-
-        do {
-            let response = try await emailManager.getStatusFor(email: "xtwx7744@duck.com")
-            XCTAssertEqual(response, .active)
-        }
-        catch {
-            XCTFail("Status should be returned")
-        }
-
-
-    }
-
-    func testWhenChangingEmailStatusThenStatusIsReturned() async {
-        let storage = storageForGetAliasTest(signedIn: true, storedAlias: false, fulfillOnFirstStorageEvent: true)
-        storage.mockToken = "token"
-        let emailManager = EmailManager(storage: storage)
-        let requestDelegate = MockEmailManagerRequestDelegate()
-        emailManager.requestDelegate = requestDelegate
-
-        do {
-            let response = try await emailManager.setStatusFor(email: "xtwx7744@duck.com", active: false)
-            XCTAssertEqual(response, .active)
-        }
-        catch {
-            XCTFail("Status should be returned")
-        }
-    }
-
     private func storageForGetAliasTest(signedIn: Bool,
                                         storedAlias: Bool,
                                         fulfillOnFirstStorageEvent: Bool,
-                                        expectationToFulfill: XCTestExpectation? = nil) -> MockEmailManagerStorage {
-        
+                                        expectationToFulfill: XCTestExpectation) -> MockEmailManagerStorage {
+
         let storage = MockEmailManagerStorage()
 
         if signedIn {
             storage.mockUsername = "username"
             storage.mockToken = "testToken"
         }
-        
+
         if storedAlias {
             storage.mockAlias = "testAlias1"
         }
-        
+
         storage.deleteAliasCallback = {
             events.append(.deleteAliasCalled)
         }
-        
+
         storage.storeTokenCallback = { _, _, _ in
             events.append(.storeTokenCalled)
         }
-                        
+
         var isFirstStorage = true
         storage.storeAliasCallback = { alias in
             events.append(.storeAliasCalled)
@@ -355,11 +321,11 @@ class EmailManagerTests: XCTestCase {
                 XCTAssertEqual(alias, "testAlias2")
                 isFirstStorage = false
                 if fulfillOnFirstStorageEvent {
-                    expectationToFulfill?.fulfill()
+                    expectationToFulfill.fulfill()
                 }
             } else {
                 XCTAssertEqual(alias, "testAlias3")
-                expectationToFulfill?.fulfill()
+                expectationToFulfill.fulfill()
             }
         }
 
@@ -391,14 +357,14 @@ class EmailManagerTests: XCTestCase {
 
         wait(for: [dateStoredExpectation], timeout: 1.0)
     }
-    
+
     func testWhenGettingUsername_AndKeychainAccessFails_ThenRequestDelegateIsCalled() {
         let username = "dax"
         let storage = MockEmailManagerStorage()
         storage.mockError = .keychainLookupFailure(errSecInternalError)
         storage.mockUsername = username
         let emailManager = EmailManager(storage: storage)
-        
+
         let requestDelegate = MockEmailManagerRequestDelegate()
         emailManager.requestDelegate = requestDelegate
 
@@ -406,43 +372,26 @@ class EmailManagerTests: XCTestCase {
         XCTAssertEqual(requestDelegate.keychainAccessErrorAccessType, .getUsername)
         XCTAssertEqual(requestDelegate.keychainAccessError, .keychainLookupFailure(errSecInternalError))
     }
-    
+
 }
 
 class MockEmailManagerRequestDelegate: EmailManagerRequestDelegate {
     var activeTask: URLSessionTask?
     var mockAliases: [String] = []
     var waitlistTimestamp: Int = 1
-    
+
     // swiftlint:disable function_parameter_count
     func emailManager(_ emailManager: EmailManager, requested url: URL, method: String, headers: [String: String], parameters: [String: String]?, httpBody: Data?, timeoutInterval: TimeInterval) async throws -> Data {
-
-        enum MockedAction: String {
-            case fetch
-            case status
-            case update
-        }
-        var action: MockedAction
-        if method == "PUT" {
-            action = .update
-        }
-        else {
-            // API uses POST for both Create and Status Fetch so look for the body
-            action = httpBody != nil ? .status : .fetch
-        }
-
-        switch action {
-            case .fetch: return try processMockAliasRequest().get()
-            case .status, .update: return try processMockAliasStatusRequest().get()
+        switch url.absoluteString {
+            case EmailUrls.Url.emailAlias: return try processMockAliasRequest().get()
+            default: fatalError("\(#file): Unsupported URL passed to mock request delegate: \(url)")
         }
     }
     // swiftlint:enable function_parameter_count
 
-
-    
     var keychainAccessErrorAccessType: EmailKeychainAccessType?
     var keychainAccessError: EmailKeychainAccessError?
-    
+
     func emailManagerKeychainAccessFailed(accessType: EmailKeychainAccessType, error: EmailKeychainAccessError) {
         keychainAccessErrorAccessType = accessType
         keychainAccessError = error
@@ -461,18 +410,12 @@ class MockEmailManagerRequestDelegate: EmailManagerRequestDelegate {
         }
     }
 
-    private func processMockAliasStatusRequest() -> Result<Data, Error> {
-        let jsonString = "{\"active\": true}"
-        let data = jsonString.data(using: .utf8)!
-        return .success(data)
-    }
-    
 }
 
 class MockEmailManagerStorage: EmailManagerStorage {
 
     var mockError: EmailKeychainAccessError?
-    
+
     var mockUsername: String?
     var mockToken: String?
     var mockAlias: String?
@@ -485,17 +428,17 @@ class MockEmailManagerStorage: EmailManagerStorage {
     var deleteAliasCallback: (() -> Void)?
     var deleteAuthenticationStateCallback: (() -> Void)?
     var deleteWaitlistStateCallback: (() -> Void)?
-    
+
     func getUsername() throws -> String? {
         if let mockError = mockError { throw mockError }
         return mockUsername
     }
-    
+
     func getToken() throws -> String? {
         if let mockError = mockError { throw mockError }
         return mockToken
     }
-    
+
     func getAlias() throws -> String? {
         if let mockError = mockError { throw mockError }
         return mockAlias
@@ -514,7 +457,7 @@ class MockEmailManagerStorage: EmailManagerStorage {
     func store(token: String, username: String, cohort: String?) throws {
         storeTokenCallback?(token, username, cohort)
     }
-    
+
     func store(alias: String) throws {
         storeAliasCallback?(alias)
     }
@@ -522,11 +465,11 @@ class MockEmailManagerStorage: EmailManagerStorage {
     func store(lastUseDate: String) throws {
         storeLastUseDateCallback?(lastUseDate)
     }
-    
+
     func deleteAlias() {
         deleteAliasCallback?()
     }
-    
+
     func deleteAuthenticationState() {
         deleteAuthenticationStateCallback?()
     }

--- a/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
@@ -299,7 +299,7 @@ class EmailManagerTests: XCTestCase {
 
         do {
             let response = try await emailManager.getStatusFor(email: "xtwx7744@duck.com")
-            XCTAssertTrue(response)
+            XCTAssertEqual(response, .active)
         }
         catch {
             XCTFail("Status should be returned")
@@ -317,7 +317,7 @@ class EmailManagerTests: XCTestCase {
 
         do {
             let response = try await emailManager.setStatusFor(email: "xtwx7744@duck.com", active: false)
-            XCTAssertTrue(response)
+            XCTAssertEqual(response, .active)
         }
         catch {
             XCTFail("Status should be returned")
@@ -410,7 +410,7 @@ class EmailManagerTests: XCTestCase {
 }
 
 class MockEmailManagerRequestDelegate: EmailManagerRequestDelegate {
-
+    var activeTask: URLSessionTask?
     var mockAliases: [String] = []
     var waitlistTimestamp: Int = 1
     
@@ -433,8 +433,7 @@ class MockEmailManagerRequestDelegate: EmailManagerRequestDelegate {
 
         switch action {
             case .fetch: return try processMockAliasRequest().get()
-            case .status, .update: return try processMockAliasStatusRequest().get()            
-            default: return Data()
+            case .status, .update: return try processMockAliasStatusRequest().get()
         }
     }
     // swiftlint:enable function_parameter_count

--- a/Tests/BrowserServicesKitTests/LinkProtection/ContentBlockerManagerMock.swift
+++ b/Tests/BrowserServicesKitTests/LinkProtection/ContentBlockerManagerMock.swift
@@ -26,9 +26,9 @@ struct ContentBlockerRulesListSourceMock: ContentBlockerRulesListsSource {
 }
 
 struct ContentBlockerRulesExceptionsSourceMock: ContentBlockerRulesExceptionsSource {
-    var tempListEtag: String = ""
+    var tempListId: String = ""
     var tempList: [String] = []
-    var allowListEtag: String = ""
+    var allowListId: String = ""
     var allowList: [TrackerException] = []
     var unprotectedSites: [String] = []
 }

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
@@ -579,8 +579,8 @@ class AppPrivacyConfigurationTests: XCTestCase {
             """.data(using: .utf8)!
     }
 
-    func testTrackerAllowlistIsAlwaysEmptyWhenDisabled() {
-        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: "disabled"), etag: "test")
+    func testTrackerAllowlistIsNotEmptyWhenEnabled() {
+        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: PrivacyConfigurationData.State.enabled), etag: "test")
         let mockInternalUserStore = MockInternalUserStoring()
 
         let manager = PrivacyConfigurationManager(fetchedETag: nil,
@@ -590,14 +590,11 @@ class AppPrivacyConfigurationTests: XCTestCase {
                                                   internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStore))
         let config = manager.privacyConfig
 
-        mockInternalUserStore.isInternalUser = true
-        XCTAssertTrue(config.trackerAllowlist.isEmpty)
-        mockInternalUserStore.isInternalUser = false
-        XCTAssertTrue(config.trackerAllowlist.isEmpty)
+        XCTAssertFalse(config.trackerAllowlist.entries.isEmpty)
     }
 
-    func testTrackerAllowlistIsEmptyForNonInternalUsersWhenInternal() {
-        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: "internal"), etag: "test")
+    func testTrackerAllowlistIsEmptyWhenDisabled() {
+        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: PrivacyConfigurationData.State.disabled), etag: "test")
         let mockInternalUserStore = MockInternalUserStoring()
 
         let manager = PrivacyConfigurationManager(fetchedETag: nil,
@@ -607,27 +604,7 @@ class AppPrivacyConfigurationTests: XCTestCase {
                                                   internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStore))
         let config = manager.privacyConfig
 
-        mockInternalUserStore.isInternalUser = true
-        XCTAssertFalse(config.trackerAllowlist.isEmpty)
-        mockInternalUserStore.isInternalUser = false
-        XCTAssertTrue(config.trackerAllowlist.isEmpty)
-    }
-
-    func testTrackerAllowlistIsNeverEmptyWhenEnabled() {
-        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: "enabled"), etag: "test")
-        let mockInternalUserStore = MockInternalUserStoring()
-
-        let manager = PrivacyConfigurationManager(fetchedETag: nil,
-                                                  fetchedData: nil,
-                                                  embeddedDataProvider: mockEmbeddedData,
-                                                  localProtection: MockDomainsProtectionStore(),
-                                                  internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStore))
-        let config = manager.privacyConfig
-
-        mockInternalUserStore.isInternalUser = true
-        XCTAssertFalse(config.trackerAllowlist.isEmpty)
-        mockInternalUserStore.isInternalUser = false
-        XCTAssertFalse(config.trackerAllowlist.isEmpty)
+        XCTAssert(config.trackerAllowlist.entries.isEmpty)
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1204615490114675/f
iOS PR:  N/A
macOS PR:  https://github.com/duckduckgo/macos-browser/pull/1297
What kind of version bump will this require?: Minor

**Description**:
This PR includes the macOS changes to manage Private Email addresses, and adds methods to fetch and activate/deactivate private emails.   

👁️  There is no iOS PR attached as this is targeting our BSK integration branch.   iOS Changes will come next.

**Steps to test this PR**:
1. New methods have tests so check CI is 🥬
2. See macOS PR for testing

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
