### PR TITLE
os_log fixes

### DIFF
--- a/Sources/Bookmarks/BookmarksDatabaseCleaner.swift
+++ b/Sources/Bookmarks/BookmarksDatabaseCleaner.swift
@@ -21,7 +21,6 @@ import Foundation
 import Combine
 import Common
 import CoreData
-import os.log
 import Persistence
 
 public struct BookmarksCleanupError: Error {

--- a/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionDetection.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionDetection.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import Common
-import os.log
 
 public protocol AdClickAttributionDetectionDelegate: AnyObject {
     

--- a/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionLogic.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionLogic.swift
@@ -20,7 +20,6 @@
 import Foundation
 import ContentBlocking
 import Common
-import os.log
 
 public protocol AdClickAttributionLogicDelegate: AnyObject {
     

--- a/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionRulesProvider.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionRulesProvider.swift
@@ -20,7 +20,6 @@
 import Foundation
 import TrackerRadarKit
 import Common
-import os.log
 
 public protocol AdClickAttributionRulesProviding {
     

--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerRulesManager.swift
@@ -22,7 +22,6 @@ import WebKit
 import TrackerRadarKit
 import Combine
 import Common
-import os.log
 
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length

--- a/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgrade.swift
+++ b/Sources/BrowserServicesKit/SmarterEncryption/HTTPSUpgrade.swift
@@ -20,7 +20,6 @@
 import Common
 import Foundation
 import BloomFilterWrapper
-import os.log
 
 public enum HTTPSUpgradeError: Error {
     case badUrl

--- a/Sources/BrowserServicesKit/SmarterEncryption/Store/AppHTTPSUpgradeStore.swift
+++ b/Sources/BrowserServicesKit/SmarterEncryption/Store/AppHTTPSUpgradeStore.swift
@@ -22,7 +22,6 @@ import Common
 import Foundation
 import CoreData
 import Persistence
-import os.log
 
 public struct AppHTTPSUpgradeStore: HTTPSUpgradeStore {
 

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -176,15 +176,27 @@ public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogTy
     os.os_log(message, log: log, type: type, arg1(), arg2(), arg3(), arg4(), arg5())
 }
 
+public enum LogVisibility {
+    case `private`
+    case `public`
+}
+
 @inlinable
 @_disfavoredOverload
-public func os_log(_ message: @autoclosure () -> String, log: OSLog = .default, type: OSLogType = .default) {
+public func os_log(_ visibility: LogVisibility = .private, _ message: @autoclosure () -> String, log: OSLog = .default, type: OSLogType = .default) {
     guard log != .disabled else { return }
 #if DEBUG
     // enable .debug/.info logging in DEBUG builds
     let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
 #endif
 
+#if !DEBUG
+    if visibility == .private {
+        os_log("%s", log: log, type: type, message())
+        return
+    }
+#endif
+    // always log to Console app (public) in DEBUG
     os_log("%{public}s", log: log, type: type, message())
 }
 
@@ -267,13 +279,20 @@ public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ messag
 
 @inlinable
 @_disfavoredOverload
-public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: @autoclosure () -> String) {
+public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: @autoclosure () -> String, _ visibility: LogVisibility = .private) {
     guard log != .disabled else { return }
 #if DEBUG
     // enable .debug/.info logging in DEBUG builds
     let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
 #endif
 
+#if !DEBUG
+    if visibility == .private {
+        os_log("%s", log: log, type: type, message())
+        return
+    }
+#endif
+    // always log to Console app (public) in DEBUG
     os_log("%{public}s", log: log, type: type, message())
 }
 

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -182,8 +182,7 @@ public enum LogVisibility {
 }
 
 @inlinable
-@_disfavoredOverload
-public func os_log(_ visibility: LogVisibility = .private, _ message: @autoclosure () -> String, log: OSLog = .default, type: OSLogType = .default) {
+public func os_log(_ visibility: LogVisibility, _ message: @autoclosure () -> String, log: OSLog = .default, type: OSLogType = .default) {
     guard log != .disabled else { return }
 #if DEBUG
     // enable .debug/.info logging in DEBUG builds
@@ -198,6 +197,12 @@ public func os_log(_ visibility: LogVisibility = .private, _ message: @autoclosu
 #endif
     // always log to Console app (public) in DEBUG
     os_log("%{public}s", log: log, type: type, message())
+}
+
+@inlinable
+@_disfavoredOverload
+public func os_log(_ message: @autoclosure () -> String, log: OSLog = .default, type: OSLogType = .default) {
+    os_log(.private, message(), log: log, type: type)
 }
 
 // MARK: - type first
@@ -279,7 +284,7 @@ public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ messag
 
 @inlinable
 @_disfavoredOverload
-public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: @autoclosure () -> String, _ visibility: LogVisibility = .private) {
+public func os_log(_ type: OSLogType, log: OSLog, _ message: @autoclosure () -> String, _ visibility: LogVisibility = .private) {
     guard log != .disabled else { return }
 #if DEBUG
     // enable .debug/.info logging in DEBUG builds
@@ -294,6 +299,24 @@ public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ messag
 #endif
     // always log to Console app (public) in DEBUG
     os_log("%{public}s", log: log, type: type, message())
+}
+
+@inlinable
+@_disfavoredOverload
+public func os_log(log: OSLog, _ message: @autoclosure () -> String, _ visibility: LogVisibility = .private) {
+    os_log(.default, log: log, message(), visibility)
+}
+
+@inlinable
+@_disfavoredOverload
+public func os_log(_ type: OSLogType, _ message: @autoclosure () -> String, _ visibility: LogVisibility = .private) {
+    os_log(type, log: .default, message(), visibility)
+}
+
+@inlinable
+@_disfavoredOverload
+public func os_log(_ message: @autoclosure () -> String, _ visibility: LogVisibility = .private) {
+    os_log(.default, log: .default, message(), visibility)
 }
 
 // swiftlint:enable line_length

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -24,6 +24,18 @@ public typealias OSLog = os.OSLog
 
 extension OSLog {
 
+    /// "exporting" `OSLog.disabled` symbol without needing to `import os.log` to disambiguate `os_log` wrapper calls and suppress "implicit import" warning
+    /// this declaration shadows the real `OSLog.disabled`
+    public static let disabled: OSLog = {
+        // the `OSLog` object returned by `OSLog.disabled` is in fact an `os_log_t *` pointer returned by `_os_log_disabled` C function
+        guard let disabledLog = dlsym(/*RTLD_DEFAULT*/ UnsafeMutableRawPointer(bitPattern: -2), "_os_log_disabled") else {
+            // just in case it fails for whatever reason (but it shouldn‘t) - return some log object
+            assertionFailure("_os_log_disabled symbol not found")
+            return .init(subsystem: "", category: "")
+        }
+        return unsafeBitCast(disabledLog, to: OSLog.self)
+    }()
+
     public enum Categories: String, CaseIterable {
         case userScripts = "User Scripts"
         case passwordManager = "Password Manager"
@@ -97,6 +109,10 @@ extension ProcessInfo {
 
 @inlinable
 public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType) {
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
     os.os_log(message, log: log, type: type)
 }
 
@@ -108,30 +124,55 @@ public func os_log(_ message: StaticString, log: OSLog) {
 @inlinable
 public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1())
 }
 
 @inlinable
 public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1(), arg2())
 }
 
 @inlinable
 public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1(), arg2(), arg3())
 }
 
 @inlinable
 public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg, _ arg4: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1(), arg2(), arg3(), arg4())
 }
 
 @inlinable
 public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogType = .default, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg, _ arg4: @autoclosure () -> some CVarArg, _ arg5: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1(), arg2(), arg3(), arg4(), arg5())
 }
 
