### PR TITLE
Use Hash instead of etag as allowlist and temp list identifiers

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesIdentifier.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesIdentifier.swift
@@ -23,12 +23,12 @@ public class ContentBlockerRulesIdentifier: Equatable, Codable {
     
     let name: String
     let tdsEtag: String
-    let tempListEtag: String
-    let allowListEtag: String
+    let tempListId: String
+    let allowListId: String
     let unprotectedSitesHash: String
     
     public var stringValue: String {
-        return name + tdsEtag + tempListEtag + unprotectedSitesHash
+        return name + tdsEtag + tempListId + allowListId + unprotectedSitesHash
     }
     
     public struct Difference: OptionSet {
@@ -39,11 +39,11 @@ public class ContentBlockerRulesIdentifier: Equatable, Codable {
         }
         
         public static let tdsEtag = Difference(rawValue: 1 << 0)
-        public static let tempListEtag = Difference(rawValue: 1 << 1)
-        public static let allowListEtag = Difference(rawValue: 1 << 2)
+        public static let tempListId = Difference(rawValue: 1 << 1)
+        public static let allowListId = Difference(rawValue: 1 << 2)
         public static let unprotectedSites = Difference(rawValue: 1 << 3)
         
-        public static let all: Difference = [.tdsEtag, .tempListEtag, .allowListEtag, .unprotectedSites]
+        public static let all: Difference = [.tdsEtag, .tempListId, .allowListId, .unprotectedSites]
     }
     
     private class func normalize(identifier: String?) -> String {
@@ -71,12 +71,12 @@ public class ContentBlockerRulesIdentifier: Equatable, Codable {
         return domains.joined().sha1
     }
     
-    public init(name: String, tdsEtag: String, tempListEtag: String?, allowListEtag: String?, unprotectedSitesHash: String?) {
+    public init(name: String, tdsEtag: String, tempListId: String?, allowListId: String?, unprotectedSitesHash: String?) {
         
         self.name = Self.normalize(identifier: name)
         self.tdsEtag = Self.normalize(identifier: tdsEtag)
-        self.tempListEtag = Self.normalize(identifier: tempListEtag)
-        self.allowListEtag = Self.normalize(identifier: allowListEtag)
+        self.tempListId = Self.normalize(identifier: tempListId)
+        self.allowListId = Self.normalize(identifier: allowListId)
         self.unprotectedSitesHash = Self.normalize(identifier: unprotectedSitesHash)
     }
     
@@ -86,11 +86,11 @@ public class ContentBlockerRulesIdentifier: Equatable, Codable {
         if tdsEtag != id.tdsEtag {
             result.insert(.tdsEtag)
         }
-        if tempListEtag != id.tempListEtag {
-            result.insert(.tempListEtag)
+        if tempListId != id.tempListId {
+            result.insert(.tempListId)
         }
-        if allowListEtag != id.allowListEtag {
-            result.insert(.allowListEtag)
+        if allowListId != id.allowListId {
+            result.insert(.allowListId)
         }
         if unprotectedSitesHash != id.unprotectedSitesHash {
             result.insert(.unprotectedSites)

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -345,8 +345,8 @@ public class ContentBlockerRulesManager: CompiledRuleListsSource {
             } else {
                 diff = result.model.rulesIdentifier.compare(with: ContentBlockerRulesIdentifier(name: task.rulesList.name,
                                                                                                 tdsEtag: "",
-                                                                                                tempListEtag: nil,
-                                                                                                allowListEtag: nil,
+                                                                                                tempListId: nil,
+                                                                                                allowListId: nil,
                                                                                                 unprotectedSitesHash: nil))
             }
 

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSource.swift
@@ -33,9 +33,9 @@ public protocol ContentBlockerRulesListsSource {
  */
 public protocol ContentBlockerRulesExceptionsSource {
 
-    var tempListEtag: String { get }
+    var tempListId: String { get }
     var tempList: [String] { get }
-    var allowListEtag: String { get }
+    var allowListId: String { get }
     var allowList: [TrackerException] { get }
     var unprotectedSites: [String] { get }
 }
@@ -93,8 +93,8 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
         self.privacyConfigManager = privacyConfigManager
     }
 
-    public var tempListEtag: String {
-        return privacyConfigManager.privacyConfig.identifier
+    public var tempListId: String {
+        return ContentBlockerRulesIdentifier.hash(domains: tempList)
     }
 
     public var tempList: [String] {
@@ -104,12 +104,12 @@ public class DefaultContentBlockerRulesExceptionsSource: ContentBlockerRulesExce
         return tempUnprotected
     }
 
-    public var allowListEtag: String {
-        return privacyConfigManager.privacyConfig.identifier
+    public var allowListId: String {
+        return privacyConfigManager.privacyConfig.trackerAllowlist.hash ?? privacyConfigManager.privacyConfig.identifier
     }
 
     public var allowList: [TrackerException] {
-        return Self.transform(allowList: privacyConfigManager.privacyConfig.trackerAllowlist)
+        return Self.transform(allowList: privacyConfigManager.privacyConfig.trackerAllowlist.entries)
     }
 
     public var unprotectedSites: [String] {

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSourceManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesSourceManager.swift
@@ -43,8 +43,8 @@ public class ContentBlockerRulesSourceIdentifiers {
     public var rulesIdentifier: ContentBlockerRulesIdentifier {
         ContentBlockerRulesIdentifier(name: name,
                                       tdsEtag: tdsIdentifier,
-                                      tempListEtag: tempListIdentifier,
-                                      allowListEtag: allowListIdentifier,
+                                      tempListId: tempListIdentifier,
+                                      allowListId: allowListIdentifier,
                                       unprotectedSitesHash: unprotectedSitesIdentifier)
     }
 }
@@ -122,8 +122,8 @@ public class ContentBlockerRulesSourceManager {
         }
 
         // Fetch identifiers up-front
-        let tempListIdentifier = exceptionsSource.tempListEtag
-        let allowListIdentifier = exceptionsSource.allowListEtag
+        let tempListIdentifier = exceptionsSource.tempListId
+        let allowListIdentifier = exceptionsSource.allowListId
         let unprotectedSites = exceptionsSource.unprotectedSites
         let unprotectedSitesIdentifier = ContentBlockerRulesIdentifier.hash(domains: unprotectedSites)
 

--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/ContentBlockerRulesUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/ContentBlockerRulesUserScript.swift
@@ -206,7 +206,7 @@ open class ContentBlockerRulesUserScript: NSObject, UserScript {
         return ContentBlockerRulesUserScript.loadJS("contentblockerrules", from: Bundle.module, withReplacements: [
             "$TEMP_UNPROTECTED_DOMAINS$": remoteUnprotectedDomains,
             "$USER_UNPROTECTED_DOMAINS$": privacyConfiguration.userUnprotectedDomains.joined(separator: "\n"),
-            "$TRACKER_ALLOWLIST_ENTRIES$": TrackerAllowlistInjection.prepareForInjection(allowlist: privacyConfiguration.trackerAllowlist)
+            "$TRACKER_ALLOWLIST_ENTRIES$": TrackerAllowlistInjection.prepareForInjection(allowlist: privacyConfiguration.trackerAllowlist.entries)
         ])
     }
 }

--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/SurrogatesUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/SurrogatesUserScript.swift
@@ -190,7 +190,7 @@ open class SurrogatesUserScript: NSObject, UserScript {
             "$IS_DEBUG$": isDebugBuild ? "true" : "false",
             "$TEMP_UNPROTECTED_DOMAINS$": remoteUnprotectedDomains,
             "$USER_UNPROTECTED_DOMAINS$": privacyConfiguration.userUnprotectedDomains.joined(separator: "\n"),
-            "$TRACKER_ALLOWLIST_ENTRIES$": TrackerAllowlistInjection.prepareForInjection(allowlist: privacyConfiguration.trackerAllowlist),
+            "$TRACKER_ALLOWLIST_ENTRIES$": TrackerAllowlistInjection.prepareForInjection(allowlist: privacyConfiguration.trackerAllowlist.entries),
             "$TRACKER_DATA$": trackerData,
             "$SURROGATES$": createSurrogateFunctions(surrogates),
             "$BLOCKING_ENABLED$": privacyConfiguration.isEnabled(featureKey: .contentBlocking) ? "true" : "false"

--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -46,12 +46,8 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         return data.unprotectedTemporary.map { $0.domain }.normalizedDomainsForContentBlocking()
     }
 
-    public var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlistData {
-        switch data.trackerAllowlist.state {
-        case PrivacyConfigurationData.State.enabled: return data.trackerAllowlist.entries
-        case PrivacyConfigurationData.State.internal: return internalUserDecider.isInternalUser ? data.trackerAllowlist.entries : [:]
-        default: return [:]
-        }
+    public var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlist {
+        return data.trackerAllowlist
     }
     
     func parse(versionString: String) -> [Int] {

--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfiguration.swift
@@ -35,7 +35,7 @@ public protocol PrivacyConfiguration {
     var tempUnprotectedDomains: [String] { get }
 
     /// Trackers that has been allow listed because of site breakage
-    var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlistData { get }
+    var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlist { get }
 
     func isEnabled(featureKey: PrivacyFeature, versionProvider: AppVersionProvider) -> Bool
 

--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
@@ -59,7 +59,7 @@ public struct PrivacyConfigurationData {
         if var featuresData = json[CodingKeys.features.rawValue] as? [String: Any] {
             var features = [FeatureName: PrivacyFeature]()
 
-            // Allowlist entry does not follow the ususal feature structure - procss it first
+            // Allowlist entry does not follow the usual feature structure - process it first
             if let allowlistEntry = featuresData[CodingKeys.trackerAllowlist.rawValue] as? [String: Any] {
                 if let allowlist = TrackerAllowlist(json: allowlistEntry) {
                     self.trackerAllowlist = allowlist
@@ -105,6 +105,7 @@ public struct PrivacyConfigurationData {
             case settings
             case features
             case minSupportedVersion
+            case hash
         }
 
         public struct Feature {
@@ -128,6 +129,7 @@ public struct PrivacyConfigurationData {
         public let settings: FeatureSettings
         public let features: Features
         public let minSupportedVersion: FeatureSupportedVersion?
+        public let hash: String?
 
         public init?(json: [String: Any]) {
             guard let state = json[CodingKeys.state.rawValue] as? String else { return nil }
@@ -149,14 +151,16 @@ public struct PrivacyConfigurationData {
             }
             self.features = features
             self.minSupportedVersion = json[CodingKeys.minSupportedVersion.rawValue] as? String
+            self.hash = json[CodingKeys.hash.rawValue] as? String
         }
 
-        public init(state: FeatureState, exceptions: [ExceptionEntry], settings: [String: Any] = [:], features: Features = [:], minSupportedVersion: String? = nil) {
+        public init(state: FeatureState, exceptions: [ExceptionEntry], settings: [String: Any] = [:], features: Features = [:], minSupportedVersion: String? = nil, hash: String? = nil) {
             self.state = state
             self.exceptions = exceptions
             self.settings = settings
             self.minSupportedVersion = minSupportedVersion
             self.features = features
+            self.hash = hash
         }
     }
 

--- a/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
@@ -177,12 +177,18 @@ public struct PrivacyConfigurationData {
             }
         }
 
-        public let entries: TrackerAllowlistData
+        public private(set) var entries: TrackerAllowlistData
 
         public override init?(json: [String: Any]) {
-            let settings = (json[PrivacyFeature.CodingKeys.settings.rawValue] as? [String: Any]) ?? [:]
+            self.entries = [:]
+            super.init(json: json)
+
+            guard self.state != State.disabled else { return }
 
             var entries = [String: [Entry]]()
+
+            let settings = (json[PrivacyFeature.CodingKeys.settings.rawValue] as? [String: Any]) ?? [:]
+
             if let trackers = settings["allowlistedTrackers"] as? [String: [String: [Any]]] {
                 for (trackerDomain, trackerRules) in trackers {
                     if let rules = trackerRules["rules"] as? [ [String: Any] ] {
@@ -196,8 +202,6 @@ public struct PrivacyConfigurationData {
             }
 
             self.entries = entries
-
-            super.init(json: json)
         }
 
         public init(entries: [String: [Entry]], state: FeatureState) {

--- a/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionLogicTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionLogicTests.swift
@@ -32,8 +32,8 @@ final class MockAttributionRulesProvider: AdClickAttributionRulesProviding {
     init() async {
         globalAttributionRules = await ContentBlockingRulesHelper().makeFakeRules(name: Constants.globalAttributionRulesListName,
                                                                                   tdsEtag: "tdsEtag",
-                                                                                  tempListEtag: "tempEtag",
-                                                                                  allowListEtag: nil,
+                                                                                  tempListId: "tempEtag",
+                                                                                  allowListId: nil,
                                                                                   unprotectedSitesHash: nil)
         
         XCTAssertNotNil(globalAttributionRules)

--- a/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionRulesProviderTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionRulesProviderTests.swift
@@ -62,23 +62,23 @@ class AdClickAttributionRulesProviderTests: XCTestCase {
         
         compiledRulesSource.currentMainRules = await ContentBlockingRulesHelper().makeFakeRules(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                                                                 tdsEtag: "tdsEtag",
-                                                                                                tempListEtag: "tempEtag",
-                                                                                                allowListEtag: nil,
+                                                                                                tempListId: "tempEtag",
+                                                                                                allowListId: nil,
                                                                                                 unprotectedSitesHash: nil)
         
         let attributionName = AdClickAttributionRulesSplitter.blockingAttributionRuleListName(forListNamed: compiledRulesSource.currentMainRules!.name)
         compiledRulesSource.currentAttributionRules = await ContentBlockingRulesHelper().makeFakeRules(name: attributionName,
                                                                                                        tdsEtag: "tdsEtag",
-                                                                                                       tempListEtag: "tempEtag",
-                                                                                                       allowListEtag: nil,
+                                                                                                       tempListId: "tempEtag",
+                                                                                                       allowListId: nil,
                                                                                                        unprotectedSitesHash: nil)
         XCTAssertNotNil(compiledRulesSource.currentMainRules)
         XCTAssertNotNil(compiledRulesSource.currentAttributionRules)
         
         fakeNewRules = await ContentBlockingRulesHelper().makeFakeRules(name: compiledRulesSource.currentAttributionRules!.name,
                                                                         tdsEtag: "updatedEtag",
-                                                                        tempListEtag: "updatedEtag",
-                                                                        allowListEtag: nil,
+                                                                        tempListId: "updatedEtag",
+                                                                        allowListId: nil,
                                                                         unprotectedSitesHash: nil)
         let log: OSLog = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "Test", category: "DDG Test")
         provider = AdClickAttributionRulesProvider(config: feature,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerInitialCompilationTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerInitialCompilationTests.swift
@@ -74,8 +74,8 @@ final class ContentBlockerRulesManagerInitialCompilationTests: XCTestCase {
         let mockLastCompiledRulesStore = MockLastCompiledRulesStore()
         let identifier = ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                        tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                       tempListEtag: nil,
-                                                       allowListEtag: nil,
+                                                       tempListId: nil,
+                                                       allowListId: nil,
                                                        unprotectedSitesHash: nil)
         let cachedRules = MockLastCompiledRules(name: mockRulesSource.rukeListName,
                                                 trackerData: mockRulesSource.trackerData!.tds,
@@ -128,13 +128,13 @@ final class ContentBlockerRulesManagerInitialCompilationTests: XCTestCase {
         let mockLastCompiledRulesStore = MockLastCompiledRulesStore()
         let oldIdentifier = ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                           tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                          tempListEtag: nil,
-                                                          allowListEtag: nil,
+                                                          tempListId: nil,
+                                                          allowListId: nil,
                                                           unprotectedSitesHash: nil)
         let newIdentifier = ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                           tdsEtag: mockUpdatedRulesSource.trackerData?.etag ?? "\"\"",
-                                                          tempListEtag: nil,
-                                                          allowListEtag: nil,
+                                                          tempListId: nil,
+                                                          allowListId: nil,
                                                           unprotectedSitesHash: nil)
         let cachedRules = MockLastCompiledRules(name: mockRulesSource.rukeListName,
                                                 trackerData: mockRulesSource.trackerData!.tds,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
@@ -238,8 +238,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "",
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -287,8 +287,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -297,7 +297,7 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -320,8 +320,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -330,7 +330,7 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.invalidRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -356,8 +356,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -366,7 +366,7 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = invalidTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -390,13 +390,13 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier, mockExceptionsSource.tempListEtag)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier, mockExceptionsSource.tempListId)
 
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -405,7 +405,7 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         mockExceptionsSource.unprotectedSites = ["example.com"]
         
@@ -432,8 +432,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: mockExceptionsSource.unprotectedSitesHash))
     }
 
@@ -442,9 +442,9 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = validAllowList
         mockExceptionsSource.unprotectedSites = ["example.com"]
 
@@ -473,8 +473,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: mockExceptionsSource.allowListEtag,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: mockExceptionsSource.allowListId,
                                                      unprotectedSitesHash: mockExceptionsSource.unprotectedSitesHash))
     }
 
@@ -483,9 +483,9 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = invalidAllowList
         mockExceptionsSource.unprotectedSites = ["example.com"]
 
@@ -510,15 +510,15 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
 
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier, mockExceptionsSource.allowListEtag)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier, mockExceptionsSource.allowListId)
 
         XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
 
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: mockExceptionsSource.unprotectedSitesHash))
     }
     
@@ -527,9 +527,9 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = validAllowList
         mockExceptionsSource.unprotectedSites = ["broken site Ltd. . 😉.com"]
         
@@ -584,11 +584,11 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier,
-                       mockExceptionsSource.tempListEtag)
+                       mockExceptionsSource.tempListId)
 
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier,
-                       mockExceptionsSource.allowListEtag)
+                       mockExceptionsSource.allowListId)
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier,
@@ -597,8 +597,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
     
@@ -607,9 +607,9 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.fakeEmbeddedDataSet,
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = validAllowList
         mockExceptionsSource.unprotectedSites = ["broken site Ltd. . 😉.com"]
         
@@ -660,11 +660,11 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier,
-                       mockExceptionsSource.tempListEtag)
+                       mockExceptionsSource.tempListId)
 
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier,
-                       mockExceptionsSource.allowListEtag)
+                       mockExceptionsSource.allowListId)
         
         XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
         XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier,
@@ -673,8 +673,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
     }
 }
@@ -688,7 +688,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.invalidRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -707,8 +707,8 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
         
         mockRulesSource.trackerData = Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag())
@@ -727,15 +727,15 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier.stringValue,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil).stringValue)
         
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
             let diff = oldId.compare(with: newId)
             
             XCTAssert(diff.contains(.tdsEtag))
