### PR TITLE
Optimize first load of Content Rule Lists

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionRulesProvider.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionRulesProvider.swift
@@ -170,7 +170,11 @@ public class AdClickAttributionRulesProvider: AdClickAttributionRulesProviding {
                "Returning attribution rules for vendor  %{private}s to %{public}d caller(s)",
                attributionTask.vendor, matchingTasks.count)
         
-        let rules = ContentBlockerRulesManager.Rules(task: compilationTask)
+        var rules: ContentBlockerRulesManager.Rules? = nil
+        if let result = compilationTask.result {
+            rules = .init(compilationResult: result)
+        }
+        
         DispatchQueue.main.async {
             for task in matchingTasks {
                 task.completion(rules)

--- a/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionRulesSplitter.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionRulesSplitter.swift
@@ -48,11 +48,10 @@ public struct AdClickAttributionRulesSplitter {
         guard !allowlistedTrackerNames.isEmpty, rulesList.contains(allowlistedTrackerNames) else { return nil }
         
         let splitTDS = rulesList.trackerData != nil ? split(tds: rulesList.trackerData!) : nil
-        let splitFallbackTDS = split(tds: rulesList.fallbackTrackerData)
         return (ContentBlockerRulesList(name: rulesList.name, trackerData: splitTDS?.0,
-                                        fallbackTrackerData: splitFallbackTDS.0),
+                                        fallbackTrackerData: split(tds: rulesList.fallbackTrackerData).0),
                 ContentBlockerRulesList(name: Self.blockingAttributionRuleListName(forListNamed: rulesList.name),
-                                        trackerData: splitTDS?.1, fallbackTrackerData: splitFallbackTDS.1))
+                                        trackerData: splitTDS?.1, fallbackTrackerData: split(tds: rulesList.fallbackTrackerData).1))
     }
     
     private func split(tds: TrackerDataManager.DataSet) -> (TrackerDataManager.DataSet, TrackerDataManager.DataSet) {

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -151,7 +151,6 @@ public class ContentBlockerRulesManager: CompiledRuleListsSource {
         workQueue.async {
             _ = self.updateCompilationState(token: "")
 
-            self.prepareSourceManagers()
             if !self.lookupCompiledRules() {
                 if let lastCompiledRules = lastCompiledRulesStore?.rules, !lastCompiledRules.isEmpty {
                     self.fetchLastCompiledRules(with: lastCompiledRules)
@@ -228,7 +227,12 @@ public class ContentBlockerRulesManager: CompiledRuleListsSource {
         return true
     }
 
+    /*
+     Go through source managers and check if there are already compiled rules in the WebKit rule cache.
+     Returns true if rules were found, false otherwise.
+     */
     private func lookupCompiledRules() -> Bool {
+        prepareSourceManagers()
         let initialCompilationTask = LookupRulesTask(sourceManagers: Array(sourceManagers.values))
         let mutex = DispatchSemaphore(value: 0)
 
@@ -246,7 +250,11 @@ public class ContentBlockerRulesManager: CompiledRuleListsSource {
         }
         return false
     }
-    
+
+    /*
+     Go through source managers and check if there are already compiled rules in the WebKit rule cache.
+     Returns true if rules were found, false otherwise.
+     */
     private func fetchLastCompiledRules(with lastCompiledRules: [LastCompiledRules]) {
         let initialCompilationTask = LastCompiledRulesLookupTask(sourceRules: rulesSource.contentBlockerRulesLists,
                                                                  lastCompiledRules: lastCompiledRules)
@@ -265,6 +273,8 @@ public class ContentBlockerRulesManager: CompiledRuleListsSource {
             state = .idle
             lock.unlock()
         }
+
+        // No matter if rules were found or not, we need to schedule recompilation, after all
         scheduleCompilation()
     }
 

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesLastCompiledRulesLookupTask.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesLastCompiledRulesLookupTask.swift
@@ -46,6 +46,11 @@ extension ContentBlockerRulesManager {
             let sourceRulesNames = sourceRules.map { $0.name }
             let filteredBySourceLastCompiledRules = lastCompiledRules.filter { sourceRulesNames.contains($0.name) }
 
+            guard filteredBySourceLastCompiledRules.count == sourceRules.count else {
+                // We should only load rule lists from cache, in case we can match every one of these
+                throw WKError(.contentRuleListStoreLookUpFailed)
+            }
+
             var result: [CachedRulesList] = []
             for rules in filteredBySourceLastCompiledRules {
                 guard let ruleList = try await Task(operation: { @MainActor in

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesLookupTask.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesLookupTask.swift
@@ -1,0 +1,56 @@
+//
+//  ContentBlockingRulesLookupTask.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+import TrackerRadarKit
+
+extension ContentBlockerRulesManager {
+
+    final class LookupRulesTask {
+
+        typealias LookupResult = (compiledRulesList: WKContentRuleList, model: ContentBlockerRulesSourceModel)
+
+        private let sourceManagers: [ContentBlockerRulesSourceManager]
+
+        public private(set) var result: [LookupResult]? = nil
+
+        init(sourceManagers: [ContentBlockerRulesSourceManager]) {
+            self.sourceManagers = sourceManagers
+        }
+
+        func lookupCachedRulesLists() async throws {
+
+            var result = [LookupResult]()
+            for sourceManager in sourceManagers {
+                guard let model = sourceManager.makeModel() else {
+                    throw WKError(.contentRuleListStoreLookUpFailed)
+                }
+
+                guard let ruleList = try await Task(operation: { @MainActor in
+                    try await WKContentRuleListStore.default().contentRuleList(forIdentifier: model.rulesIdentifier.stringValue)
+                }).value else { throw WKError(.contentRuleListStoreLookUpFailed) }
+
+                result.append((ruleList, model))
+            }
+            self.result = result
+        }
+
+    }
+}

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesLookupTask.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesLookupTask.swift
@@ -45,7 +45,10 @@ extension ContentBlockerRulesManager {
 
                 guard let ruleList = try await Task(operation: { @MainActor in
                     try await WKContentRuleListStore.default().contentRuleList(forIdentifier: model.rulesIdentifier.stringValue)
-                }).value else { throw WKError(.contentRuleListStoreLookUpFailed) }
+                }).value else {
+                    // All lists must be found for this to be considered successful
+                    throw WKError(.contentRuleListStoreLookUpFailed)
+                }
 
                 result.append((ruleList, model))
             }

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerRulesManagerTests.swift
@@ -348,8 +348,8 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         
         XCTAssertNotNil(cbrm.currentRules.first?.etag)
         
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
         
         XCTAssertEqual(cbrm.currentRules.first?.etag, mockRulesSource.embeddedTrackerData.etag)
 
@@ -386,11 +386,11 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.etag, mockRulesSource.embeddedTrackerData.etag)
         
         // TDS is also marked as invalid to simplify flow
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
         
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier, mockExceptionsSource.tempListId)
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tempListIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tempListIdentifier, mockExceptionsSource.tempListId)
 
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
@@ -425,9 +425,9 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertNotNil(cbrm.currentRules.first?.etag)
         XCTAssertEqual(cbrm.currentRules.first?.etag, mockRulesSource.trackerData?.etag)
         
-        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier)
-        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
-        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier)
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tempListIdentifier)
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.unprotectedSitesIdentifier)
         
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
@@ -465,10 +465,10 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertNotNil(cbrm.currentRules.first?.etag)
         XCTAssertEqual(cbrm.currentRules.first?.etag, mockRulesSource.trackerData?.etag)
 
