### PR TITLE
Add item to keychain in the background

### DIFF
--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultCryptoProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultCryptoProvider.swift
@@ -174,11 +174,12 @@ final class DefaultCryptoProvider: SecureVaultCryptoProvider {
             kSecValueData: data as CFData
         ]
         
-        let status = SecItemAdd(addQuery as CFDictionary, nil)
-        if status == errSecSuccess {
-            return data
+        DispatchQueue.global().async {
+            SecItemAdd(addQuery as CFDictionary, nil)
         }
-        return nil
+
+        return data
+
     }
 
     func hashData(_ data: Data, salt: Data? = nil) throws -> String? {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1204717237528130/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1761
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1251
What kind of version bump will this require?: Patch

**Description**:
Moves storing the password salt to a background queue to prevent UI locks;  (There is no need to wait for the data to be created)

**Steps to test this PR**:
1. Check macOS Instructions


###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
