### PR TITLE
Reattach orphaned bookmarks to root folder when reordering

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,6 +75,12 @@ let package = Package(
             ]
         ),
         .target(
+            name: "BookmarksTestsUtils",
+            dependencies: [
+                "Bookmarks"
+            ]
+        ),
+         .target(
             name: "BloomFilterWrapper",
             dependencies: [
                 "BloomFilter"
@@ -177,7 +183,8 @@ let package = Package(
         .testTarget(
             name: "BookmarksTests",
             dependencies: [
-                "Bookmarks"
+                "Bookmarks",
+                "BookmarksTestsUtils"
             ]),
         .testTarget(
             name: "BrowserServicesKitTests",
@@ -248,6 +255,7 @@ let package = Package(
         .testTarget(
             name: "SyncDataProvidersTests",
             dependencies: [
+                "BookmarksTestsUtils",
                 "SyncDataProviders"
             ]
         )

--- a/Sources/Bookmarks/BookmarkErrors.swift
+++ b/Sources/Bookmarks/BookmarkErrors.swift
@@ -46,6 +46,7 @@ public enum BookmarksModelError: Error, Equatable {
     case bookmarksListMissingFolder
     case bookmarksListIndexNotMatchingBookmark
     case favoritesListIndexNotMatchingBookmark
+    case orphanedBookmarksPresent
     
     case editorNewParentMissing
 }

--- a/Sources/Bookmarks/BookmarkListViewModel.swift
+++ b/Sources/Bookmarks/BookmarkListViewModel.swift
@@ -250,6 +250,9 @@ public class BookmarkListViewModel: BookmarkListInteracting, ObservableObject {
 
         if shouldFetchRootFolder {
             let orphanedBookmarks = BookmarkUtils.fetchOrphanedEntities(context)
+            if !orphanedBookmarks.isEmpty {
+                errorEvents?.fire(.orphanedBookmarksPresent)
+            }
             folderBookmarks += orphanedBookmarks
         }
         return folderBookmarks

--- a/Sources/Bookmarks/BookmarkListViewModel.swift
+++ b/Sources/Bookmarks/BookmarkListViewModel.swift
@@ -145,7 +145,7 @@ public class BookmarkListViewModel: BookmarkListInteracting, ObservableObject {
             return
         }
 
-        let orphanedBookmarks: [BookmarkEntity] = BookmarkUtils.fetchOrphanedEntities(context)
+        let orphanedBookmarks = bookmarks.filter { $0.parent == nil }
         guard !orphanedBookmarks.isEmpty else {
             return
         }

--- a/Sources/Bookmarks/BookmarkListViewModel.swift
+++ b/Sources/Bookmarks/BookmarkListViewModel.swift
@@ -107,12 +107,42 @@ public class BookmarkListViewModel: BookmarkListInteracting, ObservableObject {
         save()
     }
 
+    private func reattachOrphanedBookmarks(forMoving bookmark: BookmarkEntity, toIndex: Int) {
+        guard let rootFolder = BookmarkUtils.fetchRootFolder(context) else {
+            return
+        }
+        let orphanedBookmarks = BookmarkUtils.fetchOrphanedEntities(context)
+        let orphanedBookmarksToAttachToRootFolder: [BookmarkEntity] = {
+            guard let bookmarkIndexInOrphans = orphanedBookmarks.firstIndex(where: { $0.uuid == bookmark.uuid }) else {
+                return [bookmark]
+            }
+            let toIndexInOrphanedBookmarks = toIndex - rootFolder.childrenArray.count
+            return Array(orphanedBookmarks.prefix(through: max(toIndexInOrphanedBookmarks, bookmarkIndexInOrphans)))
+        }()
+        orphanedBookmarksToAttachToRootFolder.forEach { rootFolder.addToChildren($0) }
+    }
+
     public func moveBookmark(_ bookmark: BookmarkEntity,
                              fromIndex: Int,
                              toIndex: Int) {
-        if bookmark.parent == nil {
-            BookmarkUtils.fetchRootFolder(context)?.addToChildren(bookmark)
+        let isOrphanedBookmark = bookmark.parent == nil
+
+        if isOrphanedBookmark {
+            reattachOrphanedBookmarks(forMoving: bookmark, toIndex: toIndex)
+//            guard let rootFolder = BookmarkUtils.fetchRootFolder(context) else {
+//                return
+//            }
+//            let orphanedBookmarks = BookmarkUtils.fetchOrphanedEntities(context)
+//            let orphanedBookmarksToAttachToRootFolder: [BookmarkEntity] = {
+//                guard let bookmarkIndexInOrphans = orphanedBookmarks.firstIndex(where: { $0.uuid == bookmark.uuid }) else {
+//                    return [bookmark]
+//                }
+//                let toIndexInOrphanedBookmarks = toIndex - rootFolder.childrenArray.count
+//                return Array(orphanedBookmarks.prefix(through: max(toIndexInOrphanedBookmarks, bookmarkIndexInOrphans)))
+//            }()
+//            orphanedBookmarksToAttachToRootFolder.forEach { rootFolder.addToChildren($0) }
         }
+
         guard let parentFolder = bookmark.parent else {
             errorEvents?.fire(.missingParent(.bookmark))
             return

--- a/Sources/Bookmarks/BookmarkListViewModel.swift
+++ b/Sources/Bookmarks/BookmarkListViewModel.swift
@@ -125,29 +125,15 @@ public class BookmarkListViewModel: BookmarkListInteracting, ObservableObject {
     public func moveBookmark(_ bookmark: BookmarkEntity,
                              fromIndex: Int,
                              toIndex: Int) {
-        let isOrphanedBookmark = bookmark.parent == nil
-
-        if isOrphanedBookmark {
+        if bookmark.parent == nil {
             reattachOrphanedBookmarks(forMoving: bookmark, toIndex: toIndex)
-//            guard let rootFolder = BookmarkUtils.fetchRootFolder(context) else {
-//                return
-//            }
-//            let orphanedBookmarks = BookmarkUtils.fetchOrphanedEntities(context)
-//            let orphanedBookmarksToAttachToRootFolder: [BookmarkEntity] = {
-//                guard let bookmarkIndexInOrphans = orphanedBookmarks.firstIndex(where: { $0.uuid == bookmark.uuid }) else {
-//                    return [bookmark]
-//                }
-//                let toIndexInOrphanedBookmarks = toIndex - rootFolder.childrenArray.count
-//                return Array(orphanedBookmarks.prefix(through: max(toIndexInOrphanedBookmarks, bookmarkIndexInOrphans)))
-//            }()
-//            orphanedBookmarksToAttachToRootFolder.forEach { rootFolder.addToChildren($0) }
         }
 
         guard let parentFolder = bookmark.parent else {
             errorEvents?.fire(.missingParent(.bookmark))
             return
         }
-        
+
         guard let children = parentFolder.children,
               fromIndex < children.count,
               toIndex < children.count else {

--- a/Sources/BookmarksTestsUtils/BookmarkTree.swift
+++ b/Sources/BookmarksTestsUtils/BookmarkTree.swift
@@ -22,22 +22,22 @@ import CoreData
 import Foundation
 import XCTest
 
-struct ModifiedAtConstraint {
+public struct ModifiedAtConstraint {
     var check: (Date?) -> Void
 
-    static func `nil`(file: StaticString = #file, line: UInt = #line) -> ModifiedAtConstraint {
+    public static func `nil`(file: StaticString = #file, line: UInt = #line) -> ModifiedAtConstraint {
         ModifiedAtConstraint { date in
             XCTAssertNil(date, file: file, line: line)
         }
     }
 
-    static func notNil(file: StaticString = #file, line: UInt = #line) -> ModifiedAtConstraint {
+    public static func notNil(file: StaticString = #file, line: UInt = #line) -> ModifiedAtConstraint {
         ModifiedAtConstraint { date in
             XCTAssertNotNil(date, file: file, line: line)
         }
     }
 
-    static func greaterThan(_ date: Date, file: StaticString = #file, line: UInt = #line) -> ModifiedAtConstraint {
+    public static func greaterThan(_ date: Date, file: StaticString = #file, line: UInt = #line) -> ModifiedAtConstraint {
         ModifiedAtConstraint { actualDate in
             guard let actualDate = actualDate else {
                 XCTFail("Date is nil", file: file, line: line)
@@ -47,7 +47,7 @@ struct ModifiedAtConstraint {
         }
     }
 
-    static func lessThan(_ date: Date, file: StaticString = #file, line: UInt = #line) -> ModifiedAtConstraint {
+    public static func lessThan(_ date: Date, file: StaticString = #file, line: UInt = #line) -> ModifiedAtConstraint {
         ModifiedAtConstraint { actualDate in
             guard let actualDate = actualDate else {
                 XCTFail("Date is nil", file: file, line: line)
@@ -58,11 +58,11 @@ struct ModifiedAtConstraint {
     }
 }
 
-enum BookmarkTreeNode {
+public enum BookmarkTreeNode {
     case bookmark(id: String, name: String?, url: String?, isFavorite: Bool, modifiedAt: Date?, isDeleted: Bool, isOrphaned: Bool, modifiedAtConstraint: ModifiedAtConstraint?)
     case folder(id: String, name: String?, children: [BookmarkTreeNode], modifiedAt: Date?, isDeleted: Bool, isOrphaned: Bool, modifiedAtConstraint: ModifiedAtConstraint?)
 
-    var id: String {
+    public var id: String {
         switch self {
         case .bookmark(let id, _, _, _, _, _, _, _):
             return id
@@ -71,7 +71,7 @@ enum BookmarkTreeNode {
         }
     }
 
-    var name: String? {
+    public var name: String? {
         switch self {
         case .bookmark(_, let name, _, _, _, _, _, _):
             return name
@@ -80,7 +80,7 @@ enum BookmarkTreeNode {
         }
     }
 
-    var modifiedAt: Date? {
+    public var modifiedAt: Date? {
         switch self {
         case .bookmark(_, _, _, _, let modifiedAt, _, _, _):
             return modifiedAt
@@ -89,7 +89,7 @@ enum BookmarkTreeNode {
         }
     }
 
-    var isDeleted: Bool {
+    public var isDeleted: Bool {
         switch self {
         case .bookmark(_, _, _, _, _, let isDeleted, _, _):
             return isDeleted
@@ -98,7 +98,7 @@ enum BookmarkTreeNode {
         }
     }
 
-    var isOrphaned: Bool {
+    public var isOrphaned: Bool {
         switch self {
         case .bookmark(_, _, _, _, _, _, let isOrphaned, _):
             return isOrphaned
@@ -107,7 +107,7 @@ enum BookmarkTreeNode {
         }
     }
 
-    var modifiedAtConstraint: ModifiedAtConstraint? {
+    public var modifiedAtConstraint: ModifiedAtConstraint? {
         switch self {
         case .bookmark(_, _, _, _, _, _, _, let modifiedAtConstraint):
             return modifiedAtConstraint
@@ -117,11 +117,11 @@ enum BookmarkTreeNode {
     }
 }
 
-protocol BookmarkTreeNodeConvertible {
+public protocol BookmarkTreeNodeConvertible {
     func asBookmarkTreeNode() -> BookmarkTreeNode
 }
 
-struct Bookmark: BookmarkTreeNodeConvertible {
+public struct Bookmark: BookmarkTreeNodeConvertible {
     var id: String
     var name: String?
     var url: String?
@@ -131,7 +131,7 @@ struct Bookmark: BookmarkTreeNodeConvertible {
     var isOrphaned: Bool
     var modifiedAtConstraint: ModifiedAtConstraint?
 
-    init(_ name: String? = nil, id: String? = nil, url: String? = nil, isFavorite: Bool = false, modifiedAt: Date? = nil, isDeleted: Bool = false, isOrphaned: Bool = false, modifiedAtConstraint: ModifiedAtConstraint? = nil) {
+    public init(_ name: String? = nil, id: String? = nil, url: String? = nil, isFavorite: Bool = false, modifiedAt: Date? = nil, isDeleted: Bool = false, isOrphaned: Bool = false, modifiedAtConstraint: ModifiedAtConstraint? = nil) {
         self.id = id ?? UUID().uuidString
         self.name = name ?? id
         self.url = (url ?? name) ?? id
@@ -142,12 +142,12 @@ struct Bookmark: BookmarkTreeNodeConvertible {
         self.isOrphaned = isOrphaned
     }
 
-    func asBookmarkTreeNode() -> BookmarkTreeNode {
+    public func asBookmarkTreeNode() -> BookmarkTreeNode {
         .bookmark(id: id, name: name, url: url, isFavorite: isFavorite, modifiedAt: modifiedAt, isDeleted: isDeleted, isOrphaned: isOrphaned, modifiedAtConstraint: modifiedAtConstraint)
     }
 }
 
-struct Folder: BookmarkTreeNodeConvertible {
+public struct Folder: BookmarkTreeNodeConvertible {
     var id: String
     var name: String?
     var modifiedAt: Date?
@@ -156,11 +156,11 @@ struct Folder: BookmarkTreeNodeConvertible {
     var modifiedAtConstraint: ModifiedAtConstraint?
     var children: [BookmarkTreeNode]
 
-    init(_ name: String? = nil, id: String? = nil, modifiedAt: Date? = nil, isDeleted: Bool = false, isOrphaned: Bool = false, @BookmarkTreeBuilder children: () -> [BookmarkTreeNode] = { [] }) {
+    public init(_ name: String? = nil, id: String? = nil, modifiedAt: Date? = nil, isDeleted: Bool = false, isOrphaned: Bool = false, @BookmarkTreeBuilder children: () -> [BookmarkTreeNode] = { [] }) {
         self.init(name, id: id, modifiedAt: modifiedAt, isDeleted: isDeleted, isOrphaned: isOrphaned, modifiedAtConstraint: nil, children: children)
     }
 
-    init(_ name: String? = nil, id: String? = nil, modifiedAt: Date? = nil, isDeleted: Bool = false, isOrphaned: Bool = false, modifiedAtConstraint: ModifiedAtConstraint? = nil, @BookmarkTreeBuilder children: () -> [BookmarkTreeNode] = { [] }) {
+    public init(_ name: String? = nil, id: String? = nil, modifiedAt: Date? = nil, isDeleted: Bool = false, isOrphaned: Bool = false, modifiedAtConstraint: ModifiedAtConstraint? = nil, @BookmarkTreeBuilder children: () -> [BookmarkTreeNode] = { [] }) {
         self.id = id ?? UUID().uuidString
         self.name = name ?? id
         self.modifiedAt = modifiedAt
@@ -170,36 +170,36 @@ struct Folder: BookmarkTreeNodeConvertible {
         self.children = children()
     }
 
-    func asBookmarkTreeNode() -> BookmarkTreeNode {
+    public func asBookmarkTreeNode() -> BookmarkTreeNode {
         .folder(id: id, name: name, children: children, modifiedAt: modifiedAt, isDeleted: isDeleted, isOrphaned: isOrphaned, modifiedAtConstraint: modifiedAtConstraint)
     }
 }
 
 @resultBuilder
-struct BookmarkTreeBuilder {
+public struct BookmarkTreeBuilder {
 
-    static func buildBlock(_ components: BookmarkTreeNodeConvertible...) -> [BookmarkTreeNode] {
+    public static func buildBlock(_ components: BookmarkTreeNodeConvertible...) -> [BookmarkTreeNode] {
         components.compactMap { $0.asBookmarkTreeNode() }
     }
 }
 
 
-struct BookmarkTree {
+public struct BookmarkTree {
 
-    init(modifiedAt: Date? = nil, modifiedAtConstraint: ModifiedAtConstraint? = nil, @BookmarkTreeBuilder builder: () -> [BookmarkTreeNode]) {
+    public init(modifiedAt: Date? = nil, modifiedAtConstraint: ModifiedAtConstraint? = nil, @BookmarkTreeBuilder builder: () -> [BookmarkTreeNode]) {
         self.modifiedAt = modifiedAt
         self.modifiedAtConstraint = modifiedAtConstraint
         self.bookmarkTreeNodes = builder()
     }
 
     @discardableResult
-    func createEntities(in context: NSManagedObjectContext) -> (BookmarkEntity, [BookmarkEntity]) {
+    public func createEntities(in context: NSManagedObjectContext) -> (BookmarkEntity, [BookmarkEntity]) {
         let (rootFolder, orphans, _) = createEntitiesForCheckingModifiedAt(in: context)
         return (rootFolder, orphans)
     }
 
     @discardableResult
-    func createEntitiesForCheckingModifiedAt(in context: NSManagedObjectContext) -> (BookmarkEntity, [BookmarkEntity], [String: ModifiedAtConstraint]) {
+    public func createEntitiesForCheckingModifiedAt(in context: NSManagedObjectContext) -> (BookmarkEntity, [BookmarkEntity], [String: ModifiedAtConstraint]) {
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
         rootFolder.modifiedAt = modifiedAt
         let favoritesFolder = BookmarkUtils.fetchFavoritesFolder(context)!
@@ -226,14 +226,14 @@ struct BookmarkTree {
     let bookmarkTreeNodes: [BookmarkTreeNode]
 }
 
-extension BookmarkEntity {
+public extension BookmarkEntity {
     @discardableResult
-    static func make(with treeNode: BookmarkTreeNode, rootFolder: BookmarkEntity, favoritesFolder: BookmarkEntity, in context: NSManagedObjectContext) -> BookmarkEntity {
+    public static func make(with treeNode: BookmarkTreeNode, rootFolder: BookmarkEntity, favoritesFolder: BookmarkEntity, in context: NSManagedObjectContext) -> BookmarkEntity {
         makeWithModifiedAtConstraints(with: treeNode, rootFolder: rootFolder, favoritesFolder: favoritesFolder, in: context).0
     }
 
     @discardableResult
-    static func makeWithModifiedAtConstraints(with treeNode: BookmarkTreeNode, rootFolder: BookmarkEntity, favoritesFolder: BookmarkEntity, in context: NSManagedObjectContext) -> (BookmarkEntity, [String: ModifiedAtConstraint]) {
+    public static func makeWithModifiedAtConstraints(with treeNode: BookmarkTreeNode, rootFolder: BookmarkEntity, favoritesFolder: BookmarkEntity, in context: NSManagedObjectContext) -> (BookmarkEntity, [String: ModifiedAtConstraint]) {
         var entity: BookmarkEntity!
 
         var queues: [[BookmarkTreeNode]] = [[treeNode]]
@@ -295,8 +295,8 @@ extension BookmarkEntity {
 }
 
 
-extension XCTestCase {
-    func assertEquivalent(withTimestamps: Bool = true, _ bookmarkEntity: BookmarkEntity, _ tree: BookmarkTree, file: StaticString = #file, line: UInt = #line) {
+public extension XCTestCase {
+    public func assertEquivalent(withTimestamps: Bool = true, _ bookmarkEntity: BookmarkEntity, _ tree: BookmarkTree, file: StaticString = #file, line: UInt = #line) {
         let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         context.persistentStoreCoordinator = bookmarkEntity.managedObjectContext?.persistentStoreCoordinator
 

--- a/Tests/BookmarksTests/BookmarkListViewModelTests.swift
+++ b/Tests/BookmarksTests/BookmarkListViewModelTests.swift
@@ -188,6 +188,38 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "6", isOrphaned: true)
         })
     }
+
+    func testWhenBookmarkIsMovedWithinNonOrphanedBookmarksThenOrphanedBookmarksAreNotAffected() async throws {
+
+        let context = bookmarkListViewModel.context
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1")
+            Bookmark(id: "2")
+            Bookmark(id: "3", isOrphaned: true)
+            Bookmark(id: "4", isOrphaned: true)
+            Bookmark(id: "5", isOrphaned: true)
+            Bookmark(id: "6", isOrphaned: true)
+        }
+
+        BookmarkUtils.prepareFoldersStructure(in: context)
+        bookmarkTree.createEntities(in: context)
+        try! context.save()
+
+        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
+
+        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 1, toIndex: 0)
+
+        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+            Bookmark(id: "2")
+            Bookmark(id: "1")
+            Bookmark(id: "3", isOrphaned: true)
+            Bookmark(id: "4", isOrphaned: true)
+            Bookmark(id: "5", isOrphaned: true)
+            Bookmark(id: "6", isOrphaned: true)
+        })
+    }
 }
 
 private extension BookmarkEntity {

--- a/Tests/BookmarksTests/BookmarkListViewModelTests.swift
+++ b/Tests/BookmarksTests/BookmarkListViewModelTests.swift
@@ -116,6 +116,7 @@ final class BookmarkListViewModelTests: XCTestCase {
 
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
 
+        bookmarkListViewModel.reloadData()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 1, toIndex: 0)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
@@ -144,6 +145,7 @@ final class BookmarkListViewModelTests: XCTestCase {
 
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "5", context: context)!
 
+        bookmarkListViewModel.reloadData()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 4, toIndex: 2)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
@@ -176,6 +178,7 @@ final class BookmarkListViewModelTests: XCTestCase {
 
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "3", context: context)!
 
+        bookmarkListViewModel.reloadData()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 2, toIndex: 4)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
@@ -208,6 +211,7 @@ final class BookmarkListViewModelTests: XCTestCase {
 
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
 
+        bookmarkListViewModel.reloadData()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 0, toIndex: 3)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
@@ -240,6 +244,7 @@ final class BookmarkListViewModelTests: XCTestCase {
 
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
 
+        bookmarkListViewModel.reloadData()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 1, toIndex: 0)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!

--- a/Tests/BookmarksTests/BookmarkListViewModelTests.swift
+++ b/Tests/BookmarksTests/BookmarkListViewModelTests.swift
@@ -1,0 +1,200 @@
+//
+//  BookmarkListViewModelTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BookmarksTestsUtils
+import Common
+import Persistence
+import XCTest
+@testable import Bookmarks
+
+class MockBookmarksModelErrorEventMapping: EventMapping<BookmarksModelError> {
+//    var events: [BookmarksModelError] = []
+
+    // swiftlint:disable:next cyclomatic_complexity
+    init() {
+        super.init { event, error, _, _ in
+//            self?.events.append(event)
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<BookmarksModelError>.Mapping) {
+        fatalError("Use init()")
+    }
+}
+
+final class BookmarkListViewModelTests: XCTestCase {
+    var bookmarksDatabase: CoreDataDatabase!
+    var bookmarkListViewModel: BookmarkListViewModel!
+    var eventMapping: MockBookmarksModelErrorEventMapping!
+    var location: URL!
+
+    override func setUp() {
+        super.setUp()
+
+        location = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        let bundle = Bookmarks.bundle
+        guard let model = CoreDataDatabase.loadModel(from: bundle, named: "BookmarksModel") else {
+            XCTFail("Failed to load model")
+            return
+        }
+        bookmarksDatabase = CoreDataDatabase(name: className, containerLocation: location, model: model)
+        bookmarksDatabase.loadStore()
+        bookmarkListViewModel = BookmarkListViewModel(bookmarksDatabase: bookmarksDatabase, parentID: nil, errorEvents: eventMapping)
+
+        eventMapping = MockBookmarksModelErrorEventMapping()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        try? bookmarksDatabase.tearDown(deleteStores: true)
+        bookmarksDatabase = nil
+        try? FileManager.default.removeItem(at: location)
+    }
+
+    func testWhenOrphanedBookmarkIsMovedThenItIsAttachedToRootFolder() async throws {
+
+        let context = bookmarkListViewModel.context
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1")
+            Bookmark(id: "2", isOrphaned: true)
+        }
+
+        BookmarkUtils.prepareFoldersStructure(in: context)
+        bookmarkTree.createEntities(in: context)
+        try! context.save()
+
+        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
+
+        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 1, toIndex: 0)
+
+        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+            Bookmark(id: "2")
+            Bookmark(id: "1")
+        })
+    }
+
+    func testWhenOrphanedBookmarkIsMovedUpThenAllOrphanedBookmarksBeforeItAreAttachedToRootFolder() async throws {
+
+        let context = bookmarkListViewModel.context
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1")
+            Bookmark(id: "2", isOrphaned: true)
+            Bookmark(id: "3", isOrphaned: true)
+            Bookmark(id: "4", isOrphaned: true)
+            Bookmark(id: "5", isOrphaned: true)
+            Bookmark(id: "6", isOrphaned: true)
+        }
+
+        BookmarkUtils.prepareFoldersStructure(in: context)
+        bookmarkTree.createEntities(in: context)
+        try! context.save()
+
+        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "5", context: context)!
+
+        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 4, toIndex: 2)
+
+        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+            Bookmark(id: "1")
+            Bookmark(id: "2")
+            Bookmark(id: "5")
+            Bookmark(id: "3")
+            Bookmark(id: "4")
+            Bookmark(id: "6", isOrphaned: true)
+        })
+    }
+
+    func testWhenOrphanedBookmarkIsMovedDownThenAllOrphanedBookmarksBeforeToIndexAreAttachedToRootFolder() async throws {
+
+        let context = bookmarkListViewModel.context
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1")
+            Bookmark(id: "2", isOrphaned: true)
+            Bookmark(id: "3", isOrphaned: true)
+            Bookmark(id: "4", isOrphaned: true)
+            Bookmark(id: "5", isOrphaned: true)
+            Bookmark(id: "6", isOrphaned: true)
+        }
+
+        BookmarkUtils.prepareFoldersStructure(in: context)
+        bookmarkTree.createEntities(in: context)
+        try! context.save()
+
+        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "3", context: context)!
+
+        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 2, toIndex: 4)
+
+        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+            Bookmark(id: "1")
+            Bookmark(id: "2")
+            Bookmark(id: "4")
+            Bookmark(id: "5")
+            Bookmark(id: "3")
+            Bookmark(id: "6", isOrphaned: true)
+        })
+    }
+
+    func testWhenBookmarkIsMovedBelowOrphanedBookmarkThenAllOrphanedBookmarksBeforeToIndexAreAttachedToRootFolder() async throws {
+
+        let context = bookmarkListViewModel.context
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1")
+            Bookmark(id: "2", isOrphaned: true)
+            Bookmark(id: "3", isOrphaned: true)
+            Bookmark(id: "4", isOrphaned: true)
+            Bookmark(id: "5", isOrphaned: true)
+            Bookmark(id: "6", isOrphaned: true)
+        }
+
+        BookmarkUtils.prepareFoldersStructure(in: context)
+        bookmarkTree.createEntities(in: context)
+        try! context.save()
+
+        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
+
+        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 0, toIndex: 3)
+
+        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+            Bookmark(id: "2")
+            Bookmark(id: "3")
+            Bookmark(id: "4")
+            Bookmark(id: "1")
+            Bookmark(id: "5", isOrphaned: true)
+            Bookmark(id: "6", isOrphaned: true)
+        })
+    }
+}
+
+private extension BookmarkEntity {
+    static func fetchBookmark(withUUID uuid: String, context: NSManagedObjectContext) -> BookmarkEntity? {
+        let request = BookmarkEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "%K == %@", #keyPath(BookmarkEntity.uuid), uuid)
+        request.fetchLimit = 1
+        return try? context.fetch(request).first
+    }
+}

--- a/Tests/BookmarksTests/BookmarkListViewModelTests.swift
+++ b/Tests/BookmarksTests/BookmarkListViewModelTests.swift
@@ -91,6 +91,7 @@ final class BookmarkListViewModelTests: XCTestCase {
 
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
 
+        bookmarkListViewModel.reloadData()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 0, toIndex: 5)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
@@ -124,7 +125,7 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "2")
             Bookmark(id: "1")
         })
-        XCTAssertTrue(firedEvents.isEmpty)
+        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
     }
 
     func testWhenOrphanedBookmarkIsMovedUpThenAllOrphanedBookmarksBeforeItAreAttachedToRootFolder() async throws {
@@ -146,6 +147,7 @@ final class BookmarkListViewModelTests: XCTestCase {
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "5", context: context)!
 
         bookmarkListViewModel.reloadData()
+        firedEvents.removeAll()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 4, toIndex: 2)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
@@ -157,7 +159,7 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "4")
             Bookmark(id: "6", isOrphaned: true)
         })
-        XCTAssertTrue(firedEvents.isEmpty)
+        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
     }
 
     func testWhenOrphanedBookmarkIsMovedDownThenAllOrphanedBookmarksBeforeToIndexAreAttachedToRootFolder() async throws {
@@ -179,6 +181,7 @@ final class BookmarkListViewModelTests: XCTestCase {
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "3", context: context)!
 
         bookmarkListViewModel.reloadData()
+        firedEvents.removeAll()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 2, toIndex: 4)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
@@ -190,7 +193,7 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "3")
             Bookmark(id: "6", isOrphaned: true)
         })
-        XCTAssertTrue(firedEvents.isEmpty)
+        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
     }
 
     func testWhenBookmarkIsMovedBelowOrphanedBookmarkThenAllOrphanedBookmarksBeforeToIndexAreAttachedToRootFolder() async throws {
@@ -212,6 +215,7 @@ final class BookmarkListViewModelTests: XCTestCase {
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
 
         bookmarkListViewModel.reloadData()
+        firedEvents.removeAll()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 0, toIndex: 3)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
@@ -223,7 +227,7 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "5", isOrphaned: true)
             Bookmark(id: "6", isOrphaned: true)
         })
-        XCTAssertTrue(firedEvents.isEmpty)
+        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
     }
 
     func testWhenBookmarkIsMovedWithinNonOrphanedBookmarksThenOrphanedBookmarksAreNotAffected() async throws {
@@ -245,6 +249,7 @@ final class BookmarkListViewModelTests: XCTestCase {
         let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
 
         bookmarkListViewModel.reloadData()
+        firedEvents.removeAll()
         bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 1, toIndex: 0)
 
         let rootFolder = BookmarkUtils.fetchRootFolder(context)!
@@ -256,7 +261,7 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "5", isOrphaned: true)
             Bookmark(id: "6", isOrphaned: true)
         })
-        XCTAssertTrue(firedEvents.isEmpty)
+        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
     }
 }
 

--- a/Tests/SyncDataProvidersTests/Bookmarks/BookmarksInitialSyncResponseHandlerTests.swift
+++ b/Tests/SyncDataProvidersTests/Bookmarks/BookmarksInitialSyncResponseHandlerTests.swift
@@ -19,6 +19,7 @@
 
 import XCTest
 import Bookmarks
+import BookmarksTestsUtils
 import Common
 import DDGSync
 import Persistence

--- a/Tests/SyncDataProvidersTests/Bookmarks/BookmarksProviderTests.swift
+++ b/Tests/SyncDataProvidersTests/Bookmarks/BookmarksProviderTests.swift
@@ -19,6 +19,7 @@
 
 import XCTest
 import Bookmarks
+import BookmarksTestsUtils
 import Common
 import DDGSync
 import Persistence

--- a/Tests/SyncDataProvidersTests/Bookmarks/BookmarksRegularSyncResponseHandlerTests.swift
+++ b/Tests/SyncDataProvidersTests/Bookmarks/BookmarksRegularSyncResponseHandlerTests.swift
@@ -19,6 +19,7 @@
 
 import XCTest
 import Bookmarks
+import BookmarksTestsUtils
 import Common
 import DDGSync
 import Persistence


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1204720539208728/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1771
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1260
What kind of version bump will this require?: Major

**Description**:
When moving a bookmark inside root folder, consider orphaned bookmarks when validating toIndex and set
parent to all affected orphaned bookmarks. See unit tests for detailed logic.

This change extracts BookmarkTree into a separate Swift module called BookmarksTestsUtils, so that it can
be used for testing Bookmarks module.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Verify that unit test pass

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
