### PR TITLE
Allow for asynchronous sync initialization

### DIFF
--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -191,7 +191,7 @@ public class DDGSync: DDGSyncing {
                     try updateAccount(account)
 
                 } catch {
-                    // Pixel - migration problem
+                    dependencies.errorEvents.fire(.failedToMigrate, error: error)
                 }
             } else {
                 try? dependencies.secureStore.removeAccount()
@@ -205,7 +205,7 @@ public class DDGSync: DDGSyncing {
         do {
             account = try dependencies.secureStore.account()
         } catch {
-            // Pixel - could not access
+            dependencies.errorEvents.fire(.failedToLoadAccount, error: error)
             return
         }
 
@@ -214,7 +214,7 @@ public class DDGSync: DDGSyncing {
         do {
             try updateAccount(account)
         } catch {
-            // Pixel - could not initialize
+            dependencies.errorEvents.fire(.failedToSetupEngine, error: error)
         }
     }
 

--- a/Sources/DDGSync/DDGSyncing.swift
+++ b/Sources/DDGSync/DDGSyncing.swift
@@ -21,6 +21,8 @@ import DDGSyncCrypto
 import Combine
 
 public enum SyncAuthState: String, Sendable, Codable {
+    /// Sync engine is not initialized.
+    case initializing
     /// Sync is not enabled.
     case inactive
     /// Sync is in progress of registering new account.
@@ -50,6 +52,8 @@ public protocol DDGSyncing {
 
     /**
      Describes current state of sync account.
+
+     Must be different than `initializing` to guarantee that querying state info works as expected.
      */
     var authState: SyncAuthState { get }
 
@@ -76,6 +80,11 @@ public protocol DDGSyncing {
      Emits boolean values representing current sync operation status.
      */
     var isInProgressPublisher: AnyPublisher<Bool, Never> { get }
+
+    /**
+     Initializes Sync object, loads account info and prepares internal state.
+     */
+    func initializeIfNeeded(isInternalUser: Bool)
 
     /**
      Creates an account.

--- a/Sources/DDGSync/SyncError.swift
+++ b/Sources/DDGSync/SyncError.swift
@@ -22,6 +22,10 @@ public enum SyncError: Error, Equatable {
 
     case noToken
 
+    case failedToMigrate
+    case failedToLoadAccount
+    case failedToSetupEngine
+
     case failedToCreateAccountKeys(_ message: String)
     case accountNotFound
     case accountAlreadyExists

--- a/Sources/DDGSync/internal/KeyValueStore.swift
+++ b/Sources/DDGSync/internal/KeyValueStore.swift
@@ -1,0 +1,31 @@
+//
+//  SecureStorage.swift
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+struct KeyValueStore: KeyValueStoring {
+
+    func object(forKey key: String) -> Any? {
+        return UserDefaults().object(forKey: key)
+    }
+
+    func set(_ value: Any?, forKey key: String) {
+        UserDefaults().set(value, forKey: key)
+    }
+
+}

--- a/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -25,6 +25,7 @@ struct ProductionDependencies: SyncDependencies {
     let endpoints: Endpoints
     let account: AccountManaging
     let api: RemoteAPIRequestCreating
+    var keyValueStore: KeyValueStoring
     let secureStore: SecureStoring
     let crypter: CryptingInternal
     let scheduler: SchedulingInternal
@@ -39,6 +40,7 @@ struct ProductionDependencies: SyncDependencies {
         
         self.init(fileStorageUrl: FileManager.default.applicationSupportDirectoryForComponent(named: "Sync"),
                   baseUrl: baseUrl,
+                  keyValueStore: KeyValueStore(),
                   secureStore: SecureStorage(),
                   errorEvents: errorEvents,
                   log: log())
@@ -47,12 +49,14 @@ struct ProductionDependencies: SyncDependencies {
     init(
         fileStorageUrl: URL,
         baseUrl: URL,
+        keyValueStore: KeyValueStoring,
         secureStore: SecureStoring,
         errorEvents: EventMapping<SyncError>,
         log: @escaping @autoclosure () -> OSLog = .disabled
     ) {
         self.fileStorageUrl = fileStorageUrl
         self.endpoints = Endpoints(baseUrl: baseUrl)
+        self.keyValueStore = keyValueStore
         self.secureStore = secureStore
         self.errorEvents = errorEvents
         self.getLog = log

--- a/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/Sources/DDGSync/internal/SyncDependencies.swift
@@ -25,6 +25,7 @@ protocol SyncDependencies {
     var endpoints: Endpoints { get }
     var account: AccountManaging { get }
     var api: RemoteAPIRequestCreating { get }
+    var keyValueStore: KeyValueStoring { get }
     var secureStore: SecureStoring { get }
     var crypter: CryptingInternal { get }
     var scheduler: SchedulingInternal { get }
@@ -47,6 +48,12 @@ protocol AccountManaging {
 
     func fetchDevicesForAccount(_ account: SyncAccount) async throws -> [RegisteredDevice]
 
+}
+
+protocol KeyValueStoring {
+
+    func object(forKey: String) -> Any?
+    func set(_ value: Any?, forKey: String)
 }
 
 protocol SecureStoring {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: 
- https://app.asana.com/0/0/1204824439578897/f
- https://app.asana.com/0/0/1204824439578898/f

iOS PR: https://github.com/duckduckgo/iOS/pull/1764
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1255
What kind of version bump will this require?: Patch

**Description**:

Tweaks to error handling and initialization of the Sync.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Refer to platform PRs.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
