### PR TITLE
Fix auth token issues

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -131,6 +131,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                                                                   errorEvents: debugEvents)
 
     private lazy var tokenStore = NetworkProtectionKeychainTokenStore(keychainType: keychainType,
+                                                                      serviceName: "\(Bundle.main.bundleIdentifier!).authToken",
                                                                       errorEvents: debugEvents)
 
     /// This is for overriding the defaults.  A `nil` value means NetP will just use the defaults.

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -130,9 +130,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     private lazy var keyStore = NetworkProtectionKeychainKeyStore(keychainType: keychainType,
                                                                   errorEvents: debugEvents)
 
-    private lazy var tokenStore = NetworkProtectionKeychainTokenStore(keychainType: keychainType,
-                                                                      serviceName: "\(Bundle.main.bundleIdentifier!).authToken",
-                                                                      errorEvents: debugEvents)
+    private let tokenStore: NetworkProtectionTokenStore
 
     /// This is for overriding the defaults.  A `nil` value means NetP will just use the defaults.
     ///
@@ -305,12 +303,14 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 tunnelHealthStore: NetworkProtectionTunnelHealthStore,
                 controllerErrorStore: NetworkProtectionTunnelErrorStore,
                 keychainType: KeychainType,
+                tokenStore: NetworkProtectionTokenStore,
                 debugEvents: EventMapping<NetworkProtectionError>?,
                 providerEvents: EventMapping<Event>) {
         os_log("[+] PacketTunnelProvider", log: .networkProtectionMemoryLog, type: .debug)
 
         self.notificationsPresenter = notificationsPresenter
         self.keychainType = keychainType
+        self.tokenStore = tokenStore
         self.debugEvents = debugEvents
         self.providerEvents = providerEvents
         self.tunnelHealth = tunnelHealthStore


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205381920971737/f
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1563
iOS PR: https://github.com/duckduckgo/iOS/pull/1966

## Description

Fixes some auth token regressions.  See the parent task for background info.

The issue is that our system extension still needs per-build service names, while our App and agent don't (and are better off without them).

## Steps to test this PR

Use the macOS PR to test this.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
