### PR TITLE
Update autofill to 8.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "20a6aeddbd86b43fd83c42aa45fdd9ec6db0e0f7",
-        "version" : "8.2.0"
+        "revision" : "21aa20e272b7de06e471c6e646d25e26a5887b60",
+        "version" : "8.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.2.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.3.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205523970598663/1205523970598663
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.3.0


## Description
Updates Autofill to version [8.3.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.3.0).

### Autofill 8.3.0 release notes
## What's Changed
* Update password-related json files (2023-08-30) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/378
* Speed up tests and other perf improvements by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/381


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.2.0...8.3.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).