### PR TITLE
Append build number to metricKit crash version

### DIFF
--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import MetricKit
-import Common
 
 @available(iOSApplicationExtension, unavailable)
 @available(iOS 13, macOS 12, *)

--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import MetricKit
+import Common
 
 @available(iOSApplicationExtension, unavailable)
 @available(iOS 13, macOS 12, *)
@@ -41,7 +42,7 @@ public struct CrashCollection {
                 .flatMap { $0 }
                 .forEach {
                     completion([
-                        "appVersion": $0.applicationVersion,
+                        "appVersion": "\($0.applicationVersion).\($0.metaData.applicationBuildVersion)",
                         "code": "\($0.exceptionCode ?? -1)",
                         "type": "\($0.exceptionType ?? -1)",
                         "signal": "\($0.signal ?? -1)"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1205691485107802/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2100
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1758
What kind of version bump will this require?: Minor

See: [Comment by Lorenzo on iOS Weekly Maintenance](https://app.asana.com/0/0/1205671501750315/1205697291522645/f) for context.

The crashes are not shown in the Crash per launches/version board because the format of the version we report with the crash pixel has changed. We used to report the full version, including the build number (so, 4 numbers in the version), but starting from 7.92.0 it looks like we report only 3 numbers. Since we still send the full version number for Launches (ml.ios.*), the query fails.
It’s related to this PR: https://github.com/duckduckgo/iOS/pull/2046.
We can monitor crashes for 7.92.0 in Kibana.

**Steps to test this PR**:
1. Run the app via Xcode, and take note of the current app version
2. Now kill the app via Xcode 🙂 (this is so that the app will record a crash metric in step 4, it won't do so if a debugger is attached)
3. Open the app directly, without launching it from Xcode
4. Go to the Debug menu and tap "Crash (fatal error)”
5. Before launching the app again, change the version number using ./scripts/set_version.sh to some other value, it's not important what it is as long as it's different
6. Launch the app via Xcode
7. Check that you see that the crash pixel m_d_crash has fired in the Xcode console logs, and that it contains the appVersion parameter set to the original app version, before you changed it in step 5 **with the build number (formatted x.x.x.x)**

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
