### PR TITLE
Connection interruption simulation option

### DIFF
--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionConnectionTester.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionConnectionTester.swift
@@ -96,6 +96,8 @@ final class NetworkProtectionConnectionTester {
     private var failureCount = 0
     private let resultHandler: @MainActor (Result, Bool) -> Void
 
+    private var simulateFailure = false
+
     // MARK: - Init & deinit
 
     init(timerQueue: DispatchQueue, log: OSLog, resultHandler: @escaping @MainActor (Result, Bool) -> Void) {
@@ -110,6 +112,12 @@ final class NetworkProtectionConnectionTester {
         os_log("[-] %{public}@", log: .networkProtectionMemoryLog, type: .debug, String(describing: self))
 
         cancelTimerImmediately()
+    }
+
+    // MARK: - Testing
+
+    func failNextTest() {
+        simulateFailure = true
     }
 
     // MARK: - Starting & Stopping the tester
@@ -247,7 +255,8 @@ final class NetworkProtectionConnectionTester {
         let vpnIsConnected = await vpnConnected
         let localIsConnected = await localConnected
 
-        let onlyVPNIsDown = !vpnIsConnected && localIsConnected
+        let onlyVPNIsDown = simulateFailure || (!vpnIsConnected && localIsConnected)
+        simulateFailure = false
 
         // After completing the conection tests we check if the tester is still supposed to be running
         // to avoid giving results when it should not be running.

--- a/Sources/NetworkProtection/ExtensionMessage/ExtensionMessage.swift
+++ b/Sources/NetworkProtection/ExtensionMessage/ExtensionMessage.swift
@@ -37,6 +37,7 @@ public enum ExtensionMessage: RawRepresentable {
         case simulateTunnelFailure
         case simulateTunnelFatalError
         case simulateTunnelMemoryOveruse
+        case simulateConnectionInterruption
     }
 
     // important: Preserve this order because Message Name is represented by Int value
@@ -55,6 +56,7 @@ public enum ExtensionMessage: RawRepresentable {
     case simulateTunnelFailure
     case simulateTunnelFatalError
     case simulateTunnelMemoryOveruse
+    case simulateConnectionInterruption
 
     // swiftlint:disable:next cyclomatic_complexity
     public init?(rawValue data: Data) {
@@ -112,6 +114,9 @@ public enum ExtensionMessage: RawRepresentable {
 
         case .simulateTunnelMemoryOveruse:
             self = .simulateTunnelMemoryOveruse
+
+        case .simulateConnectionInterruption:
+            self = .simulateConnectionInterruption
             
         case .none:
             assertionFailure("Invalid data")
@@ -137,6 +142,7 @@ public enum ExtensionMessage: RawRepresentable {
         case .simulateTunnelFailure: return .simulateTunnelFailure
         case .simulateTunnelFatalError: return .simulateTunnelFatalError
         case .simulateTunnelMemoryOveruse: return .simulateTunnelMemoryOveruse
+        case .simulateConnectionInterruption: return .simulateConnectionInterruption
         }
     }
 
@@ -176,7 +182,9 @@ public enum ExtensionMessage: RawRepresentable {
              .triggerTestNotification,
              .simulateTunnelFailure,
              .simulateTunnelFatalError,
-             .simulateTunnelMemoryOveruse: break
+             .simulateTunnelMemoryOveruse,
+             .simulateConnectionInterruption: break
+
         }
 
         var data = Data([self.name.rawValue])

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -881,10 +881,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     private func simulateConnectionInterruption(completionHandler: ((Data?) -> Void)? = nil) {
-        notificationsPresenter.showReconnectingNotification()
         reasserting = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 15.0) {
-            self.notificationsPresenter.showReconnectedNotification()
             self.reasserting = false
         }
         completionHandler?(nil)

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -248,7 +248,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             case .reconnected:
                 self.tunnelHealth.isHavingConnectivityIssues = false
                 self.notificationsPresenter.showReconnectedNotification()
-                self.reasserting = false
                 self.updateBandwidthAnalyzerAndRekeyIfExpired()
                 self.startLatencyReporter()
 
@@ -262,7 +261,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
                     // Only do these things if this is not a connection startup test.
                     if !isStartupTest {
-                        self.reasserting = true
                         self.fixTunnel()
                     }
                 } else if failureCount == 2 {
@@ -881,10 +879,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     private func simulateConnectionInterruption(completionHandler: ((Data?) -> Void)? = nil) {
-        reasserting = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 15.0) {
-            self.reasserting = false
-        }
+        connectionTester.failNextTest()
         completionHandler?(nil)
     }
 

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -882,8 +882,10 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     private func simulateConnectionInterruption(completionHandler: ((Data?) -> Void)? = nil) {
         notificationsPresenter.showReconnectingNotification()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+        reasserting = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 15.0) {
             self.notificationsPresenter.showReconnectedNotification()
+            self.reasserting = false
         }
         completionHandler?(nil)
     }

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -748,6 +748,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             simulateTunnelFatalError(completionHandler: completionHandler)
         case .simulateTunnelMemoryOveruse:
             simulateTunnelMemoryOveruse(completionHandler: completionHandler)
+        case .simulateConnectionInterruption:
+            simulateConnectionInterruption(completionHandler: completionHandler)
         }
     }
 
@@ -876,6 +878,14 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         while true {
             array.append("Crash")
         }
+    }
+
+    private func simulateConnectionInterruption(completionHandler: ((Data?) -> Void)? = nil) {
+        notificationsPresenter.showReconnectingNotification()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+            self.notificationsPresenter.showReconnectedNotification()
+        }
+        completionHandler?(nil)
     }
 
     // MARK: - Adapter start completion handling

