### PR TITLE
Removes the auth token when a resetAllState message is received

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -663,6 +663,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         let serverCache = NetworkProtectionServerListFileSystemStore(errorEvents: nil)
         try? serverCache.removeServerList()
+
+        try? tokenStore.deleteToken()
+
         // This is not really an error, we received a command to reset the connection
         cancelTunnelWithError(nil)
         completionHandler?(nil)
@@ -727,6 +730,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     private func handleTriggerTestNotification(completionHandler: ((Data?) -> Void)? = nil) {
         notificationsPresenter.showTestNotification()
+        completionHandler?(nil)
     }
 
     private func setExcludedRoutes(_ excludedRoutes: [IPAddressRange], completionHandler: ((Data?) -> Void)? = nil) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205416442924462/f

iOS PR: https://github.com/duckduckgo/iOS/pull/1975
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1588
What kind of version bump will this require?: Patch

## Description

When the extension receives a `resetAllState` message, it's now properly cleaning the stored auth token.
Executes a callback that was missing.

## Testing

Rely on the instructions in the macOS and iOS PRs.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
