### PR TITLE
Add last updated parameter to sorting

### DIFF
--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -521,7 +521,7 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
         return urlComponents.eTLDplus1(tld: tld)
     }
 
-    // Last Updated (if accountForLastUpdate = true) > Alphabetical Domain > Alphabetical Username > Empty Usernames
+    // Last Updated (if alphabeticalOnly = false) > Alphabetical Domain > Alphabetical Username > Empty Usernames
     private func compareAccount(_ account1: SecureVaultModels.WebsiteAccount,
                                 _ account2: SecureVaultModels.WebsiteAccount,
                                 alphabeticalOnly: Bool = false) -> Bool {

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -509,9 +509,9 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
 
         let exactMatches = accountGroups["exactMatches"]?.sorted { compareAccount( $0, $1 ) } ?? []
         let tldMatches = accountGroups["tldMatches"]?.sorted { compareAccount( $0, $1 ) } ?? []
-        let other = accountGroups["other"]?.sorted { compareAccount( $0, $1 ) } ?? []
+        let other = accountGroups["other"]?.sorted { compareAccount( $0, $1, lastUpdatedFirst: false ) } ?? []
         let result = exactMatches + tldMatches + other
-
+        
         return (removeDuplicates ? result.removeDuplicates() : result).filter { $0.domain?.isEmpty == false }
     }
 
@@ -521,8 +521,10 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
         return urlComponents.eTLDplus1(tld: tld)
     }
 
-    // Last Updated > Alphabetical Domain > Alphabetical Username > Empty Usernames
-    private func compareAccount(_ account1: SecureVaultModels.WebsiteAccount, _ account2: SecureVaultModels.WebsiteAccount) -> Bool {
+    // Last Updated (if accountForLastUpdate = true) > Alphabetical Domain > Alphabetical Username > Empty Usernames
+    private func compareAccount(_ account1: SecureVaultModels.WebsiteAccount,
+                                _ account2: SecureVaultModels.WebsiteAccount,
+                                lastUpdatedFirst: Bool = true) -> Bool {
         let username1 = account1.username ?? ""
         let username2 = account2.username ?? ""
 
@@ -534,8 +536,10 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
             return false
         }
 
-        if account1.lastUpdated.withoutTime != account2.lastUpdated.withoutTime {
-            return account1.lastUpdated.withoutTime > account2.lastUpdated.withoutTime
+        if lastUpdatedFirst {
+            if account1.lastUpdated.withoutTime != account2.lastUpdated.withoutTime {
+                return account1.lastUpdated.withoutTime > account2.lastUpdated.withoutTime
+            }
         }
 
         let domain1 = account1.domain ?? ""

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -489,7 +489,7 @@ extension SecureVaultModels.CreditCard: SecureVaultAutofillEquatable {
 // MARK: - WebsiteAccount Array extensions
 extension Array where Element == SecureVaultModels.WebsiteAccount {
 
-    public func sortedForDomain(_ targetDomain: String, tld: TLD, removeDuplicates: Bool = false) -> [SecureVaultModels.WebsiteAccount] {
+    public func sortedForDomain(_ targetDomain: String, tld: TLD, removeDuplicates: Bool = false, alphabeticalOnly: Bool = false) -> [SecureVaultModels.WebsiteAccount] {
 
         guard let targetTLD = extractTLD(domain: targetDomain, tld: tld) else {
             return []
@@ -507,9 +507,9 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
             }
         }
 
-        let exactMatches = accountGroups["exactMatches"]?.sorted { compareAccount( $0, $1 ) } ?? []
-        let tldMatches = accountGroups["tldMatches"]?.sorted { compareAccount( $0, $1 ) } ?? []
-        let other = accountGroups["other"]?.sorted { compareAccount( $0, $1, lastUpdatedFirst: false ) } ?? []
+        let exactMatches = accountGroups["exactMatches"]?.sorted { compareAccount( $0, $1, alphabeticalOnly: alphabeticalOnly ) } ?? []
+        let tldMatches = accountGroups["tldMatches"]?.sorted { compareAccount( $0, $1, alphabeticalOnly: alphabeticalOnly ) } ?? []
+        let other = accountGroups["other"]?.sorted { compareAccount( $0, $1, alphabeticalOnly: alphabeticalOnly ) } ?? []
         let result = exactMatches + tldMatches + other
         
         return (removeDuplicates ? result.removeDuplicates() : result).filter { $0.domain?.isEmpty == false }
@@ -524,7 +524,7 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
     // Last Updated (if accountForLastUpdate = true) > Alphabetical Domain > Alphabetical Username > Empty Usernames
     private func compareAccount(_ account1: SecureVaultModels.WebsiteAccount,
                                 _ account2: SecureVaultModels.WebsiteAccount,
-                                lastUpdatedFirst: Bool = true) -> Bool {
+                                alphabeticalOnly: Bool = false) -> Bool {
         let username1 = account1.username ?? ""
         let username2 = account2.username ?? ""
 
@@ -536,7 +536,7 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
             return false
         }
 
-        if lastUpdatedFirst {
+        if !alphabeticalOnly {
             if account1.lastUpdated.withoutTime != account2.lastUpdated.withoutTime {
                 return account1.lastUpdated.withoutTime > account2.lastUpdated.withoutTime
             }

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
@@ -329,5 +329,35 @@ class SecureVaultModelTests: XCTestCase {
             XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
         }
     }
+    
+    func testAlphabeticalSorting() {
+        // (Note Duplicates are removed exclusively based on signature -- Ignoring usernames/domains)
+        let sortedAccounts  = sortTestAccounts.sortedForDomain("toys.amazon.com", tld: tld, removeDuplicates: false, alphabeticalOnly: true)
+        let controlAccounts  = [
+            testAccount("olivia", "toys.amazon.com", "4567", 50 * days),
+            testAccount("anna", "amazon.com", "1234", 50 * days),
+            testAccount("jane", "amazon.com", "7890", 0),
+            testAccount("oscar", "amazon.com", "7890", 0),
+            testAccount("paul", "amazon.com", "3456", 0),
+            testAccount("rachel", "amazon.com", "7890", 0),
+            testAccount("daniel", "www.amazon.com", "23456", 0),
+            testAccount("john", "www.amazon.com", "4567", 0),
+            testAccount("quinn", "www.amazon.com", "2345", 0),
+            testAccount("", "amazon.com", "3456", 0),
+            testAccount("chris", "baby.amazon.com", "3456", 0),
+            testAccount("lisa", "books.amazon.com", "5678", 50 * days),
+            testAccount("william", "fashion.amazon.com", "1234", 50 * days),
+            testAccount("mary", "garden.amazon.com", "12345", 50 * days),
+            testAccount("jacob", "office.amazon.com", "12345", 0),
+            testAccount("peter", "primevideo.amazon.com", "4567", 85 * days),
+            testAccount("frank", "sports.amazon.com", "23456", 0),
+            testAccount("", "appliances.amazon.com", "5678", 0),
+            testAccount("", "grocery.amazon.com", "4567", 0),
+            testAccount("", "movies.amazon.com", "2345", 0)
+        ]
+        for i in 0...7 {
+            XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
+        }
+    }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL:  https://app.asana.com/0/1204099484721401/1205016455499671/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/1977
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1596
What kind of version bump will this require?: Minor

**Description**:
Adds a `alphabeticalOnly` parameter to the account comparison algo, so it's possible to skip sorting by last update date, and default to alphabetical

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
See macOS PR


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
