### PR TITLE
Fix occasional failures in BookmarkListViewModelTests

### DIFF
--- a/Tests/BookmarksTests/BookmarkListViewModelTests.swift
+++ b/Tests/BookmarksTests/BookmarkListViewModelTests.swift
@@ -86,21 +86,23 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "2")
         }
 
-        bookmarkTree.createEntities(in: context)
-        try! context.save()
+        context.performAndWait {
+            bookmarkTree.createEntities(in: context)
+            try! context.save()
 
-        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
+            let bookmark = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
 
-        bookmarkListViewModel.reloadData()
-        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 0, toIndex: 5)
+            bookmarkListViewModel.reloadData()
+            bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 0, toIndex: 5)
 
-        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
-        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
-            Bookmark(id: "1")
-            Bookmark(id: "2")
-        })
+            let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+            assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+                Bookmark(id: "1")
+                Bookmark(id: "2")
+            })
 
-        XCTAssertEqual(firedEvents, [.indexOutOfRange(.bookmarks)])
+            XCTAssertEqual(firedEvents, [.indexOutOfRange(.bookmarks)])
+        }
     }
 
     func testWhenOrphanedBookmarkIsMovedThenItIsAttachedToRootFolder() async throws {
@@ -112,20 +114,22 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "2", isOrphaned: true)
         }
 
-        bookmarkTree.createEntities(in: context)
-        try! context.save()
+        context.performAndWait {
+            bookmarkTree.createEntities(in: context)
+            try! context.save()
 
-        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
+            let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
 
-        bookmarkListViewModel.reloadData()
-        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 1, toIndex: 0)
+            bookmarkListViewModel.reloadData()
+            bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 1, toIndex: 0)
 
-        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
-        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
-            Bookmark(id: "2")
-            Bookmark(id: "1")
-        })
-        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+            let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+            assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+                Bookmark(id: "2")
+                Bookmark(id: "1")
+            })
+            XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+        }
     }
 
     func testWhenOrphanedBookmarkIsMovedUpThenAllOrphanedBookmarksBeforeItAreAttachedToRootFolder() async throws {
@@ -141,25 +145,27 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "6", isOrphaned: true)
         }
 
-        bookmarkTree.createEntities(in: context)
-        try! context.save()
+        context.performAndWait {
+            bookmarkTree.createEntities(in: context)
+            try! context.save()
 
-        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "5", context: context)!
+            let bookmark = BookmarkEntity.fetchBookmark(withUUID: "5", context: context)!
 
-        bookmarkListViewModel.reloadData()
-        firedEvents.removeAll()
-        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 4, toIndex: 2)
+            bookmarkListViewModel.reloadData()
+            firedEvents.removeAll()
+            bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 4, toIndex: 2)
 
-        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
-        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
-            Bookmark(id: "1")
-            Bookmark(id: "2")
-            Bookmark(id: "5")
-            Bookmark(id: "3")
-            Bookmark(id: "4")
-            Bookmark(id: "6", isOrphaned: true)
-        })
-        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+            let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+            assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+                Bookmark(id: "1")
+                Bookmark(id: "2")
+                Bookmark(id: "5")
+                Bookmark(id: "3")
+                Bookmark(id: "4")
+                Bookmark(id: "6", isOrphaned: true)
+            })
+            XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+        }
     }
 
     func testWhenOrphanedBookmarkIsMovedDownThenAllOrphanedBookmarksBeforeToIndexAreAttachedToRootFolder() async throws {
@@ -175,25 +181,27 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "6", isOrphaned: true)
         }
 
-        bookmarkTree.createEntities(in: context)
-        try! context.save()
+        context.performAndWait {
+            bookmarkTree.createEntities(in: context)
+            try! context.save()
 
-        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "3", context: context)!
+            let bookmark = BookmarkEntity.fetchBookmark(withUUID: "3", context: context)!
 
-        bookmarkListViewModel.reloadData()
-        firedEvents.removeAll()
-        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 2, toIndex: 4)
+            bookmarkListViewModel.reloadData()
+            firedEvents.removeAll()
+            bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 2, toIndex: 4)
 
