### PR TITLE
Add dry-run feature flag to test incremental rollouts on iOS

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -41,6 +41,7 @@ public enum PrivacyFeature: String {
     case incontextSignup
     case newTabContinueSetUp
     case networkProtection
+    case incrementalRolloutTest2 // Temporary feature flag for testing incremental rollouts
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.
@@ -72,3 +73,11 @@ public enum NetworkProtectionSubfeature: String, Equatable, PrivacySubfeature {
     case waitlist
     case waitlistBetaActive
 }
+
+public enum IncrementalRolloutTestSubfeature2: String, PrivacySubfeature {
+     public var parent: PrivacyFeature {
+         .incrementalRolloutTest2
+     }
+
+     case rollout
+ }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->
**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205431733474504/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2008
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1623
What kind of version bump will this require?: Patch

**Description**:
Adds dry-run feature flag to test incremental rollouts on iOS, based off of process used to test macOS

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client-side PRs for per-platform testing steps

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
