### PR TITLE
Use unencrypted password for deduplicated Credentials objects

### DIFF
--- a/Sources/BrowserServicesKit/SecureVault/AutofillSecureVault.swift
+++ b/Sources/BrowserServicesKit/SecureVault/AutofillSecureVault.swift
@@ -336,6 +336,9 @@ public class DefaultAutofillSecureVault<T: AutofillDatabaseProvider>: AutofillSe
                                  key l2Key: Data? = nil,
                                  salt: Data? = nil) throws -> SecureVaultModels.WebsiteCredentials {
         do {
+            if let password = credentials.password, String(bytes: password, encoding: .utf8) == nil {
+                assertionFailure("Encrypted password passed to \(#function)")
+            }
             // Generate a new signature
             let hashData = credentials.account.hashValue + (credentials.password ?? Data())
             var creds = credentials

--- a/Sources/SyncDataProviders/Credentials/internal/CredentialsResponseHandler.swift
+++ b/Sources/SyncDataProviders/Credentials/internal/CredentialsResponseHandler.swift
@@ -160,11 +160,14 @@ final class CredentialsResponseHandler {
         }
 
         if let password, let passwordData = password.data(using: .utf8) {
-            return try syncableCredentials.first(where: { credentials in
+            var matchingSyncableCredentials = try syncableCredentials.first(where: { credentials in
                 let decryptedPassword = try credentials.credentialsRecord?.password
                     .flatMap { try secureVault.decrypt($0, using: secureVaultEncryptionKey) }
                 return decryptedPassword == passwordData
             })
+            // update matched credentials with decrypted password, as that's what Secure Vault expects
+            matchingSyncableCredentials?.credentials?.password = passwordData
+            return matchingSyncableCredentials
         }
         return syncableCredentials.first(where: { $0.credentialsRecord?.password == nil })
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199230911884351/1205352938100234/f
iOS PR: https://github.com/duckduckgo/iOS/pull/1959
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1554
What kind of version bump will this require?: Patch

**Description**:
Credentials deduplication code looks for an existing credentials entity in the Secure Vault,
then returns it to Sync code where its title is updated, and then the credentials entity is passed
back to Secure Vault to be stored. The storing function expects unencrypted password
(such as when passed from the UI) and does encryption before storing.

The issue here was that we were passing an already encrypted password (just retrieved
from Secure Vault) in which case the encryption function failed to encrypt the value, returning nil.

This patch fixes the problem on the Sync Data Provider end (to feed an unencrypted password
to Secure Vault for saving) and also adds an assertion failure to AutofillSecureVault when an encrypted
password is passed to encryptPassword method.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Refer to macOS PR for testing steps.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