-            XCTAssertFalse(diff.contains(.tempListEtag))
+            XCTAssertFalse(diff.contains(.tempListId))
             XCTAssertFalse(diff.contains(.unprotectedSites))
         } else {
             XCTFail("Missing identifiers")
@@ -747,7 +747,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = invalidTempSites
         
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -766,11 +766,11 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
         
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         
         let identifier = cbrm.currentRules.first?.identifier
@@ -787,15 +787,15 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
         
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
             let diff = oldId.compare(with: newId)
             
             XCTAssert(diff.contains(.tdsEtag))
-            XCTAssert(diff.contains(.tempListEtag))
+            XCTAssert(diff.contains(.tempListId))
             XCTAssertFalse(diff.contains(.unprotectedSites))
         } else {
             XCTFail("Missing identifiers")
@@ -807,7 +807,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = invalidAllowList
 
         XCTAssertNotEqual(mockRulesSource.trackerData?.etag, mockRulesSource.embeddedTrackerData.etag)
@@ -826,11 +826,11 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
 
-        mockExceptionsSource.allowListEtag = Self.makeEtag()
+        mockExceptionsSource.allowListId = Self.makeEtag()
         mockExceptionsSource.allowList = validAllowList
 
         let identifier = cbrm.currentRules.first?.identifier
@@ -847,15 +847,15 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: nil,
-                                                     allowListEtag: mockExceptionsSource.allowListEtag,
+                                                     tempListId: nil,
+                                                     allowListId: mockExceptionsSource.allowListId,
                                                      unprotectedSitesHash: nil))
 
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
             let diff = oldId.compare(with: newId)
 
             XCTAssert(diff.contains(.tdsEtag))
