### PR TITLE
Update CrashCollection to return the crash metric app version

### DIFF
--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -41,6 +41,7 @@ public struct CrashCollection {
                 .flatMap { $0 }
                 .forEach {
                     completion([
+                        "appVersion": $0.applicationVersion,
                         "code": "\($0.exceptionCode ?? -1)",
                         "type": "\($0.exceptionType ?? -1)",
                         "signal": "\($0.signal ?? -1)"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205599209825567/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2046
macOS PR: N/A
What kind of version bump will this require?: Minor

**Description**:

This PR updates the crash collector to include the app version from MetricKit.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See [PR task](https://app.asana.com/0/0/1205599209825567/f)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