@@ -139,13 +180,23 @@ public func os_log(_ message: StaticString, log: OSLog = .default, type: OSLogTy
 @_disfavoredOverload
 public func os_log(_ message: @autoclosure () -> String, log: OSLog = .default, type: OSLogType = .default) {
     guard log != .disabled else { return }
-    os_log("%s", log: log, type: type, message())
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
+    os_log("%{public}s", log: log, type: type, message())
 }
 
 // MARK: - type first
 
 @inlinable
 public func os_log(_ type: OSLogType, log: OSLog = .default, _ message: StaticString) {
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type)
 }
 
@@ -162,30 +213,55 @@ public func os_log(_ message: StaticString) {
 @inlinable
 public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1())
 }
 
 @inlinable
 public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1(), arg2())
 }
 
 @inlinable
 public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1(), arg2(), arg3())
 }
 
 @inlinable
 public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg, _ arg4: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1(), arg2(), arg3(), arg4())
 }
 
 @inlinable
 public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: StaticString, _ arg1: @autoclosure () -> some CVarArg, _ arg2: @autoclosure () -> some CVarArg, _ arg3: @autoclosure () -> some CVarArg, _ arg4: @autoclosure () -> some CVarArg, _ arg5: @autoclosure () -> some CVarArg) {
     guard log != .disabled else { return }
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
     os.os_log(message, log: log, type: type, arg1(), arg2(), arg3(), arg4(), arg5())
 }
 
