### PR TITLE
Fix timing issues with tracker surrogate injection

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/surrogates.js
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/surrogates.js
@@ -31,7 +31,6 @@
 
             log = function log () {
                 try {
-                    console.log(arguments)
                     webkit.messageHandlers.log.postMessage(JSON.stringify(arguments))
                 } catch (error) {}
             }
@@ -508,14 +507,13 @@
             }
             try {
                 loadSurrogate(result.matchedRule.surrogate)
+                // Trigger a load event on the original element
+                if (element && element.onload) {
+                    element.onload(new Event('load'))
+                }
             } catch (e) {
                 duckduckgoDebugMessaging.log(`error loading surrogate: ${e.toString()}`)
             }
-            // Trigger a load event on the original element
-            if (element && element.onload) {
-                element.onload(new Event('load'))
-            }
-
             const pageUrl = window.location.href
             surrogateInjected({
                 url: trackerUrl,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205905930000666/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2143
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1830
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL: https://app.asana.com/0/481882893211075/1205883828810956/f 
CC: @bwaresiak 

**Description**:
Improves surrogate injection:
- Removes debounce.
- Remove checking of non-script elements.
- Only check mutated elements in the mutation observer.

**Steps to test this PR**:
1. Visit https://test.smbco.de/privacy-protections/surrogates/ in macOS or iOS browser.
1. All tests (except 'Chromium only') should return 'surrogate loaded'


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