-        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier)
-        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
-        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
-        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier)
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tempListIdentifier)
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.allowListIdentifier)
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.unprotectedSitesIdentifier)
 
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
@@ -506,13 +506,13 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.etag, mockRulesSource.embeddedTrackerData.etag)
 
         // TDS is also marked as invalid to simplify flow
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier, mockRulesSource.trackerData?.etag)
 
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier, mockExceptionsSource.allowListId)
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.allowListIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.allowListIdentifier, mockExceptionsSource.allowListId)
 
-        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.unprotectedSitesIdentifier)
 
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
                        ContentBlockerRulesIdentifier(name: DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName,
@@ -578,20 +578,20 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertEqual(cbrm.currentRules.first?.etag, mockRulesSource.embeddedTrackerData.etag)
         
         // TDS is also marked as invalid to simplify flow
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier,
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier,
                        mockRulesSource.trackerData?.etag)
         
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier,
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tempListIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tempListIdentifier,
                        mockExceptionsSource.tempListId)
 
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier,
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.allowListIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.allowListIdentifier,
                        mockExceptionsSource.allowListId)
         
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier,
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.unprotectedSitesIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.unprotectedSitesIdentifier,
                        mockExceptionsSource.unprotectedSitesHash)
 
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
@@ -656,18 +656,18 @@ class ContentBlockerRulesManagerLoadingTests: ContentBlockerRulesManagerTests {
         XCTAssertNotNil(cbrm.currentRules.first?.etag)
         XCTAssertEqual(cbrm.currentRules.first?.etag, mockRulesSource.embeddedTrackerData.etag)
         
-        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tdsIdentifier)
+        XCTAssertNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tdsIdentifier)
         
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.tempListIdentifier,
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tempListIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.tempListIdentifier,
                        mockExceptionsSource.tempListId)
 
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.allowListIdentifier,
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.allowListIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.allowListIdentifier,
                        mockExceptionsSource.allowListId)
         
