### PR TITLE
Ignore form factor specific favorites if they're received in Sync response

### DIFF
--- a/Sources/SyncDataProviders/Bookmarks/internal/BookmarksResponseHandler.swift
+++ b/Sources/SyncDataProviders/Bookmarks/internal/BookmarksResponseHandler.swift
@@ -23,6 +23,9 @@ import DDGSync
 import Foundation
 
 final class BookmarksResponseHandler {
+    // Before form-factor-specific favorites is supported, we deliberately ignore FFS folders.
+    static let ignoredFoldersUUIDs: Set<String> = ["desktop_favorites_root", "mobile_favorites_root"]
+
     let clientTimestamp: Date?
     let received: [SyncableBookmarkAdapter]
     let context: NSManagedObjectContext
@@ -84,10 +87,11 @@ final class BookmarksResponseHandler {
         self.favoritesUUIDs = favoritesUUIDs
 
         let foldersWithoutParent = Set(parentFoldersToChildren.keys).subtracting(childrenToParents.keys)
+            .subtracting(Self.ignoredFoldersUUIDs)
         topLevelFoldersSyncables = foldersWithoutParent.compactMap { syncablesByUUID[$0] }
 
         bookmarkSyncablesWithoutParent = allUUIDs.subtracting(childrenToParents.keys)
-            .subtracting(foldersWithoutParent + [BookmarkEntity.Constants.favoritesFolderID])
+            .subtracting(foldersWithoutParent + [BookmarkEntity.Constants.favoritesFolderID] + Self.ignoredFoldersUUIDs)
             .compactMap { syncablesByUUID[$0] }
 
         BookmarkEntity.fetchBookmarks(with: allReceivedIDs, in: context)

--- a/Tests/SyncDataProvidersTests/Bookmarks/FormFactorSpecificFavoritesFoldersIgnoringTests.swift
+++ b/Tests/SyncDataProvidersTests/Bookmarks/FormFactorSpecificFavoritesFoldersIgnoringTests.swift
@@ -1,0 +1,142 @@
+//
+//  FormFactorSpecificFavoritesFoldersIgnoringTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Bookmarks
+import BookmarksTestsUtils
+import Common
+import DDGSync
+import Persistence
+@testable import SyncDataProviders
+
+private extension Syncable {
+    static func desktopFavoritesFolder(favorites: [String]) -> Syncable {
+        .folder(id: "desktop_favorites_root", children: favorites)
+    }
+
+    static func mobileFavoritesFolder(favorites: [String]) -> Syncable {
+        .folder(id: "mobile_favorites_root", children: favorites)
+    }
+}
+
+final class FormFactorSpecificFavoritesFoldersIgnoringTests: BookmarksProviderTestsBase {
+
+    func testThatDesktopFavoritesFolderIsIgnored() async throws {
+        let context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1", isFavorite: true)
+            Bookmark(id: "2")
+        }
+
+        let received: [Syncable] = [.desktopFavoritesFolder(favorites: ["1", "2"])]
+
+        let rootFolder = try await createEntitiesAndHandleSyncResponse(with: bookmarkTree, received: received, in: context)
+        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+            Bookmark(id: "1", isFavorite: true)
+            Bookmark(id: "2")
+        })
+    }
+
+    func testThatMobileFavoritesFolderIsIgnored() async throws {
+        let context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1", isFavorite: true)
+            Bookmark(id: "2")
+        }
+
+        let received: [Syncable] = [.mobileFavoritesFolder(favorites: ["1", "2"])]
+
+        let rootFolder = try await createEntitiesAndHandleSyncResponse(with: bookmarkTree, received: received, in: context)
+        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+            Bookmark(id: "1", isFavorite: true)
+            Bookmark(id: "2")
+        })
+    }
+
+    func testThatDesktopFavoritesFolderDoesNotAffectReceivedFavoritesFolder() async throws {
+        let context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1", isFavorite: true)
+            Bookmark(id: "2")
+        }
+
+        let received: [Syncable] = [
+            .favoritesFolder(favorites: ["1", "2"]),
+            .desktopFavoritesFolder(favorites: ["1", "2"])
+        ]
+
+        let rootFolder = try await createEntitiesAndHandleSyncResponse(with: bookmarkTree, received: received, in: context)
+        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+            Bookmark(id: "1", isFavorite: true)
+            Bookmark(id: "2", isFavorite: true)
+        })
+    }
+
+    func testThatMobileFavoritesFolderDoesNotAffectReceivedFavoritesFolder() async throws {
+        let context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1", isFavorite: true)
+            Bookmark(id: "2")
+        }
+
+        let received: [Syncable] = [
+            .favoritesFolder(favorites: ["1", "2"]),
+            .mobileFavoritesFolder(favorites: ["1", "2"])
+        ]
+
+        let rootFolder = try await createEntitiesAndHandleSyncResponse(with: bookmarkTree, received: received, in: context)
+        assertEquivalent(withTimestamps: false, rootFolder, BookmarkTree {
+            Bookmark(id: "1", isFavorite: true)
+            Bookmark(id: "2", isFavorite: true)
+        })
+    }
+
+    // MARK: - Helpers
+
+    func createEntitiesAndHandleSyncResponse(
+        with bookmarkTree: BookmarkTree,
+        sent: [Syncable] = [],
+        received: [Syncable],
+        clientTimestamp: Date = Date(),
+        serverTimestamp: String = "1234",
+        in context: NSManagedObjectContext
+    ) async throws -> BookmarkEntity {
+
+        context.performAndWait {
+            BookmarkUtils.prepareFoldersStructure(in: context)
+            bookmarkTree.createEntities(in: context)
+            try! context.save()
+        }
+
+        try await provider.handleSyncResponse(sent: sent, received: received, clientTimestamp: Date(), serverTimestamp: "1234", crypter: crypter)
+
+        var rootFolder: BookmarkEntity!
+
+        context.performAndWait {
+            context.refreshAllObjects()
+            rootFolder = BookmarkUtils.fetchRootFolder(context)
+        }
+
+        return rootFolder
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1205688495536992/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2083
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1743
What kind of version bump will this require?: Patch

**Description**:
Until FFS favorites support is released, deliberately ignore any FFS
favorites folders received in Sync response.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the FFS favorites review app. Get it from [this Asana task](https://app.asana.com/0/0/1205470563151378/f) for instance.
2. Run the app from this branch.
3. Connect two apps in Sync.
4. Verify that desktop and mobile favorites folders don't show up in Bookmarks list, favorites list displays correct data and that no regular bookmarks are lost.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
