### PR TITLE
Fix setting Sync auth state when signing up for Sync

### DIFF
--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -226,7 +226,7 @@ public class DDGSync: DDGSyncing {
             return
         }
 
-        guard let account, account.state != .inactive else {
+        guard var account, account.state != .inactive else {
             dependencies.scheduler.isEnabled = false
             startSyncCancellable?.cancel()
             syncQueueCancellable?.cancel()
@@ -245,6 +245,9 @@ public class DDGSync: DDGSyncing {
         let previousState = try dependencies.secureStore.account()?.state
         if previousState == nil || previousState ==  .inactive {
             try syncQueue.prepareForFirstSync()
+        }
+        if account.state == .settingUpNewAccount {
+            account = account.updatingState(.active)
         }
         try dependencies.secureStore.persistAccount(account)
         authState = account.state


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201493110486074/1204953194098101/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1809
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1324
What kind of version bump will this require?: Patch

**Description**:
Set auth state to active right after preparing for first sync is complete if the user is signing up for Sync.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Refer to macOS PR for testing.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
