### PR TITLE
Lowercase Emails

### DIFF
--- a/Sources/BrowserServicesKit/Email/EmailManager.swift
+++ b/Sources/BrowserServicesKit/Email/EmailManager.swift
@@ -309,11 +309,11 @@ public class EmailManager {
     }
 
     public func aliasFor(_ email: String) -> String {
-        return email.replacingOccurrences(of: "@" + Self.emailDomain, with: "")
+        return email.lowercased().replacingOccurrences(of: "@" + Self.emailDomain, with: "")
     }
 
     public func isPrivateEmail(email: String) -> Bool {
-        if email != userEmail?.lowercased() && email.hasSuffix(Self.emailDomain) {
+        if email != userEmail?.lowercased() && email.lowercased().hasSuffix(Self.emailDomain) {
             return true
         }
         return false


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205091595242093/f
What kind of version bump will this require?: Patch

**Description**:
Lowercases user input for private emails, so ecample@Duck.com and example@DuCK.com are treated as valid

**Steps to test this PR**:
1. Point the macOS or iOS "private email management" branch to this BSK branch
3. Generate a private email address so it's saved to your logins
4. Edit to change the duck.com part to have caps at random
5. Observe the email is still treated as a valid private address

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
