### PR TITLE
Improve NetP DAU pixel reliability

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -201,6 +201,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 return
             }
 
+            // This provides a more frequent active user pixel check
+            providerEvents.fire(.userBecameActive)
+
             await rekeyIfExpired()
         }
     }


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205909514194474/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2134
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1820
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

This PR updates the NetP pixel to be more reliable. It was previously only sent when `rekey` was called, but rekeying can happen without going through this function at all, so now we check whether we can send the pixel any time the connection tester has completed a test.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs for instructions

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
