### PR TITLE
Create NetworkProtectionTestUtils

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
         .library(name: "Navigation", targets: ["Navigation"]),
         .library(name: "SyncDataProviders", targets: ["SyncDataProviders"]),
         .library(name: "NetworkProtection", targets: ["NetworkProtection"]),
-        .library(name: "SecureStorage", targets: ["SecureStorage"]),
+        .library(name: "NetworkProtectionTestUtils", targets: ["NetworkProtectionTestUtils"]),
+        .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [
         .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "7.2.0"),
@@ -200,6 +201,12 @@ let package = Package(
             ]
         ),
         .target(name: "WireGuardC"),
+        .target(
+            name: "NetworkProtectionTestUtils",
+            dependencies: [
+                "NetworkProtection"
+            ]
+        ),
 
         // MARK: - Test Targets
 

--- a/Sources/NetworkProtectionTestUtils/FeatureActivation/NetworkProtectionCodeRedemptionCoordinatorTestExtensions.swift
+++ b/Sources/NetworkProtectionTestUtils/FeatureActivation/NetworkProtectionCodeRedemptionCoordinatorTestExtensions.swift
@@ -1,0 +1,45 @@
+//
+//  NetworkProtectionRedemptionCoordinatorTestExtensions.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import NetworkProtection
+import Common
+
+public extension NetworkProtectionCodeRedemptionCoordinator {
+    private static var errorEvents: EventMapping<NetworkProtectionError> = .init { _, _, _, _ in
+    }
+
+    class func stubbed() -> NetworkProtectionCodeRedemptionCoordinator {
+        whereRedeemSucceeds()
+    }
+
+    class func whereRedeemSucceeds(returning token: String = "") -> NetworkProtectionCodeRedemptionCoordinator {
+        let client = MockNetworkProtectionClient()
+        client.stubRedeem = .success(token)
+        let tokenStore = MockNetworkProtectionTokenStorage()
+        return NetworkProtectionCodeRedemptionCoordinator(networkClient: client, tokenStore: tokenStore, errorEvents: errorEvents)
+    }
+
+    class func whereRedeemFails(returning error: NetworkProtectionClientError = .failedToEncodeRedeemRequest) -> NetworkProtectionCodeRedemptionCoordinator {
+        let client = MockNetworkProtectionClient()
+        client.stubRedeem = .failure(error)
+        let tokenStore = MockNetworkProtectionTokenStorage()
+        return NetworkProtectionCodeRedemptionCoordinator(networkClient: client, tokenStore: tokenStore, errorEvents: errorEvents)
+    }
+}

--- a/Sources/NetworkProtectionTestUtils/KeyManagement/MockNetworkProtectionTokenStore.swift
+++ b/Sources/NetworkProtectionTestUtils/KeyManagement/MockNetworkProtectionTokenStore.swift
@@ -1,0 +1,46 @@
+//
+//  MockNetworkProtectionTokenStorage.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import NetworkProtection
+
+public final class MockNetworkProtectionTokenStorage: NetworkProtectionTokenStore {
+
+    var spyToken: String?
+    var storeError: Error?
+
+    public func store(_ token: String) throws {
+        if let storeError {
+            throw storeError
+        }
+        spyToken = token
+    }
+
+    var stubFetchToken: String?
+
+    public func fetchToken() throws -> String? {
+        return stubFetchToken
+    }
+
+    var didCallDeleteToken: Bool = false
+
+    public func deleteToken() throws {
+        didCallDeleteToken = true
+    }
+}

--- a/Sources/NetworkProtectionTestUtils/Networking/MockNetworkProtectionClient.swift
+++ b/Sources/NetworkProtectionTestUtils/Networking/MockNetworkProtectionClient.swift
@@ -1,0 +1,47 @@
+//
+//  MockNetworkProtectionClient.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import NetworkProtection
+
+public final class MockNetworkProtectionClient: NetworkProtectionClient {
+    public var spyRedeemInviteCode: String?
+    public var stubRedeem: Result<String, NetworkProtection.NetworkProtectionClientError> = .success("")
+
+    public func redeem(inviteCode: String) async -> Result<String, NetworkProtection.NetworkProtectionClientError> {
+        spyRedeemInviteCode = inviteCode
+        return stubRedeem
+    }
+
+    public var spyGetServersAuthToken: String?
+    public var stubGetServers: Result<[NetworkProtection.NetworkProtectionServer], NetworkProtection.NetworkProtectionClientError> = .success([])
+
+    public func getServers(authToken: String) async -> Result<[NetworkProtection.NetworkProtectionServer], NetworkProtection.NetworkProtectionClientError> {
+        spyGetServersAuthToken = authToken
+        return stubGetServers
+    }
+
+    public var spyRegister: (authToken: String, publicKey: NetworkProtection.PublicKey, serverName: String?)?
+    public var stubRegister: Result<[NetworkProtection.NetworkProtectionServer], NetworkProtection.NetworkProtectionClientError> = .success([])
+
+    public func register(authToken: String, publicKey: NetworkProtection.PublicKey, withServerNamed serverName: String?) async -> Result<[NetworkProtection.NetworkProtectionServer], NetworkProtection.NetworkProtectionClientError> {
+        spyRegister = (authToken: authToken, publicKey: publicKey, serverName: serverName)
+        return stubRegister
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205084446087083/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1883
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1415
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL:
CC:

**Description**:

Adds some test helpers and mocks for NetP to a NetworkProtectionTestUtils library.

**Steps to test this PR**:
1. Just run the tests in the iOS codebase as it’s only test helpers for NetP

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
