### PR TITLE
Change service name for NetP auth tokens.

### DIFF
--- a/Sources/NetworkProtection/KeyManagement/NetworkProtectionKeychainStore.swift
+++ b/Sources/NetworkProtection/KeyManagement/NetworkProtectionKeychainStore.swift
@@ -42,8 +42,8 @@ final class NetworkProtectionKeychainStore {
     private let keychainType: KeychainType
 
     init(label: String,
-                serviceName: String,
-                keychainType: KeychainType) {
+        serviceName: String,
+        keychainType: KeychainType) {
 
         self.label = label
         self.serviceName = serviceName

--- a/Sources/NetworkProtection/KeyManagement/NetworkProtectionTokenStore.swift
+++ b/Sources/NetworkProtection/KeyManagement/NetworkProtectionTokenStore.swift
@@ -40,16 +40,17 @@ public final class NetworkProtectionKeychainTokenStore: NetworkProtectionTokenSt
     private let keychainStore: NetworkProtectionKeychainStore
     private let errorEvents: EventMapping<NetworkProtectionError>?
 
-    private struct Defaults {
+    public struct Defaults {
         static let tokenStoreEntryLabel = "DuckDuckGo Network Protection Auth Token"
-        static let tokenStoreService = "\(Bundle.main.bundleIdentifier!).authToken"
+        public static let tokenStoreService = "com.duckduckgo.networkprotection.authToken"
         static let tokenStoreName = "com.duckduckgo.networkprotection.token"
     }
 
     public init(keychainType: KeychainType,
+                serviceName: String = Defaults.tokenStoreService,
                 errorEvents: EventMapping<NetworkProtectionError>?) {
         keychainStore = NetworkProtectionKeychainStore(label: Defaults.tokenStoreEntryLabel,
-                                                       serviceName: Defaults.tokenStoreService,
+                                                       serviceName: serviceName,
                                                        keychainType: keychainType)
         self.errorEvents = errorEvents
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205354504536670/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1956
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1552
What kind of version bump will this require?: Minor

## Description

Uses a default for the auth token service that does not depend on the app's bundle ID.

## Testing

Test these changes in the iOS and macOS PRs.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