-        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
-        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
-            Bookmark(id: "1")
-            Bookmark(id: "2")
-            Bookmark(id: "4")
-            Bookmark(id: "5")
-            Bookmark(id: "3")
-            Bookmark(id: "6", isOrphaned: true)
-        })
-        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+            let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+            assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+                Bookmark(id: "1")
+                Bookmark(id: "2")
+                Bookmark(id: "4")
+                Bookmark(id: "5")
+                Bookmark(id: "3")
+                Bookmark(id: "6", isOrphaned: true)
+            })
+            XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+        }
     }
 
     func testWhenBookmarkIsMovedBelowOrphanedBookmarkThenAllOrphanedBookmarksBeforeToIndexAreAttachedToRootFolder() async throws {
@@ -209,25 +217,27 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "6", isOrphaned: true)
         }
 
-        bookmarkTree.createEntities(in: context)
-        try! context.save()
+        context.performAndWait {
+            bookmarkTree.createEntities(in: context)
+            try! context.save()
 
-        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
+            let bookmark = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
 
-        bookmarkListViewModel.reloadData()
-        firedEvents.removeAll()
-        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 0, toIndex: 3)
+            bookmarkListViewModel.reloadData()
+            firedEvents.removeAll()
+            bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 0, toIndex: 3)
 
-        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
-        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
-            Bookmark(id: "2")
-            Bookmark(id: "3")
-            Bookmark(id: "4")
-            Bookmark(id: "1")
-            Bookmark(id: "5", isOrphaned: true)
-            Bookmark(id: "6", isOrphaned: true)
-        })
-        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+            let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+            assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+                Bookmark(id: "2")
+                Bookmark(id: "3")
+                Bookmark(id: "4")
+                Bookmark(id: "1")
+                Bookmark(id: "5", isOrphaned: true)
+                Bookmark(id: "6", isOrphaned: true)
+            })
+            XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+        }
     }
 
     func testWhenBookmarkIsMovedWithinNonOrphanedBookmarksThenOrphanedBookmarksAreNotAffected() async throws {
@@ -243,25 +253,27 @@ final class BookmarkListViewModelTests: XCTestCase {
             Bookmark(id: "6", isOrphaned: true)
         }
 
-        bookmarkTree.createEntities(in: context)
-        try! context.save()
+        context.performAndWait {
+            bookmarkTree.createEntities(in: context)
+            try! context.save()
 
-        let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
+            let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
 
-        bookmarkListViewModel.reloadData()
-        firedEvents.removeAll()
-        bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 1, toIndex: 0)
+            bookmarkListViewModel.reloadData()
+            firedEvents.removeAll()
+            bookmarkListViewModel.moveBookmark(bookmark, fromIndex: 1, toIndex: 0)
 
-        let rootFolder = BookmarkUtils.fetchRootFolder(context)!
-        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
-            Bookmark(id: "2")
-            Bookmark(id: "1")
-            Bookmark(id: "3", isOrphaned: true)
-            Bookmark(id: "4", isOrphaned: true)
-            Bookmark(id: "5", isOrphaned: true)
-            Bookmark(id: "6", isOrphaned: true)
-        })
-        XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+            let rootFolder = BookmarkUtils.fetchRootFolder(context)!
+            assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+                Bookmark(id: "2")
+                Bookmark(id: "1")
+                Bookmark(id: "3", isOrphaned: true)
+                Bookmark(id: "4", isOrphaned: true)
+                Bookmark(id: "5", isOrphaned: true)
+                Bookmark(id: "6", isOrphaned: true)
+            })
+            XCTAssertEqual(firedEvents, [.orphanedBookmarksPresent])
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1204953194098089/f 
iOS PR: N/A
macOS PR: N/A
What kind of version bump will this require?: None

**Description**:
This change adds context.performAndWait as needed in BookmarkListViewModelTests to ensure
operations on the context are performed on its proper queue (in this case, the main queue), also
when tests are run in parallel which causes this test case to be run on a non-main queue.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Verify that BookmarksListViewModel tests pass when you run a full test suite for BookmarksTests module
(or entire BSK package).

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
