### PR TITLE
Update autofill to 8.1.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "b1160df954eea20cd4cdf9356afc369751981b16",
-        "version" : "8.0.0"
+        "revision" : "56f1a4e8879888d05331c5749f49a7b6aa9c6a1d",
+        "version" : "8.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [        
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.0.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.1.1"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205223917466051/1205223917466051
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.1


## Description
Updates Autofill to version [8.1.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.1).

### Autofill 8.1.1 release notes
## What's Changed
* Add shared creds by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/361


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.1.0...8.1.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).