### PR TITLE
Add API for stored failed compilations

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerDebugEvents.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/ContentBlockerDebugEvents.swift
@@ -26,7 +26,7 @@ public enum ContentBlockerDebugEvents {
         static let errorDescription = "error_desc"
     }
     
-    public enum Component: String, CustomStringConvertible {
+    public enum Component: String, CustomStringConvertible, CaseIterable {
     
         public var description: String { rawValue }
         

--- a/Sources/BrowserServicesKit/ContentBlocking/FailedCompilationsStore.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/FailedCompilationsStore.swift
@@ -1,0 +1,51 @@
+//
+//  FailedCompilationsStore.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Persistence
+
+public struct FailedCompilationsStore: KeyValueStoring {
+
+    private var userDefaults: UserDefaults? { UserDefaults(suiteName: "com.duckduckgo.app.failedCompilations") }
+
+    public init() {}
+
+    public func object(forKey defaultName: String) -> Any? { userDefaults?.object(forKey: defaultName) }
+    public func set(_ value: Any?, forKey defaultName: String) { userDefaults?.set(value, forKey: defaultName) }
+    public func removeObject(forKey defaultName: String) { userDefaults?.removeObject(forKey: defaultName) }
+
+    private func counter(for component: ContentBlockerDebugEvents.Component) -> Int { object(forKey: component.rawValue) as? Int ?? 0 }
+
+    func compilationFailed(for component: ContentBlockerDebugEvents.Component) {
+        set(counter(for: component) + 1, forKey: component.rawValue)
+    }
+
+    public func cleanup() {
+        for component in ContentBlockerDebugEvents.Component.allCases {
+            removeObject(forKey: component.rawValue)
+        }
+    }
+
+    public var hasAnyFailures: Bool { ContentBlockerDebugEvents.Component.allCases.contains { counter(for: $0) != 0 } }
+
+    public var summary: [String: String] {
+        Dictionary(uniqueKeysWithValues: ContentBlockerDebugEvents.Component.allCases.map { ($0.rawValue, String(counter(for: $0))) })
+    }
+
+}


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/1203790657351911/1205404596674276/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2014/
macOS PR: 
What kind of version bump will this require?: Minor

**Description**:

Introduce daily pixel containing information about failed content blocking rules compilations.

**Steps to test this PR**:
1. Run the app and make sure the pixel is not being sent.
1. Make compilation fail, by for instance adding some incorrect characters to temporary unprotected sites.
1. Notice the counter increases for a given step of compilation.
1. See that the pixel is being sent on the next app run and that statistics are being reset. 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