-            XCTAssert(diff.contains(.allowListEtag))
+            XCTAssert(diff.contains(.allowListId))
             XCTAssertFalse(diff.contains(.unprotectedSites))
         } else {
             XCTFail("Missing identifiers")
@@ -867,7 +867,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         mockExceptionsSource.unprotectedSites = ["broken site Ltd. . 😉.com"]
         
@@ -887,8 +887,8 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
         
         mockExceptionsSource.unprotectedSites = ["example.com"]
@@ -907,15 +907,15 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.trackerData?.etag ?? "\"\"",
-                                                     tempListEtag: mockExceptionsSource.tempListEtag,
-                                                     allowListEtag: nil,
+                                                     tempListId: mockExceptionsSource.tempListId,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: mockExceptionsSource.unprotectedSitesHash))
         
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
             let diff = oldId.compare(with: newId)
             
             XCTAssert(diff.contains(.tdsEtag))
-            XCTAssert(diff.contains(.tempListEtag))
+            XCTAssert(diff.contains(.tempListId))
             XCTAssert(diff.contains(.unprotectedSites))
         } else {
             XCTFail("Missing identifiers")
@@ -927,7 +927,7 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         let mockRulesSource = MockSimpleContentBlockerRulesListsSource(trackerData: Self.makeDataSet(tds: Self.validRules, etag: Self.makeEtag()),
                                                                        embeddedTrackerData: Self.fakeEmbeddedDataSet)
         let mockExceptionsSource = MockContentBlockerRulesExceptionsSource()
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
         mockExceptionsSource.tempList = validTempSites
         mockExceptionsSource.unprotectedSites = ["broken site Ltd. . 😉.com"]
 
@@ -947,11 +947,11 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil, allowListEtag: nil,
+                                                     tempListId: nil, allowListId: nil,
                                                      unprotectedSitesHash: nil))
 
         // New etag (testing update)
