### PR TITLE
Fixes the format in a log call

### DIFF
--- a/Sources/Bookmarks/BookmarksDatabaseCleaner.swift
+++ b/Sources/Bookmarks/BookmarksDatabaseCleaner.swift
@@ -84,7 +84,7 @@ public final class BookmarkDatabaseCleaner {
 
                 do {
                     try context.save()
-                    os_log(.debug, log: log, "Successfully purged %{public}s bookmarks", bookmarksPendingDeletion.count)
+                    os_log(.debug, log: log, "Successfully purged %{public}d bookmarks", bookmarksPendingDeletion.count)
                     break
                 } catch {
                     if (error as NSError).code == NSManagedObjectMergeError {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204785816528431/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1760
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1249
What kind of version bump will this require?: Patch
CC: @ayoy 

## Description

Fixes a string formatting issue that crashes the app in debug builds, when Bookmarks logging is ON.

## Testing

Please refer to the iOS and macOS PRs for testing steps.

## OS Testing

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
