### PR TITLE
Do not crash on empty string in decrypt

### DIFF
--- a/Sources/DDGSync/internal/Crypter.swift
+++ b/Sources/DDGSync/internal/Crypter.swift
@@ -52,6 +52,7 @@ struct Crypter: CryptingInternal {
     }
 
     func base64DecodeAndDecrypt(_ value: String, using secretKey: Data) throws -> String {
+        guard !value.isEmpty else { return "" }
         var decryptionKey: [UInt8] = secretKey.safeBytes
         guard let data = Data(base64Encoded: value) else {
             throw SyncError.failedToDecryptValue("Unable to decode base64 value")

--- a/Tests/DDGSyncTests/CrypterTests.swift
+++ b/Tests/DDGSyncTests/CrypterTests.swift
@@ -96,6 +96,24 @@ class CrypterTests: XCTestCase {
         XCTAssertEqual(decrypted, message)
     }
 
+    func testWhenDecryptingEmptyStringThenEmptyStringIsReturned() throws {
+        let storage = SecureStorageStub()
+        let primaryKey = Data([UInt8]((0 ..< DDGSYNCCRYPTO_PRIMARY_KEY_SIZE.rawValue).map { _ in UInt8.random(in: 0 ..< UInt8.max )}))
+        let secretKey = Data([UInt8]((0 ..< DDGSYNCCRYPTO_SECRET_KEY_SIZE.rawValue).map { _ in UInt8.random(in: 0 ..< UInt8.max )}))
+        try storage.persistAccount(SyncAccount(deviceId: "deviceId",
+                                               deviceName: "deviceName",
+                                               deviceType: "deviceType",
+                                               userId: "userId",
+                                               primaryKey: primaryKey,
+                                               secretKey: secretKey,
+                                               token: "token",
+                                               state: .active))
+        let message = ""
+        let crypter = Crypter(secureStore: storage)
+
+        XCTAssertEqual(try crypter.base64DecodeAndDecrypt(message), "")
+    }
+
     func assertValidBase64(_ base64: String) {
         for c in base64 {
             XCTAssertTrue(c.isLetter || c.isNumber || ["+", "/", "="].contains(c), "\(c) not valid base64 char")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201493110486074/1205490564949137
iOS PR: https://github.com/duckduckgo/iOS/pull/2059
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1697
What kind of version bump will this require?: Patch

**Description**:

Return empty string instead of crashing if empty strign is passed to decrypt.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Validate tests.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
