### PR TITLE
Use stable version instead of branch for bloom filter ref

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/bloom_cpp.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "8076199456290b61b4544bf2f4caf296759906a0"
+        "revision" : "8076199456290b61b4544bf2f4caf296759906a0",
+        "version" : "3.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.22.3"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "1.4.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
-        .package(url: "https://github.com/duckduckgo/bloom_cpp.git", branch: "main"),
+        .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/903182762228930/1202443550575711/f
What kind of version bump will this require?: Patch

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