-        mockExceptionsSource.tempListEtag = Self.makeEtag()
+        mockExceptionsSource.tempListId = Self.makeEtag()
 
         let identifier = cbrm.currentRules.first?.identifier
 
@@ -967,8 +967,8 @@ class ContentBlockerRulesManagerUpdatingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
                                                      tdsEtag: mockRulesSource.embeddedTrackerData.etag,
-                                                     tempListEtag: nil,
-                                                     allowListEtag: nil,
+                                                     tempListId: nil,
+                                                     allowListId: nil,
                                                      unprotectedSitesHash: nil))
 
         if let oldId = identifier, let newId = cbrm.currentRules.first?.identifier {
@@ -1142,9 +1142,9 @@ class MockSimpleContentBlockerRulesListsSource: ContentBlockerRulesListsSource {
 
 class MockContentBlockerRulesExceptionsSource: ContentBlockerRulesExceptionsSource {
 
-    var tempListEtag: String = ""
+    var tempListId: String = ""
     var tempList: [String] = []
-    var allowListEtag: String = ""
+    var allowListId: String = ""
     var allowList: [TrackerException] = []
     var unprotectedSites: [String] = []
     

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesUserScriptsTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesUserScriptsTests.swift
@@ -104,7 +104,7 @@ class ContentBlockerRulesUserScriptsTests: XCTestCase {
         var tempUnprotected = privacyConfig.tempUnprotectedDomains.filter { !$0.trimmingWhitespace().isEmpty }
         tempUnprotected.append(contentsOf: privacyConfig.exceptionsList(forFeature: .contentBlocking))
 
-        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist)
+        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist.entries)
 
         WebKitTestHelper.prepareContentBlockingRules(trackerData: trackerData,
                                                      exceptions: privacyConfig.userUnprotectedDomains,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockingRulesHelper.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockingRulesHelper.swift
@@ -52,14 +52,14 @@ final class ContentBlockingRulesHelper {
     
     func makeFakeRules(name: String,
                        tdsEtag: String,
-                       tempListEtag: String? = nil,
-                       allowListEtag: String? = nil,
+                       tempListId: String? = nil,
+                       allowListId: String? = nil,
                        unprotectedSitesHash: String? = nil) async -> ContentBlockerRulesManager.Rules? {
         
         let identifier = ContentBlockerRulesIdentifier(name: name,
                                                        tdsEtag: tdsEtag,
-                                                       tempListEtag: tempListEtag,
-                                                       allowListEtag: allowListEtag,
+                                                       tempListId: tempListId,
+                                                       allowListId: allowListId,
                                                        unprotectedSitesHash: unprotectedSitesHash)
         let tds = makeFakeTDS()
         

--- a/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesReferenceTests.swift
@@ -187,7 +187,7 @@ final class SurrogatesReferenceTests: XCTestCase {
         var tempUnprotected = privacyConfig.tempUnprotectedDomains.filter { !$0.trimmingWhitespace().isEmpty }
         tempUnprotected.append(contentsOf: privacyConfig.exceptionsList(forFeature: .contentBlocking))
         
-        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist)
+        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist.entries)
         
         WebKitTestHelper.prepareContentBlockingRules(trackerData: trackerData,
                                                      exceptions: privacyConfig.userUnprotectedDomains,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/SurrogatesUserScriptTests.swift
@@ -141,7 +141,7 @@ class SurrogatesUserScriptsTests: XCTestCase {
         var tempUnprotected = privacyConfig.tempUnprotectedDomains.filter { !$0.trimmingWhitespace().isEmpty }
         tempUnprotected.append(contentsOf: privacyConfig.exceptionsList(forFeature: .contentBlocking))
 
-        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist)
+        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: privacyConfig.trackerAllowlist.entries)
 
         WebKitTestHelper.prepareContentBlockingRules(trackerData: trackerData,
                                                      exceptions: privacyConfig.userUnprotectedDomains,

--- a/Tests/BrowserServicesKitTests/LinkProtection/ContentBlockerManagerMock.swift
+++ b/Tests/BrowserServicesKitTests/LinkProtection/ContentBlockerManagerMock.swift
@@ -26,9 +26,9 @@ struct ContentBlockerRulesListSourceMock: ContentBlockerRulesListsSource {
 }
 
 struct ContentBlockerRulesExceptionsSourceMock: ContentBlockerRulesExceptionsSource {
-    var tempListEtag: String = ""
+    var tempListId: String = ""
     var tempList: [String] = []
-    var allowListEtag: String = ""
+    var allowListId: String = ""
     var allowList: [TrackerException] = []
     var unprotectedSites: [String] = []
 }

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
@@ -579,40 +579,6 @@ class AppPrivacyConfigurationTests: XCTestCase {
             """.data(using: .utf8)!
     }
 
-    func testTrackerAllowlistIsAlwaysEmptyWhenDisabled() {
-        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: "disabled"), etag: "test")
-        let mockInternalUserStore = MockInternalUserStoring()
-
-        let manager = PrivacyConfigurationManager(fetchedETag: nil,
-                                                  fetchedData: nil,
-                                                  embeddedDataProvider: mockEmbeddedData,
-                                                  localProtection: MockDomainsProtectionStore(),
-                                                  internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStore))
-        let config = manager.privacyConfig
-
-        mockInternalUserStore.isInternalUser = true
-        XCTAssertTrue(config.trackerAllowlist.isEmpty)
-        mockInternalUserStore.isInternalUser = false
-        XCTAssertTrue(config.trackerAllowlist.isEmpty)
-    }
-
-    func testTrackerAllowlistIsEmptyForNonInternalUsersWhenInternal() {
-        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: "internal"), etag: "test")
-        let mockInternalUserStore = MockInternalUserStoring()
-
-        let manager = PrivacyConfigurationManager(fetchedETag: nil,
-                                                  fetchedData: nil,
-                                                  embeddedDataProvider: mockEmbeddedData,
-                                                  localProtection: MockDomainsProtectionStore(),
-                                                  internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStore))
-        let config = manager.privacyConfig
-
-        mockInternalUserStore.isInternalUser = true
-        XCTAssertFalse(config.trackerAllowlist.isEmpty)
-        mockInternalUserStore.isInternalUser = false
-        XCTAssertTrue(config.trackerAllowlist.isEmpty)
-    }
-
     func testTrackerAllowlistIsNeverEmptyWhenEnabled() {
         let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: "enabled"), etag: "test")
         let mockInternalUserStore = MockInternalUserStoring()
@@ -625,9 +591,9 @@ class AppPrivacyConfigurationTests: XCTestCase {
         let config = manager.privacyConfig
 
         mockInternalUserStore.isInternalUser = true
-        XCTAssertFalse(config.trackerAllowlist.isEmpty)
+        XCTAssertFalse(config.trackerAllowlist.entries.isEmpty)
         mockInternalUserStore.isInternalUser = false
-        XCTAssertFalse(config.trackerAllowlist.isEmpty)
+        XCTAssertFalse(config.trackerAllowlist.entries.isEmpty)
     }
 
 }

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
@@ -579,8 +579,8 @@ class AppPrivacyConfigurationTests: XCTestCase {
             """.data(using: .utf8)!
     }
 
-    func testTrackerAllowlistIsNeverEmptyWhenEnabled() {
-        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: "enabled"), etag: "test")
+    func testTrackerAllowlistIsNotEmptyWhenEnabled() {
+        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: PrivacyConfigurationData.State.enabled), etag: "test")
         let mockInternalUserStore = MockInternalUserStoring()
 
         let manager = PrivacyConfigurationManager(fetchedETag: nil,
@@ -590,10 +590,21 @@ class AppPrivacyConfigurationTests: XCTestCase {
                                                   internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStore))
         let config = manager.privacyConfig
 
-        mockInternalUserStore.isInternalUser = true
         XCTAssertFalse(config.trackerAllowlist.entries.isEmpty)
-        mockInternalUserStore.isInternalUser = false
-        XCTAssertFalse(config.trackerAllowlist.entries.isEmpty)
+    }
+
+    func testTrackerAllowlistIsEmptyWhenDisabled() {
+        let mockEmbeddedData = MockEmbeddedDataProvider(data: exampleTrackerAllowlistConfig(with: PrivacyConfigurationData.State.disabled), etag: "test")
+        let mockInternalUserStore = MockInternalUserStoring()
+
+        let manager = PrivacyConfigurationManager(fetchedETag: nil,
+                                                  fetchedData: nil,
+                                                  embeddedDataProvider: mockEmbeddedData,
+                                                  localProtection: MockDomainsProtectionStore(),
+                                                  internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStore))
+        let config = manager.privacyConfig
+
+        XCTAssert(config.trackerAllowlist.entries.isEmpty)
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: 
 - https://app.asana.com/0/1163321984198618/1204236089135865/f
 - https://app.asana.com/0/414709148257752/1204916184448572/f
 
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

Use Hash instead of etag as allowlist and temp list identifiers to avoid excess rule recompilation.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Generic smoke tests of content blocking feature.

Also:
1. Disable using fetched config by:
    - Passing nil to PrivacyConfigurationManager first two parameters.
    - Comment out call to PrivacyConfigurationManager.reload(...)
2. Put breakpoints in `ContentBlockingRulesCompilationTask` on `lookUpContentRuleList` and `compileContentRuleList`.
3. Run app few times - you should see restarts does not recompile anything.
4. Change embedded config hash for allowlist, or, change unprotected domains contents, or, change content blocking exceptions (not hash) and see that it triggers recompilation.
5. Change embedded etag in `AppPrivacyConfigurationDataProvider` - this should not cause recompilation.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
