### PR TITLE
Validate canonical links are http(s) only

### DIFF
--- a/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
+++ b/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
@@ -44,6 +44,7 @@ public class LinkCleaner {
     
     public func isURLExcluded(url: URL, feature: PrivacyFeature = .ampLinks) -> Bool {
         guard let host = url.host else { return true }
+        guard url.scheme == "http" || url.scheme == "https" else { return true }
         
         return !privacyConfig.isFeature(feature, enabledForDomain: host)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL:  https://app.asana.com/0/1177771139624306/1205292391529323/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1922
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1497
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

Validates that we're not redirecting to unsupported URL schemes.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
