### PR TITLE
Log user out of Sync when SyncOperation receives a HTTP 401

### DIFF
--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -248,6 +248,9 @@ public class DDGSync: DDGSyncing {
         dependencies.keyValueStore.set(true, forKey: Constants.syncEnabledKey)
 
         syncQueueCancellable = syncQueue.isSyncInProgressPublisher
+            .handleEvents(receiveCancel: { [weak self] in
+                self?.isSyncInProgress = false
+            })
             .sink(receiveCompletion: { [weak self] _ in
                 self?.isSyncInProgress = false
             }, receiveValue: { [weak self] isInProgress in
@@ -257,6 +260,13 @@ public class DDGSync: DDGSyncing {
         startSyncCancellable = dependencies.scheduler.startSyncPublisher
             .sink { [weak self] in
                 self?.syncQueue?.startSync()
+            }
+
+        syncQueueRequestErrorCancellable = syncQueue.syncHTTPRequestErrorPublisher
+            .sink { [weak self] error in
+                // Safe to try? because the error is reported to Sync Data Provider anyway
+                // and here we only care about logging the user out of Sync
+                try? self?.handleUnauthenticated(error)
             }
 
         cancelSyncCancellable = dependencies.scheduler.cancelSyncPublisher
@@ -298,4 +308,5 @@ public class DDGSync: DDGSyncing {
 
     private var syncQueue: SyncQueue?
     private var syncQueueCancellable: AnyCancellable?
+    private var syncQueueRequestErrorCancellable: AnyCancellable?
 }

--- a/Sources/DDGSync/internal/SyncOperation.swift
+++ b/Sources/DDGSync/internal/SyncOperation.swift
@@ -174,6 +174,9 @@ class SyncOperation: Operation {
                     } catch is CancellationError {
                         os_log(.debug, log: self.log, "Syncing %{public}s cancelled", dataProvider.feature.name)
                     } catch {
+                        if case SyncError.unexpectedStatusCode = error {
+                            didReceiveHTTPRequestError?(error)
+                        }
                         os_log(.debug, log: self.log, "Error syncing %{public}s: %{public}s", dataProvider.feature.name, error.localizedDescription)
                         dataProvider.handleSyncError(error)
                         throw FeatureError(feature: dataProvider.feature, underlyingError: error)

--- a/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -68,15 +68,25 @@ final class DDGSyncTests: XCTestCase {
     // MARK: - Setup
 
     func setUpExpectations(started syncStartedExpectedCount: Int, fetch fetchExpectedCount: Int, handleResponse handleSyncResponseExpectedCount: Int, finished syncFinishedExpectedCount: Int) {
-        syncStartedExpectation = expectation(description: "syncStarted")
-        fetchExpectation = expectation(description: "fetch")
-        handleSyncResponseExpectation = expectation(description: "handleSyncResponse")
-        syncFinishedExpectation = expectation(description: "syncFinished")
+        if syncStartedExpectedCount > 0 {
+            syncStartedExpectation = expectation(description: "syncStarted")
+            syncStartedExpectation.expectedFulfillmentCount = syncStartedExpectedCount
+        }
 
-        syncStartedExpectation.expectedFulfillmentCount = syncStartedExpectedCount
-        fetchExpectation.expectedFulfillmentCount = fetchExpectedCount
-        handleSyncResponseExpectation.expectedFulfillmentCount = handleSyncResponseExpectedCount
-        syncFinishedExpectation.expectedFulfillmentCount = syncFinishedExpectedCount
+        if fetchExpectedCount > 0 {
+            fetchExpectation = expectation(description: "fetch")
+            fetchExpectation.expectedFulfillmentCount = fetchExpectedCount
+        }
+
+        if handleSyncResponseExpectedCount > 0 {
+            handleSyncResponseExpectation = expectation(description: "handleSyncResponse")
+            handleSyncResponseExpectation.expectedFulfillmentCount = handleSyncResponseExpectedCount
+        }
+
+        if syncFinishedExpectedCount > 0 {
+            syncFinishedExpectation = expectation(description: "syncFinished")
+            syncFinishedExpectation.expectedFulfillmentCount = syncFinishedExpectedCount
+        }
     }
 
     func setUpDataProviderCallbacks(for dataProvider: DataProvidingMock) {
@@ -435,5 +445,35 @@ final class DDGSyncTests: XCTestCase {
 
         let api = dependencies.api as! RemoteAPIRequestCreatingMock
         XCTAssertTrue(api.createRequestCallArgs.isEmpty)
+    }
+
+    func testThatSyncOperationRequestReturningHTTP401CausesLoggingOutOfSync() {
+        let dataProvider = DataProvidingMock(feature: .init(name: "bookmarks"))
+        dataProvider.lastSyncTimestamp = "1234"
+        setUpDataProviderCallbacks(for: dataProvider)
+        setUpExpectations(started: 1, fetch: 1, handleResponse: 0, finished: 1)
+
+        dataProvidersSource.dataProviders = [dataProvider]
+        (dependencies.api as! RemoteAPIRequestCreatingMock).fakeRequests = [:]
+        let http401Response = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 401, httpVersion: nil, headerFields: [:])!
+        dependencies.request.result = HTTPResult(data: Data(), response: http401Response)
+
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+        syncService.initializeIfNeeded()
+        bindInProgressPublisher(for: syncService)
+
+        XCTAssertEqual(syncService.authState, .active)
+
+        syncService.scheduler.requestSyncImmediately()
+
+        waitForExpectations(timeout: 2)
+
+        XCTAssertEqual(recordedEvents, [
+            .started(1),
+            .fetch(1),
+            .finished(1)
+        ])
+
+        XCTAssertEqual(syncService.authState, .inactive)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201493110486074/1205552640876379/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2031
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1666
What kind of version bump will this require?: Minor

**Description**:
Pass `SyncError.unexpectedStatusCode` from SyncOperation, through SyncQueue to DDGSync to
call `handleUnauthenticated` and log out the user when a HTTP 401 is received while syncing data.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
For either iOS or macOS app:
1. Run the app from Xcode, and sign in to Sync. On macOS, enable Sync Logging: Main Menu -> Debug -> Logging -> Sync.
2. Close the app, open AppDelegate.swift and change sync's `defaultEnvironment` for debug builds to `.production`
3. Run the app again BUT DON'T GO TO SYNC SETTINGS.
4. Verify that you've been logged out from Sync (sync requests aren't logged to the console when you enter Bookmarks Management or open New Tab Page).

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
