### PR TITLE
Enable nightly CodeQL scans

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "sam/codeql" ]
+  schedule:
+    - cron: '0 2 * * *' # Run at 2 AM UTC
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: macos-13
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: "swift"
+
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_14.3.app/Contents/Developer
+
+    - run: swift build
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:swift"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "sam/codeql" ]
   schedule:
     - cron: '0 2 * * *' # Run at 2 AM UTC
 

--- a/Sources/BrowserServicesKit/SecureVault/AutofillSecureVault.swift
+++ b/Sources/BrowserServicesKit/SecureVault/AutofillSecureVault.swift
@@ -127,6 +127,14 @@ public class DefaultAutofillSecureVault<T: AutofillDatabaseProvider>: AutofillSe
     public required init(providers: AutofillStorageProviders) {
         self.providers = providers
         self.expiringPassword = ExpiringValue(expiresAfter: 60 * 60 * 24 * 3)
+
+
+        let tainted = try! String(contentsOf: URL(string: "http://example.com")!)
+
+        let a = String("abc") // GOOD: not a format string
+        let b = String(tainted) // GOOD: not a format string
+        let c = String(format: "abc") // GOOD: not tainted
+        let d = String(format: tainted) // BAD
     }
 
     // MARK: - public interface (protocol candidates)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205371338744155/f
iOS PR: N/A
macOS PR: N/A
What kind of version bump will this require?: None, this is a workflow change

CC: @ayoy 

**Description**:

This PR enables nightly CodeQL scans. The iOS equivalent was done here: https://github.com/duckduckgo/iOS/pull/1958

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check that this PR has a CodeQL alert visible
1. Remove the code that triggers this alert (see commit history for that)
1. Check that the alert goes away

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
