### PR TITLE
Update autofill to 8.1.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "b1160df954eea20cd4cdf9356afc369751981b16",
-        "version" : "8.0.0"
+        "revision" : "40bcd0d347b51d14e8114f191df2817d8dcb4284",
+        "version" : "8.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [        
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.0.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.1.2"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205255555424025/1205255555424025
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.2


## Description
Updates Autofill to version [8.1.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.2).

### Autofill 8.1.2 release notes
## What's Changed
* Ema/fix script naming by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/364
* Minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/365
* Send a breakage report flag when autofill is "activated" on the page by @muodov in https://github.com/duckduckgo/duckduckgo-autofill/pull/363
* Fix extension bugs by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/366
* Add regression test by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/367

## New Contributors
* @muodov made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/363

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.1.1...8.1.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).