-        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier)
-        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.rukeListName]?.brokenSources?.unprotectedSitesIdentifier,
+        XCTAssertNotNil(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.unprotectedSitesIdentifier)
+        XCTAssertEqual(cbrm.sourceManagers[mockRulesSource.ruleListName]?.brokenSources?.unprotectedSitesIdentifier,
                        mockExceptionsSource.unprotectedSitesHash)
 
         XCTAssertEqual(cbrm.currentRules.first?.identifier,
@@ -1110,7 +1110,7 @@ class MockSimpleContentBlockerRulesListsSource: ContentBlockerRulesListsSource {
         didSet {
             let trackerData = trackerData
             let embeddedTrackerData = embeddedTrackerData
-            contentBlockerRulesLists = [ContentBlockerRulesList(name: rukeListName,
+            contentBlockerRulesLists = [ContentBlockerRulesList(name: ruleListName,
                                                                 trackerData: trackerData,
                                                                 fallbackTrackerData: embeddedTrackerData)]
         }
@@ -1119,7 +1119,7 @@ class MockSimpleContentBlockerRulesListsSource: ContentBlockerRulesListsSource {
         didSet {
             let trackerData = trackerData
             let embeddedTrackerData = embeddedTrackerData
-            contentBlockerRulesLists = [ContentBlockerRulesList(name: rukeListName,
+            contentBlockerRulesLists = [ContentBlockerRulesList(name: ruleListName,
                                                                 trackerData: trackerData,
                                                                 fallbackTrackerData: embeddedTrackerData)]
         }
@@ -1127,13 +1127,13 @@ class MockSimpleContentBlockerRulesListsSource: ContentBlockerRulesListsSource {
     
     var contentBlockerRulesLists: [ContentBlockerRulesList]
     
-    var rukeListName = DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName
+    var ruleListName = DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName
     
     init(trackerData: TrackerDataManager.DataSet?, embeddedTrackerData: TrackerDataManager.DataSet) {
         self.trackerData = trackerData
         self.embeddedTrackerData = embeddedTrackerData
         
-        contentBlockerRulesLists = [ContentBlockerRulesList(name: rukeListName,
+        contentBlockerRulesLists = [ContentBlockerRulesList(name: ruleListName,
                                                             trackerData: trackerData,
                                                             fallbackTrackerData: embeddedTrackerData)]
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1204978316870813/f
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Patch

**Description**:

Speed up initial setup of the Content Blocking stack.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Happy path testing - content blocking smoke tests along with attribution ones.

Removal of WebKit-cached rules lists should fall back to Last Compiled Rules cache.
Removal of WebKit-cached rules and Last Compiled Rules cache should just compile and block navigation till it's done.

Changing TDS etag (must be done manually) should cause miss of initial lookup but fallback to Last Rules.
Changing current rules set (e.g. by changing the name of the rule list) should fail both the WebKit and Last Compiled caches and result in recompilation.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
