### PR TITLE
Update autofill to 9.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "c8e895c8fd50dc76e8d8dc827a636ad77b7f46ff",
-        "version" : "9.0.0"
+        "revision" : "3b8211a59020c875422c65937e41f9b2536606e1",
+        "version" : "9.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "9.0.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "9.1.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205843087392114/1205843087392114
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.1.0


## Description
Updates Autofill to version [9.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.1.0).

### Autofill 9.1.0 release notes
## What's Changed
* Re-enable mutObs with better safeguards by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/403
* Bump zod from 3.22.2 to 3.22.4 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/395
* Workaround for pcsretirement by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/406


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/9.0.0...9.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).