### PR TITLE
Making sure string is strictly valid according to the RFC (Xcode 15 SDK change)

### DIFF
--- a/Sources/Common/Extensions/URLExtension.swift
+++ b/Sources/Common/Extensions/URLExtension.swift
@@ -158,10 +158,21 @@ extension URL {
             s = scheme.separated() + s.dropFirst(scheme.separated().count - 1)
         }
 
-        if let url = URL(string: s) {
+        let url: URL?
+        let urlWithScheme: URL?
+        if #available(macOS 14.0, *) {
+            // Making sure string is strictly valid according to the RFC
+            url = URL(string: s, encodingInvalidCharacters: false)
+            urlWithScheme = URL(string: NavigationalScheme.http.separated() + s, encodingInvalidCharacters: false)
+        } else {
+            url = URL(string: s)
+            urlWithScheme = URL(string: NavigationalScheme.http.separated() + s)
+        }
+
+        if let url {
             // if URL has domain:port or user:password@domain mistakengly interpreted as a scheme
             if url.navigationalScheme != .mailto,
-               let urlWithScheme = URL(string: NavigationalScheme.http.separated() + s),
+               let urlWithScheme,
                urlWithScheme.port != nil || urlWithScheme.user != nil {
                 // could be a local domain but user needs to use the protocol to specify that
                 // make exception for "localhost"


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1199230911884351/1205638643093186/f
iOS PR: - _(TBD when merging to main)_
macOS PR:  https://github.com/duckduckgo/macos-browser/pull/1724
What kind of version bump will this require?: Major/Minor/Patch

**Description**:
Taking care of new logic in URL(string:) constructor. See [documentation](https://developer.apple.com/documentation/foundation/url/3126806-init) for more info

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See https://github.com/duckduckgo/macos-browser/pull/1724

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:
* [ ] macOS 13
* [ ] macOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
