### PR TITLE
Autofill iOS de-duplication of prompted logins

### DIFF
--- a/Tests/BrowserServicesKitTests/Autofill/Matchers/AutofillWebsiteAccountMatcherTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/Matchers/AutofillWebsiteAccountMatcherTests.swift
@@ -40,7 +40,7 @@ final class AutofillWebsiteAccountMatcherTests: XCTestCase {
 
     func testWhenOnlyOnePerfectMatchThenCorrectlyPutIntoPerfectMatches() {
         let accounts = [websiteAccountFor(domain: "example.com")]
-        let matches = autofillWebsiteAccountMatcher.findMatchesSortedByLastUpdated(accounts: accounts, for: "example.com")
+        let matches = autofillWebsiteAccountMatcher.findDeduplicatedSortedMatches(accounts: accounts, for: "example.com")
         XCTAssertEqual(matches.perfectMatches.count, 1)
         XCTAssertEqual(matches.partialMatches.count, 0)
     }
@@ -49,21 +49,21 @@ final class AutofillWebsiteAccountMatcherTests: XCTestCase {
         let accounts = [websiteAccountFor(domain: "example.com"),
                         websiteAccountFor(domain: "example.com"),
                         websiteAccountFor(domain: "example.com")]
-        let matches = autofillWebsiteAccountMatcher.findMatchesSortedByLastUpdated(accounts: accounts, for: "example.com")
+        let matches = autofillWebsiteAccountMatcher.findDeduplicatedSortedMatches(accounts: accounts, for: "example.com")
         XCTAssertEqual(matches.perfectMatches.count, 3)
         XCTAssertEqual(matches.partialMatches.count, 0)
     }
 
     func testWhenNotAMatchThenNotIncludedInGroups() {
         let accounts = [websiteAccountFor(domain: "example.com")]
-        let matches = autofillWebsiteAccountMatcher.findMatchesSortedByLastUpdated(accounts: accounts, for: "example.org")
+        let matches = autofillWebsiteAccountMatcher.findDeduplicatedSortedMatches(accounts: accounts, for: "example.org")
         XCTAssertEqual(matches.perfectMatches.count, 0)
         XCTAssertEqual(matches.partialMatches.count, 0)
     }
 
     func testWhenSinglePartialMatchThenGetsItsOwnGroup() {
         let accounts = [websiteAccountFor(domain: "foo.example.com")]
-        let matches = autofillWebsiteAccountMatcher.findMatchesSortedByLastUpdated(accounts: accounts, for: "example.com")
+        let matches = autofillWebsiteAccountMatcher.findDeduplicatedSortedMatches(accounts: accounts, for: "example.com")
         XCTAssertEqual(matches.perfectMatches.count, 0)
         XCTAssertEqual(matches.partialMatches.count, 1)
     }
@@ -71,7 +71,7 @@ final class AutofillWebsiteAccountMatcherTests: XCTestCase {
     func testWhenMultiplePartialMatchesWithSameSubdomainThenAllShareAGroup() {
         let accounts = [websiteAccountFor(domain: "foo.example.com"),
                         websiteAccountFor(domain: "foo.example.com")]
-        let matches = autofillWebsiteAccountMatcher.findMatchesSortedByLastUpdated(accounts: accounts, for: "example.com")
+        let matches = autofillWebsiteAccountMatcher.findDeduplicatedSortedMatches(accounts: accounts, for: "example.com")
         XCTAssertEqual(matches.perfectMatches.count, 0)
         XCTAssertEqual(matches.partialMatches.count, 1)
         XCTAssertEqual(matches.partialMatches["foo.example.com"]?.count, 2)
@@ -81,7 +81,7 @@ final class AutofillWebsiteAccountMatcherTests: XCTestCase {
         let accounts = [websiteAccountFor(domain: "foo.example.com"),
                         websiteAccountFor(domain: "bar.example.com"),
                         websiteAccountFor(domain: "bar.example.com")]
-        let matches = autofillWebsiteAccountMatcher.findMatchesSortedByLastUpdated(accounts: accounts, for: "example.com")
+        let matches = autofillWebsiteAccountMatcher.findDeduplicatedSortedMatches(accounts: accounts, for: "example.com")
         XCTAssertEqual(matches.perfectMatches.count, 0)
         XCTAssertEqual(matches.partialMatches.count, 2)
         XCTAssertEqual(matches.partialMatches["foo.example.com"]?.count, 1)
@@ -90,24 +90,24 @@ final class AutofillWebsiteAccountMatcherTests: XCTestCase {
 
     func testWhenSortingPerfectMatchesThenLastEditedSortedFirst() {
         let now = Date()
-        let accounts = [websiteAccountFor(domain: "example.com", lastUpdated: now.addingTimeInterval(-100)),
-                        websiteAccountFor(domain: "example.com", lastUpdated: now.addingTimeInterval(-10)),
+        let accounts = [websiteAccountFor(domain: "example.com", lastUpdated: now.addingTimeInterval(-24*60*60*2)),
+                        websiteAccountFor(domain: "example.com", lastUpdated: now.addingTimeInterval(-24*60*60)),
                         websiteAccountFor(domain: "example.com", lastUpdated: now.addingTimeInterval(-1))]
-        let matches = autofillWebsiteAccountMatcher.findMatchesSortedByLastUpdated(accounts: accounts, for: "example.com")
+        let matches = autofillWebsiteAccountMatcher.findDeduplicatedSortedMatches(accounts: accounts, for: "example.com")
         XCTAssertEqual(matches.perfectMatches[0].lastUpdated, now.addingTimeInterval(-1))
-        XCTAssertEqual(matches.perfectMatches[1].lastUpdated, now.addingTimeInterval(-10))
-        XCTAssertEqual(matches.perfectMatches[2].lastUpdated, now.addingTimeInterval(-100))
+        XCTAssertEqual(matches.perfectMatches[1].lastUpdated, now.addingTimeInterval(-24*60*60))
+        XCTAssertEqual(matches.perfectMatches[2].lastUpdated, now.addingTimeInterval(-24*60*60*2))
     }
 
     func testWhenSortingPartialMatchesThenLastEditedSortedFirst() {
         let now = Date()
-        let accounts = [websiteAccountFor(domain: "foo.example.com", lastUpdated: now.addingTimeInterval(-100)),
-                        websiteAccountFor(domain: "foo.example.com", lastUpdated: now.addingTimeInterval(-10)),
+        let accounts = [websiteAccountFor(domain: "foo.example.com", lastUpdated: now.addingTimeInterval(-24*60*60*2)),
+                        websiteAccountFor(domain: "foo.example.com", lastUpdated: now.addingTimeInterval(-24*60*60)),
                         websiteAccountFor(domain: "foo.example.com", lastUpdated: now.addingTimeInterval(-1))]
-        let matches = autofillWebsiteAccountMatcher.findMatchesSortedByLastUpdated(accounts: accounts, for: "example.com")
+        let matches = autofillWebsiteAccountMatcher.findDeduplicatedSortedMatches(accounts: accounts, for: "example.com")
         XCTAssertEqual(matches.partialMatches["foo.example.com"]?[0].lastUpdated, now.addingTimeInterval(-1))
-        XCTAssertEqual(matches.partialMatches["foo.example.com"]?[1].lastUpdated, now.addingTimeInterval(-10))
-        XCTAssertEqual(matches.partialMatches["foo.example.com"]?[2].lastUpdated, now.addingTimeInterval(-100))
+        XCTAssertEqual(matches.partialMatches["foo.example.com"]?[1].lastUpdated, now.addingTimeInterval(-24*60*60))
+        XCTAssertEqual(matches.partialMatches["foo.example.com"]?[2].lastUpdated, now.addingTimeInterval(-24*60*60*2))
     }
 
     func websiteAccountFor(domain: String = "", lastUpdated: Date = Date()) -> SecureVaultModels.WebsiteAccount {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203822806345703/1205369440069075/f 
iOS PR: https://github.com/duckduckgo/iOS/pull/1995
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1612
What kind of version bump will this require?: Minor

**Description**:
Brings iOS into parity with macOS de-duplication of logins when prompting to autofill

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