--- a/Sources/NetworkProtection/Storage/NetworkProtectionSimulationOptionsStore.swift
+++ b/Sources/NetworkProtection/Storage/NetworkProtectionSimulationOptionsStore.swift
@@ -23,6 +23,7 @@ public enum NetworkProtectionSimulationOption: Sendable {
     case tunnelFailure
     case crashFatalError
     case crashMemory
+    case connectionInterruption
 }
 
 public class NetworkProtectionSimulationOptions {

--- a/Sources/NetworkProtection/Storage/NetworkProtectionTunnelHealthStore.swift
+++ b/Sources/NetworkProtection/Storage/NetworkProtectionTunnelHealthStore.swift
@@ -63,8 +63,8 @@ public final class NetworkProtectionTunnelHealthStore {
                 return
             }
             userDefaults.set(newValue, forKey: Self.isHavingConnectivityIssuesKey)
-#if os(macOS)
             os_log("Issues set to %{public}@", log: .networkProtectionConnectionTesterLog, String(reflecting: newValue))
+#if os(macOS)
             postIssueChangeNotification(newValue: newValue)
 #endif
         }

--- a/Sources/NetworkProtection/Storage/NetworkProtectionTunnelHealthStore.swift
+++ b/Sources/NetworkProtection/Storage/NetworkProtectionTunnelHealthStore.swift
@@ -62,8 +62,8 @@ public final class NetworkProtectionTunnelHealthStore {
             guard newValue != userDefaults.bool(forKey: Self.isHavingConnectivityIssuesKey) else {
                 return
             }
-#if os(macOS)
             userDefaults.set(newValue, forKey: Self.isHavingConnectivityIssuesKey)
+#if os(macOS)
             os_log("Issues set to %{public}@", log: .networkProtectionConnectionTesterLog, String(reflecting: newValue))
             postIssueChangeNotification(newValue: newValue)
 #endif

--- a/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
@@ -313,12 +313,12 @@ public class WireGuardAdapter {
                 // Tell the system that the tunnel is going to reconnect using new WireGuard
                 // configuration.
                 // This will broadcast the `NEVPNStatusDidChange` notification to the GUI process.
-                // self.packetTunnelProvider?.reasserting = true
+                self.packetTunnelProvider?.reasserting = true
             }
 
             defer {
                 if reassert {
-                    //self.packetTunnelProvider?.reasserting = false
+                    self.packetTunnelProvider?.reasserting = false
                 }
             }
 


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205601804599806/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2047
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1686
What kind of version bump will this require?: Minor

**Description**:

I added some changes to the PacketTunnelProvider in order to test connection interruptions for the iOS NetP Notifications project. I found that simply setting reasserting to true causes the ConnectionnTester to trigger an interruption, then setting it to false recovers it. This has the benefit of testing the result of the real callback, not needing to mess with any of the connection tester’s callback handling, not needing to add any new state and also mimicking an actual interruption (as the VPN connection status also changes).

**Steps to test this PR**:
1. Test the two apps

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
