### PR TITLE
NetP connection notifications improvements

### DIFF
--- a/Sources/NetworkProtection/Models/NetworkProtectionServerInfo.swift
+++ b/Sources/NetworkProtection/Models/NetworkProtectionServerInfo.swift
@@ -28,11 +28,13 @@ public struct NetworkProtectionServerInfo: Codable, Equatable, Sendable {
     public struct ServerAttributes: Codable, Equatable, Sendable {
         public let city: String
         public let country: String
+        public let state: String
         public let timezoneOffset: Int
 
         enum CodingKeys: String, CodingKey {
             case city
             case country
+            case state
             case timezoneOffset = "tzOffset"
         }
     }
@@ -59,7 +61,8 @@ extension NetworkProtectionServerInfo {
 
     /// Returns the physical location of the server, if one is available. For instance, this may return "Amsterdam, NL". If location attributes are not present, this will return the server name.
     public var serverLocation: String {
-        return "\(attributes.city), \(attributes.country.localizedUppercase)"
+        let stateOrCountry = isUSServerLocation ? attributes.state : attributes.country
+        return "\(attributes.city), \(stateOrCountry.localizedUppercase)"
     }
 
     /// Calculates the total available addresses for this server.
@@ -78,6 +81,10 @@ extension NetworkProtectionServerInfo {
     /// first available IPv4 address
     public var ipv4: IPv4Address? {
         ips.lazy.compactMap(\.ipv4).first
+    }
+
+    private var isUSServerLocation: Bool {
+        return attributes.country.localizedUppercase == "US"
     }
 
 }

--- a/Sources/NetworkProtection/Notifications/NetworkProtectionNotification.swift
+++ b/Sources/NetworkProtection/Notifications/NetworkProtectionNotification.swift
@@ -54,6 +54,7 @@ extension DistributedNotificationCenter {
 extension DistributedNotificationCenter: NetworkProtectionNotificationPosting {
     public func post(_ networkProtectionNotification: NetworkProtectionNotification,
                      object: String? = nil,
+                     userInfo: [AnyHashable: Any]? = nil,
                      log: OSLog = .networkProtectionDistributedNotificationsLog) {
         logPost(networkProtectionNotification, object: object, log: log)
 
@@ -62,12 +63,12 @@ extension DistributedNotificationCenter: NetworkProtectionNotificationPosting {
 }
 
 public protocol NetworkProtectionNotificationPosting: AnyObject {
-    func post(_ networkProtectionNotification: NetworkProtectionNotification, object: String?, log: OSLog)
+    func post(_ networkProtectionNotification: NetworkProtectionNotification, object: String?, userInfo: [AnyHashable: Any]?, log: OSLog)
 }
 
 public extension NetworkProtectionNotificationPosting {
-    func post(_ networkProtectionNotification: NetworkProtectionNotification, object: String? = nil) {
-        post(networkProtectionNotification, object: object, log: .networkProtectionDistributedNotificationsLog)
+    func post(_ networkProtectionNotification: NetworkProtectionNotification, object: String? = nil, userInfo: [AnyHashable: Any]? = nil) {
+        post(networkProtectionNotification, object: object, userInfo: userInfo, log: .networkProtectionDistributedNotificationsLog)
     }
 }
 
@@ -90,6 +91,10 @@ extension NotificationCenter {
 }
 
 public enum NetworkProtectionNotification: String {
+    public enum UserInfoKey {
+        public static let connectedServerLocation = "NetworkProtectionServerLocationKey"
+    }
+
     // Tunnel Status
     case statusDidChange
 
@@ -99,7 +104,7 @@ public enum NetworkProtectionNotification: String {
 
     // User Notification Events
     case showIssuesStartedNotification
-    case showIssuesResolvedNotification
+    case showConnectedNotification
     case showIssuesNotResolvedNotification
     case showVPNSupersededNotification
     case showTestNotification

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -97,7 +97,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             guard connectionStatus != oldValue else {
                 return
             }
-
+            if case .connected = connectionStatus {
+                self.notificationsPresenter.showConnectedNotification(serverLocation: lastSelectedServerInfo?.serverLocation)
+            }
             connectionStatusPublisher.send(connectionStatus)
         }
     }
@@ -247,7 +249,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             case .reconnected:
                 self.tunnelHealth.isHavingConnectivityIssues = false
-                self.notificationsPresenter.showReconnectedNotification()
                 self.updateBandwidthAnalyzerAndRekeyIfExpired()
                 self.startLatencyReporter()
 

--- a/Sources/NetworkProtection/Status/NetworkProtectionNotificationsPresenter.swift
+++ b/Sources/NetworkProtection/Status/NetworkProtectionNotificationsPresenter.swift
@@ -22,8 +22,8 @@ import Foundation
 ///
 public protocol NetworkProtectionNotificationsPresenter {
 
-    /// Present a "reconnected" notification to the user.
-    func showReconnectedNotification()
+    /// Present a "connected" notification to the user.
+    func showConnectedNotification(serverLocation: String?)
 
     /// Present a "reconnecting" notification to the user.
     func showReconnectingNotification()

--- a/Tests/NetworkProtectionTests/Mocks/NetworkProtectionServerMocks.swift
+++ b/Tests/NetworkProtectionTests/Mocks/NetworkProtectionServerMocks.swift
@@ -34,21 +34,21 @@ extension NetworkProtectionServerInfo {
                                                   hostNames: ["duckduckgo.com"],
                                                   ips: ["192.168.1.1"],
                                                   port: 443,
-                                                  attributes: .init(city: "City", country: "Country", timezoneOffset: 0))
+                                                  attributes: .init(city: "City", country: "Country", state: "State", timezoneOffset: 0))
 
     static let hostNameOnly = NetworkProtectionServerInfo(name: "Mock Server",
                                                           publicKey: "ovn9RpzUuvQ4XLQt6B3RKuEXGIxa5QpTnehjduZlcSE=",
                                                           hostNames: ["duckduckgo.com"],
                                                           ips: [],
                                                           port: 443,
-                                                          attributes: .init(city: "City", country: "Country", timezoneOffset: 0))
+                                                          attributes: .init(city: "City", country: "Country", state: "State", timezoneOffset: 0))
 
     static let ipAddressOnly = NetworkProtectionServerInfo(name: "Mock Server",
                                                            publicKey: "ovn9RpzUuvQ4XLQt6B3RKuEXGIxa5QpTnehjduZlcSE=",
                                                            hostNames: [],
                                                            ips: ["192.168.1.1"],
                                                            port: 443,
-                                                           attributes: .init(city: "City", country: "Country", timezoneOffset: 0))
+                                                           attributes: .init(city: "City", country: "Country", state: "State", timezoneOffset: 0))
 
     static func make(named name: String, withPublicKey publicKey: String = "") -> Self {
         NetworkProtectionServerInfo(name: name,
@@ -56,7 +56,7 @@ extension NetworkProtectionServerInfo {
                                     hostNames: ["duckduckgo.com"],
                                     ips: ["192.168.1.1"],
                                     port: 443,
-                                    attributes: .init(city: "City", country: "Country", timezoneOffset: 0))
+                                    attributes: .init(city: "City", country: "Country", state: "State", timezoneOffset: 0))
     }
 
 }

--- a/Tests/NetworkProtectionTests/NetworkProtectionServerInfoTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionServerInfoTests.swift
@@ -44,5 +44,4 @@ final class NetworkProtectionServerInfoTests: XCTestCase {
         XCTAssertEqual(serverInfo.serverLocation, "New York, NY")
     }
 
-
 }

--- a/Tests/NetworkProtectionTests/NetworkProtectionServerInfoTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionServerInfoTests.swift
@@ -22,15 +22,27 @@ import XCTest
 
 final class NetworkProtectionServerInfoTests: XCTestCase {
 
-    func testWhenGettingServerLocation_AndAttributesExist_ThenServerLocationIsCityCountry() {
+    func testWhenGettingServerLocation_AndAttributesExist_notUS_ThenServerLocationIsCityCountry() {
         let serverInfo = NetworkProtectionServerInfo(name: "Server Name",
                                                      publicKey: "",
                                                      hostNames: [],
                                                      ips: [],
                                                      port: 42,
-                                                     attributes: .init(city: "Amsterdam", country: "nl", timezoneOffset: 3600))
+                                                     attributes: .init(city: "Amsterdam", country: "nl", state: "na", timezoneOffset: 3600))
 
         XCTAssertEqual(serverInfo.serverLocation, "Amsterdam, NL")
     }
+
+    func testWhenGettingServerLocation_AndAttributesExist_isUS_ThenServerLocationIsCityState() {
+        let serverInfo = NetworkProtectionServerInfo(name: "Server Name",
+                                                     publicKey: "",
+                                                     hostNames: [],
+                                                     ips: [],
+                                                     port: 42,
+                                                     attributes: .init(city: "New York", country: "us", state: "ny", timezoneOffset: 3600))
+
+        XCTAssertEqual(serverInfo.serverLocation, "New York, NY")
+    }
+
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205656863843386/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2073
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1730
What kind of version bump will this require?: Major

**Description**:

On testing the Network Protection notifications on iOS, we decided to make a few UX tweaks:
- Show the same connection notifications when the user connects manually as well as when they reconnect after an interruption
- Include the server location in the body text of these notifications

This update makes changes required for those tweaks.

**Steps to test this PR**:
- See the app specific PRs

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [x] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [x] macOS 12

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
