### PR TITLE
Fix bookmarks reordering

### DIFF
--- a/Sources/Bookmarks/BookmarkListViewModel.swift
+++ b/Sources/Bookmarks/BookmarkListViewModel.swift
@@ -139,6 +139,12 @@ public class BookmarkListViewModel: BookmarkListInteracting, ObservableObject {
         let actualFromIndex = mutableChildrenSet.index(of: bookmark)
         let actualToIndex = mutableChildrenSet.index(of: visibleChildren[toIndex])
 
+        guard actualFromIndex != NSNotFound, actualToIndex != NSNotFound else {
+            assertionFailure("Bookmark: position could not be determined")
+            refresh()
+            return
+        }
+
         mutableChildrenSet.moveObjects(at: IndexSet(integer: actualFromIndex), to: actualToIndex)
 
         save()

--- a/Sources/Bookmarks/BookmarkListViewModel.swift
+++ b/Sources/Bookmarks/BookmarkListViewModel.swift
@@ -120,21 +120,26 @@ public class BookmarkListViewModel: BookmarkListInteracting, ObservableObject {
             return
         }
 
-        guard let children = parentFolder.children,
-              fromIndex < children.count,
-              toIndex < children.count else {
+        let visibleChildren = parentFolder.childrenArray
+
+        guard fromIndex < visibleChildren.count,
+              toIndex < visibleChildren.count else {
             errorEvents?.fire(.indexOutOfRange(.bookmarks))
             return
         }
 
-        guard let actualBookmark = children[fromIndex] as? BookmarkEntity,
-              actualBookmark == bookmark else {
+        guard visibleChildren[fromIndex] == bookmark else {
             errorEvents?.fire(.bookmarksListIndexNotMatchingBookmark)
             return
         }
 
+        // Take into account bookmarks that are pending deletion
         let mutableChildrenSet = parentFolder.mutableOrderedSetValue(forKeyPath: #keyPath(BookmarkEntity.children))
-        mutableChildrenSet.moveObjects(at: IndexSet(integer: fromIndex), to: toIndex)
+
+        let actualFromIndex = mutableChildrenSet.index(of: bookmark)
+        let actualToIndex = mutableChildrenSet.index(of: visibleChildren[toIndex])
+
+        mutableChildrenSet.moveObjects(at: IndexSet(integer: actualFromIndex), to: actualToIndex)
 
         save()
         refresh()

--- a/Tests/BookmarksTests/BookmarkListViewModelTests.swift
+++ b/Tests/BookmarksTests/BookmarkListViewModelTests.swift
@@ -82,20 +82,14 @@ final class BookmarkListViewModelTests: XCTestCase {
         let context = bookmarkListViewModel.context
 
         let bookmarkTree = BookmarkTree {
-            Bookmark(id: "1")
+            Bookmark(id: "1", isDeleted: true)
             Bookmark(id: "2")
-            Bookmark(id: "3")
+            Bookmark(id: "3", isDeleted: true)
             Bookmark(id: "4")
         }
 
         context.performAndWait {
             bookmarkTree.createEntities(in: context)
-
-            let deleted1 = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
-            deleted1.markPendingDeletion()
-
-            let deleted3 = BookmarkEntity.fetchBookmark(withUUID: "3", context: context)!
-            deleted3.markPendingDeletion()
             
             try! context.save()
 

--- a/Tests/BookmarksTests/BookmarkListViewModelTests.swift
+++ b/Tests/BookmarksTests/BookmarkListViewModelTests.swift
@@ -310,7 +310,7 @@ final class BookmarkListViewModelTests: XCTestCase {
     }
 }
 
-private extension BookmarkEntity {
+extension BookmarkEntity {
     static func fetchBookmark(withUUID uuid: String, context: NSManagedObjectContext) -> BookmarkEntity? {
         let request = BookmarkEntity.fetchRequest()
         request.predicate = NSPredicate(format: "%K == %@", #keyPath(BookmarkEntity.uuid), uuid)

--- a/Tests/BookmarksTests/FavoriteListViewModelTests.swift
+++ b/Tests/BookmarksTests/FavoriteListViewModelTests.swift
@@ -1,0 +1,97 @@
+//
+//  FavoriteListViewModelTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BookmarksTestsUtils
+import Common
+import Persistence
+import XCTest
+@testable import Bookmarks
+
+final class FavoriteListViewModelTests: XCTestCase {
+    var bookmarksDatabase: CoreDataDatabase!
+    var favoriteListViewModel: FavoritesListViewModel!
+    var eventMapping: MockBookmarksModelErrorEventMapping!
+    var firedEvents: [BookmarksModelError] = []
+    var location: URL!
+
+    override func setUp() {
+        super.setUp()
+
+        location = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        let bundle = Bookmarks.bundle
+        guard let model = CoreDataDatabase.loadModel(from: bundle, named: "BookmarksModel") else {
+            XCTFail("Failed to load model")
+            return
+        }
+        bookmarksDatabase = CoreDataDatabase(name: className, containerLocation: location, model: model)
+        bookmarksDatabase.loadStore()
+        eventMapping = MockBookmarksModelErrorEventMapping { [weak self] event in
+            self?.firedEvents.append(event)
+        }
+
+        let context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+        context.performAndWait {
+            BookmarkUtils.prepareFoldersStructure(in: context)
+            try! context.save()
+        }
+
+        favoriteListViewModel = FavoritesListViewModel(bookmarksDatabase: bookmarksDatabase,
+                                                       errorEvents: eventMapping)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        firedEvents.removeAll()
+
+        try? bookmarksDatabase.tearDown(deleteStores: true)
+        bookmarksDatabase = nil
+        try? FileManager.default.removeItem(at: location)
+    }
+
+    func testWhenBookmarkIsDeletedAndAnotherIsMovedThenNoErrorIsFired() {
+
+        let context = favoriteListViewModel.context
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1", isFavorite: true, isDeleted: true)
+            Bookmark(id: "2", isFavorite: true)
+            Bookmark(id: "3", isFavorite: true, isDeleted: true)
+            Bookmark(id: "4", isFavorite: true)
+        }
+
+        context.performAndWait {
+            bookmarkTree.createEntities(in: context)
+
+            try! context.save()
+
+            let rootFavoriteFolder = BookmarkUtils.fetchFavoritesFolder(context)!
+            XCTAssertEqual(rootFavoriteFolder.favoritesArray.map(\.title), ["2", "4"])
+
+            let bookmark = BookmarkEntity.fetchBookmark(withUUID: "2", context: context)!
+            favoriteListViewModel.reloadData()
+            favoriteListViewModel.moveFavorite(bookmark, fromIndex: 0, toIndex: 1)
+            context.refreshAllObjects()
+
+            XCTAssertEqual(rootFavoriteFolder.favoritesArray.map(\.title), ["4", "2"])
+            XCTAssertEqual(firedEvents, [])
+        }
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1204953708712054/f
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Patch

**Description**:

Fix reordering of bookmarks in case there are objects pending deletion.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Delete first & last bookmarks from the list, then start reordering other ones.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
