### PR TITLE
swizzle WKNavigationAction.request, return empty request if nil

### DIFF
--- a/Sources/Common/Debug.swift
+++ b/Sources/Common/Debug.swift
@@ -54,7 +54,7 @@ public func callingSymbol() -> String {
         // caller for the procedure
         callingSymbolIdx += 1
         let line = stackTrace[callingSymbolIdx].replacingOccurrences(of: Bundle.main.name!, with: "DDG")
-        symbolName = String(line.split(separator: " ")[3])
+        symbolName = String(line.split(separator: " ", maxSplits: 3)[3]).components(separatedBy: " + ")[0]
     } while stackTrace[callingSymbolIdx - 1].contains(symbolName.dropping(suffix: "To")) // skip objc wrappers
 
     return symbolName

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -89,6 +89,7 @@ public final class DistributedNavigationDelegate: NSObject {
 #if !_MAIN_FRAME_NAVIGATION_ENABLED
         _=WKWebView.swizzleLoadMethodOnce
 #endif
+        _=WKNavigationAction.swizzleRequestOnce
     }
 
     /** set responder chain for Navigation Events with defined ownership and nullability:

--- a/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
+++ b/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
@@ -58,6 +58,8 @@ public extension WKFrameInfo {
 
         // ignore `request` selector calls from `safeRequest` itself
         ignoredRequestUsageSymbols.insert(callingSymbol())
+        // ignore `-[WKFrameInfo description]`
+        ignoredRequestUsageSymbols.insert("-[WKFrameInfo description]")
     }()
 
     @objc dynamic private func swizzledRequest() -> URLRequest? {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1205419940512581/f
macOS PR: 
iOS PR: not affected
What kind of version bump will this require?: Patch

**Description**:
- swizzle WKNavigationAction.request and return empty URLRequest if it‘s nil


**Steps to test this PR**:
1. On the home page navigate to "about:blank", then duplicate tab - > new blank window is open
2. Open developer console, run `document.body.innerHTML = '<a id="a" href="/">link</a>'`
3. Enter in the console: `setTimeout(function() { document.getElementById("a").removeAttribute("href") }, 2000)` but don‘t submit just yet
4. Point cursor to the created link
5. Press enter in the Console then instantly right-click the link
6. Wait until the link turns black
7. Choose Copy Link → ensure there‘s no crash


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->
