### PR TITLE
Update autofill to 8.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "40bcd0d347b51d14e8114f191df2817d8dcb4284",
-        "version" : "8.1.2"
+        "revision" : "20a6aeddbd86b43fd83c42aa45fdd9ec6db0e0f7",
+        "version" : "8.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.1.2"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.2.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205338112741817/1205338112741817
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.2.0


## Description
Updates Autofill to version [8.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.2.0).

### Autofill 8.2.0 release notes
## What's Changed
* Updates for iOS in-context signup support by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/347
* Trigger tooltip option on pointer up by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/333


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.1.2...8.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).