### PR TITLE
replace assertion in assertObjectDeallocated with sigint

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/OverlayAutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/OverlayAutofillUserScript.swift
@@ -70,7 +70,7 @@ public class OverlayAutofillUserScript: AutofillUserScript {
     }
 
     func closeAutofillParent(_ message: UserScriptMessage, _ replyHandler: MessageReplyHandler) {
-        guard let websiteAutofillInstance = websiteAutofillInstance else { return }
+        guard websiteAutofillInstance != nil else { return }
         closeAutofillParent()
         replyHandler(nil)
     }

--- a/Sources/Common/Extensions/NSObjectExtension.swift
+++ b/Sources/Common/Extensions/NSObjectExtension.swift
@@ -76,7 +76,7 @@ extension NSObject {
             return
         }
         let assertion = DispatchWorkItem { [unowned self] in
-            assertionFailure("\(self) has not been deallocated")
+            breakByRaisingSigInt("\(self) has not been deallocated. Ensure there‘s no retain cycle added.")
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: assertion)
         self.onDeinit {

--- a/Sources/Common/Extensions/NSObjectExtension.swift
+++ b/Sources/Common/Extensions/NSObjectExtension.swift
@@ -65,10 +65,28 @@ extension NSObject {
         }
     }
 
+    public struct DeallocationCheckAction {
+        let perform: (NSObject) -> Void
+        public init(action: @escaping (NSObject) -> Void) {
+            self.perform = action
+        }
+
+        public static let assert = DeallocationCheckAction { object in
+            assertionFailure("\(object) has not been deallocated. Ensure there‘s no retain cycle added.")
+        }
+        public static let interrupt = DeallocationCheckAction { object in
+        #if DEBUG
+            breakByRaisingSigInt("\(object) has not been deallocated. Ensure there‘s no retain cycle added.")
+        #endif
+        }
+        public static let log = DeallocationCheckAction { object in
+            os_log(.error, "\(object) has not been deallocated. Ensure there‘s no retain cycle added.")
+        }
+    }
 #if DEBUG
     /// DEBUG-only runtime check for an expected object deallocation
     /// will raise an assertionFailure if the object is not deallocated after the timeout
-    public func assertObjectDeallocated(after timeout: TimeInterval = 0) {
+    public func ensureObjectDeallocated(after timeout: TimeInterval = 0, do action: DeallocationCheckAction) {
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in
                 self?.assertObjectDeallocated(after: timeout)
@@ -76,7 +94,7 @@ extension NSObject {
             return
         }
         let assertion = DispatchWorkItem { [unowned self] in
-            breakByRaisingSigInt("\(self) has not been deallocated. Ensure there‘s no retain cycle added.")
+            action.perform(self)
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: assertion)
         self.onDeinit {
@@ -85,7 +103,12 @@ extension NSObject {
     }
 #else
     @inlinable
-    public func assertObjectDeallocated(after timeout: TimeInterval = 0) {}
+    public func ensureObjectDeallocated(after _: TimeInterval = 0, do _: DeallocationCheckAction) {}
 #endif
+
+    @inlinable
+    public func assertObjectDeallocated(after timeout: TimeInterval = 0) {
+        ensureObjectDeallocated(after: timeout, do: .assert)
+    }
 
 }

--- a/Sources/UserScript/UserScriptMessaging.swift
+++ b/Sources/UserScript/UserScriptMessaging.swift
@@ -112,7 +112,7 @@ public final class UserScriptMessageBroker: NSObject {
     }
 
     public func messagingConfig() -> WebkitMessagingConfig {
-        var config = WebkitMessagingConfig(
+        let config = WebkitMessagingConfig(
                 webkitMessageHandlerNames: [context],
                 secret: generatedSecret,
                 hasModernWebkitAPI: true
@@ -187,7 +187,7 @@ public final class UserScriptMessageBroker: NSObject {
         }
 
         /// just send empty params if absent
-        var methodParams: Any = [:] as Any
+        var methodParams: Any = [String: Any]()
         if let params = dict["params"] {
             methodParams = params
         }
@@ -215,7 +215,7 @@ public final class UserScriptMessageBroker: NSObject {
             /// As far as the client is concerned, a `notification` is fire-and-forget
         case .notify(let handler, let notification):
             do {
-                try await handler(notification.params, original)
+                _=try await handler(notification.params, original)
             } catch {
                 os_log("UserScriptMessaging: unhandled exception %s", type: .error, String(describing: error.localizedDescription))
             }
@@ -304,7 +304,7 @@ public enum MessageOriginPolicy {
                 case .exact(hostname: let hostname):
                     return hostname == origin
                     /// etldPlus1, like duckduckgo.com to match dev.duckduckgo.com + duckduckgo.com
-                case .etldPlus1(hostname: let hostname):
+                case .etldPlus1(hostname: _):
                     return false // todo - this isn't used yet!
                 }
             }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199230911884351/1205078062142519/f
iOS PR: not affected
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1374
What kind of version bump will this require?: Patch

**Description**:
replace deinit check assert with sigint; UPD: added different options
fix some warning

**Steps to test this PR**:
1. Make a retain cycle for Tab or WebView, close the tab
2. Ensure sigint is raised instead of assertion
