### PR TITLE
Disabling flaky Navigation Redirect test

### DIFF
--- a/Tests/NavigationTests/NavigationRedirectsTests.swift
+++ b/Tests/NavigationTests/NavigationRedirectsTests.swift
@@ -30,7 +30,7 @@ import XCTest
 @available(macOS 12.0, iOS 15.0, *)
 class NavigationRedirectsTests: DistributedNavigationDelegateTestsBase {
 
-    func testClientRedirectToSameDocument() throws {
+    func skip_testClientRedirectToSameDocument() throws {
         let customCallbacksHandler = CustomCallbacksHandler()
         navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })), .weak(customCallbacksHandler))
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1205237866452338/1205344247172464/f, https://app.asana.com/0/1200194497630846/1204022321706940/f 
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Patch

**Description**:
Disables a flaky test

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Confirm test `testClientRedirectToSameDocument` is skipped

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