@@ -193,7 +269,12 @@ public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ messag
 @_disfavoredOverload
 public func os_log(_ type: OSLogType = .default, log: OSLog = .default, _ message: @autoclosure () -> String) {
     guard log != .disabled else { return }
-    os_log("%s", log: log, type: type, message())
+#if DEBUG
+    // enable .debug/.info logging in DEBUG builds
+    let type = OSLogType(min(type.rawValue, OSLogType.default.rawValue))
+#endif
+
+    os_log("%{public}s", log: log, type: type, message())
 }
 
 // swiftlint:enable line_length

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -27,7 +27,7 @@ extension OSLog {
     /// "exporting" `OSLog.disabled` symbol without needing to `import os.log` to disambiguate `os_log` wrapper calls and suppress "implicit import" warning
     /// this declaration shadows the real `OSLog.disabled`
     public static let disabled: OSLog = {
-        // the `OSLog` object returned by `OSLog.disabled` is in fact an `os_log_t *` pointer returned by `_os_log_disabled` C function
+        // the `OSLog` object returned by `OSLog.disabled` is in fact an `os_log_t *` pointer defined by C `_os_log_disabled` symbol
         guard let disabledLog = dlsym(/*RTLD_DEFAULT*/ UnsafeMutableRawPointer(bitPattern: -2), "_os_log_disabled") else {
             // just in case it fails for whatever reason (but it shouldn‘t) - return some log object
             assertionFailure("_os_log_disabled symbol not found")

--- a/Sources/Configuration/ConfigurationFetching.swift
+++ b/Sources/Configuration/ConfigurationFetching.swift
@@ -20,7 +20,6 @@
 import Foundation
 import Common
 import Networking
-import os.log
 
 protocol ConfigurationFetching {
 

--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -20,7 +20,6 @@ import Foundation
 import Combine
 import DDGSyncCrypto
 import Common
-import os.log
 
 public class DDGSync: DDGSyncing {
 

--- a/Sources/DDGSync/internal/RemoteAPIRequestCreator.swift
+++ b/Sources/DDGSync/internal/RemoteAPIRequestCreator.swift
@@ -19,7 +19,6 @@
 import Foundation
 import Networking
 import Common
-import os.log
 
 struct RemoteAPIRequestCreator: RemoteAPIRequestCreating {
 

--- a/Sources/DDGSync/internal/SyncOperation.swift
+++ b/Sources/DDGSync/internal/SyncOperation.swift
@@ -20,7 +20,6 @@
 import Foundation
 import Combine
 import Common
-import os
 
 class SyncOperation: Operation {
 

--- a/Sources/DDGSync/internal/SyncQueue.swift
+++ b/Sources/DDGSync/internal/SyncQueue.swift
@@ -20,7 +20,6 @@
 import Foundation
 import Combine
 import Common
-import os
 
 struct FeatureError: Error {
     let feature: Feature

--- a/Sources/Networking/APIRequest.swift
+++ b/Sources/Networking/APIRequest.swift
@@ -19,7 +19,6 @@
 
 import Common
 import Foundation
-import os.log
 
 public typealias APIResponse = (data: Data?, response: HTTPURLResponse)
 public typealias APIRequestCompletion = (APIResponse?, APIRequest.Error?) -> Void


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1205157723964854/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1875
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1406
What kind of version bump will this require?: Patch

**Optional**:

**Description**:
- fixes "implicit import" warning
- fixes "<private>" message in Console app for interpolated messages: will always output "public" for DEBUG builds
- added `.public` modifier argument to `os_log` with string interpolation: `os_log(.public, "interpolated \(arg)")`, `os_log("interpolated \(arg)", log: log, .public)`
- outputs .debug messages to Console app for DEBUG builds

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate macOS & iOS projects build&run, there shouldn‘t be "implicit import" warning for the .disabled OSLog default arguments
2. add interpolated os_log output, validate it‘s shown in Console app: `os_log("some interpolated \(value)")` in DEBUG mode and not shown in RELEASE
3. validate `os_log(.public, "interpolated \(arg)")`, `os_log("interpolated \(arg)", log: log, .public)` calls with `.puiblic` modifier argument always output in Console app even in RELEASE
4. validate `.debug` level os_log is shown in Console app: `os_log("test debug message", type: .debug)`

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS
* [ ] macOS
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
