### PR TITLE
Update autofill to 8.4.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "f3eccad8647fdba2b5d180a02a0513c61375b8fb",
-        "version" : "8.4.0"
+        "revision" : "55466f10a339843cb79a27af62d5d61c030740b2",
+        "version" : "8.4.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.4.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.4.1"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205602928782192/1205602928782192
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.1


## Description
Updates Autofill to version [8.4.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.1).

### Autofill 8.4.1 release notes
## What's Changed
* Precompile regexes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/382
* Add perf tests by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/383
* deps: remove deprecated content-scope-utils by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/384
* Update dependencies by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/368
* Fix perf regressions by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/385


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.4.0...8.4.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).