### PR TITLE
Update autofill to 8.4.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "21aa20e272b7de06e471c6e646d25e26a5887b60",
-        "version" : "8.3.0"
+        "revision" : "f3eccad8647fdba2b5d180a02a0513c61375b8fb",
+        "version" : "8.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.3.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.4.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205538042573900/1205538042573900
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.0


## Description
Updates Autofill to version [8.4.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.0).

### Autofill 8.4.0 release notes
## What's Changed
* Improve non-English matching by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/374


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.3.0...8.4.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).