### PR TITLE
De-flake pinger tests

### DIFF
--- a/Sources/NetworkProtection/Networking/Pinger.swift
+++ b/Sources/NetworkProtection/Networking/Pinger.swift
@@ -100,20 +100,6 @@ public final class Pinger: @unchecked Sendable {
         self.getLogger = log
     }
 
-    public func ping(completion: @escaping (Result<PingResult, PingError>) -> Void) {
-        func mainQueueCompletion(_ r: Result<PingResult, PingError>) {
-            DispatchQueue.main.async {
-                completion(r)
-            }
-        }
-        queue.async { [weak self] in
-            guard let self else { return mainQueueCompletion(.failure(.cancelled)) }
-
-            let r = self.ping_unsafe()
-            mainQueueCompletion(r)
-        }
-    }
-
     public func ping() async -> Result<PingResult, PingError> {
         await withUnsafeContinuation { continuation in
             queue.async { [self /* held by async call */] in

--- a/Tests/NetworkProtectionTests/PingerTests.swift
+++ b/Tests/NetworkProtectionTests/PingerTests.swift
@@ -23,67 +23,44 @@ import XCTest
 
 final class PingerTests: XCTestCase {
 
-    func testPingValidIpShouldSucceed() {
+    func testPingValidIpShouldSucceed() async throws {
         let ip = IPv4Address("8.8.8.8")!
         let timeout = 3.0
 
-        let e = expectation(description: "ready")
-        Task {
-            do {
-                let pinger = Pinger(ip: ip, timeout: timeout, log: .default)
-                let r = try await pinger.ping().get()
+        let pinger = Pinger(ip: ip, timeout: timeout, log: .default)
+        let r = try await pinger.ping().get()
 
-                XCTAssertEqual(r.ip, ip)
-                XCTAssertLessThan(20, r.bytesCount)
-                XCTAssertEqual(r.seq, 0)
-                XCTAssertLessThanOrEqual(r.time/1000, timeout)
-                XCTAssertNotEqual(r.ttl, 0)
-
-            } catch {
-                XCTFail("error: \(error)")
-            }
-            e.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
+        XCTAssertEqual(r.ip, ip)
+        XCTAssertLessThan(20, r.bytesCount)
+        XCTAssertEqual(r.seq, 0)
+        XCTAssertLessThanOrEqual(r.time/1000, timeout)
+        XCTAssertNotEqual(r.ttl, 0)
     }
 
-    func testPingValidIpAsyncShouldSucceed() {
+    func testPingValidIpAsyncShouldSucceed() async throws {
         let ip = IPv4Address("8.8.8.8")!
         let timeout = 3.0
 
-        let e = expectation(description: "ready")
+        let pinger = Pinger(ip: ip, timeout: timeout, log: .default)
+        let r = try await pinger.ping().get()
 
-        Task {
-            do {
-                let pinger = Pinger(ip: ip, timeout: timeout, log: .default)
-                let r = try await pinger.ping().get()
+        XCTAssertEqual(r.ip, ip)
+        XCTAssertLessThan(20, r.bytesCount)
+        XCTAssertEqual(r.seq, 0)
+        XCTAssertLessThanOrEqual(r.time/1000, timeout)
+        XCTAssertNotEqual(r.ttl, 0)
 
-                XCTAssertEqual(r.ip, ip)
-                XCTAssertLessThan(20, r.bytesCount)
-                XCTAssertEqual(r.seq, 0)
-                XCTAssertLessThanOrEqual(r.time/1000, timeout)
-                XCTAssertNotEqual(r.ttl, 0)
+        // ping twice
+        let r2 = try await pinger.ping().get()
 
-                // ping twice
-                let r2 = try await pinger.ping().get()
-
-                XCTAssertEqual(r2.ip, ip)
-                XCTAssertEqual(r.bytesCount, r2.bytesCount)
-                XCTAssertEqual(r2.seq, 1)
-                XCTAssertLessThanOrEqual(r2.time/1000, timeout)
-                XCTAssertEqual(r.ttl, r2.ttl)
-
-            } catch {
-                XCTFail("error: \(error)")
-            }
-            e.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
+        XCTAssertEqual(r2.ip, ip)
+        XCTAssertEqual(r.bytesCount, r2.bytesCount)
+        XCTAssertEqual(r2.seq, 1)
+        XCTAssertLessThanOrEqual(r2.time/1000, timeout)
+        XCTAssertEqual(r.ttl, r2.ttl)
     }
 
-    func testNonExistentIpShouldTimeout() throws {
+    func testNonExistentIpShouldTimeout() async throws {
         let ip = IPv4Address("111.2.155.2")!
         let timeout = 0.2
 
@@ -102,11 +79,10 @@ final class PingerTests: XCTestCase {
             }
             e.fulfill()
         }
-
-        waitForExpectations(timeout: 5)
+        await fulfillment(of: [e], timeout: 5)
     }
 
-    func testNonExistentIpAsyncShouldTimeout() throws {
+    func testNonExistentIpAsyncShouldTimeout() async throws {
         let ip = IPv4Address("111.2.155.2")!
         let timeout = 0.2
 
@@ -126,7 +102,7 @@ final class PingerTests: XCTestCase {
             e.fulfill()
         }
 
-        waitForExpectations(timeout: 5)
+        await fulfillment(of: [e], timeout: 5)
     }
 
 }

--- a/Tests/NetworkProtectionTests/PingerTests.swift
+++ b/Tests/NetworkProtectionTests/PingerTests.swift
@@ -37,70 +37,22 @@ final class PingerTests: XCTestCase {
         XCTAssertNotEqual(r.ttl, 0)
     }
 
-    func testPingValidIpAsyncShouldSucceed() async throws {
-        let ip = IPv4Address("8.8.8.8")!
-        let timeout = 3.0
-
-        let pinger = Pinger(ip: ip, timeout: timeout, log: .default)
-        let r = try await pinger.ping().get()
-
-        XCTAssertEqual(r.ip, ip)
-        XCTAssertLessThan(20, r.bytesCount)
-        XCTAssertEqual(r.seq, 0)
-        XCTAssertLessThanOrEqual(r.time/1000, timeout)
-        XCTAssertNotEqual(r.ttl, 0)
-
-        // ping twice
-        let r2 = try await pinger.ping().get()
-
-        XCTAssertEqual(r2.ip, ip)
-        XCTAssertEqual(r.bytesCount, r2.bytesCount)
-        XCTAssertEqual(r2.seq, 1)
-        XCTAssertLessThanOrEqual(r2.time/1000, timeout)
-        XCTAssertEqual(r.ttl, r2.ttl)
-    }
-
     func testNonExistentIpShouldTimeout() async throws {
         let ip = IPv4Address("111.2.155.2")!
         let timeout = 0.2
 
         let e = expectation(description: "ready")
+        do {
+            let pinger = Pinger(ip: ip, timeout: timeout, log: .default)
+            _=try await pinger.ping().get()
 
-        let pinger = Pinger(ip: ip, timeout: timeout, log: .default)
-        pinger.ping { result in
-            XCTAssert(Thread.isMainThread)
-            do {
-                _=try result.get()
-                XCTFail("ping should fail")
-            } catch Pinger.PingError.timeout(.select) {
-                // pass
-            } catch {
-                XCTFail("error: \(error)")
-            }
-            e.fulfill()
+            XCTFail("ping should fail")
+        } catch Pinger.PingError.timeout(.select) {
+            // pass
+        } catch {
+            XCTFail("error: \(error)")
         }
-        await fulfillment(of: [e], timeout: 5)
-    }
-
-    func testNonExistentIpAsyncShouldTimeout() async throws {
-        let ip = IPv4Address("111.2.155.2")!
-        let timeout = 0.2
-
-        let e = expectation(description: "ready")
-        Task {
-            do {
-                let pinger = Pinger(ip: ip, timeout: timeout, log: .default)
-                _=try await pinger.ping().get()
-
-                XCTFail("ping should fail")
-
-            } catch Pinger.PingError.timeout(.select) {
-                // pass
-            } catch {
-                XCTFail("error: \(error)")
-            }
-            e.fulfill()
-        }
+        e.fulfill()
 
         await fulfillment(of: [e], timeout: 5)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1200194497630846/1205155153293825/f
iOS PR: Just a unit test update
macOS PR: Just a unit test update
What kind of version bump will this require?: None - only dead code and tests removed

**Optional**:

Tech Design URL:
CC:

**Description**:

These tests are flaky. However, they’re also testing async functions with pure XCTestExpectations without using async test functions. According to [this article](https://www.avanderlee.com/concurrency/unit-testing-async-await/), that can result in flakiness.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run CI and make sure it’s green

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
