### PR TITLE
extend valid urls to include IPv6

### DIFF
--- a/Sources/Common/Extensions/StringExtension.swift
+++ b/Sources/Common/Extensions/StringExtension.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import Punycode
+import Network
 
 public typealias RegEx = NSRegularExpression
 
@@ -28,9 +29,6 @@ public func regex(_ pattern: String, _ options: NSRegularExpression.Options = []
 extension RegEx {
     // from https://stackoverflow.com/a/25717506/73479
     static let hostName = regex("^(((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)*[A-Za-z0-9-]{2,63})$", .caseInsensitive)
-    // from https://stackoverflow.com/a/30023010/73479
-    static let ipAddress = regex("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
-                                 .caseInsensitive)
 }
 
 public extension String {
@@ -104,7 +102,10 @@ public extension String {
     }
 
     var isValidIpHost: Bool {
-        return matches(.ipAddress)
+        if IPv4Address(self) != nil || IPv6Address(self) != nil {
+            return true
+        }
+        return false
     }
 
     func matches(_ regex: NSRegularExpression) -> Bool {

--- a/Tests/CommonTests/Extensions/URLExtensionTests.swift
+++ b/Tests/CommonTests/Extensions/URLExtensionTests.swift
@@ -61,6 +61,11 @@ final class URLExtensionTests: XCTestCase {
             .init("sheep%2B:P%40%24swrd@xn--ls8h.la/?arg=b#1"),
             .init("https://sheep%2B:P%40%24swrd@💩.la"),
             .init("data:text/vnd-example+xyz;foo=bar;base64,R0lGODdh"),
+            .init("http://192.168.0.1"),
+            .init("http://203.0.113.0"),
+            .init("http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"),
+            .init("http://[2001:0db8::1]"),
+            .init("http://[::]:8080")
         ]
         for item in urls {
             XCTAssertTrue(item.url!.isValid, item.rawValue, line: item.line)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203127427026896/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1919
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1492
What kind of version bump will this require?: Major/Minor/Patch

**Description**: Makes IPv6 valid url when used in navigation.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Type on the search bar http://[::]:8080/ it should navigate to it rather than searching
2. Try the same for other IPv6 or IPv4 addresses ex: 
http://192.168.0.1
http://203.0.113.0
http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]
http://[2001:0db8::1]

<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
