### PR TITLE
Update autofill to 8.4.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "55466f10a339843cb79a27af62d5d61c030740b2",
-        "version" : "8.4.1"
+        "revision" : "6dd7d696d4e666cedb2f1890a46fe53615226646",
+        "version" : "8.4.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.4.1"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "8.4.2"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205691418983706/1205691418983706
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.2


## Description
Updates Autofill to version [8.4.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.2).

### Autofill 8.4.2 release notes
## What's Changed
* Ema/perf followups by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/386
* Fix handler regression by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/392
* Bump markdown-it from 13.0.1 to 13.0.2 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/388
* Revert mutation observer for forms by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/396


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.4.1...8.4.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).