### PR TITLE
Attempts to fix a crasher with BloomFilterWrapper in macOS 11.x

### DIFF
--- a/Sources/BloomFilterObjC/include/module.private.modulemap
+++ b/Sources/BloomFilterObjC/include/module.private.modulemap
@@ -1,4 +1,4 @@
-module BloomFilterWrapper {
+module BloomFilterObjC {
     header "BloomFilterObjC.h"
     export *
 }

--- a/Sources/BloomFilterWrapper/BloomFilterWrapper.swift
+++ b/Sources/BloomFilterWrapper/BloomFilterWrapper.swift
@@ -22,18 +22,22 @@ import Foundation
 public final class BloomFilterWrapper {
     private let bloomFilter: BloomFilterObjC
 
+    @inline(never)
     public init(fromPath path: String, withBitCount bitCount: Int32, andTotalItems totalItems: Int32) {
         bloomFilter = BloomFilterObjC(fromPath: path, withBitCount: bitCount, andTotalItems: totalItems)
     }
 
+    @inline(never)
     public init(totalItems count: Int32, errorRate: Double) {
         bloomFilter = BloomFilterObjC(totalItems: count, errorRate: errorRate)
     }
 
+    @inline(never)
     public func add(_ entry: String) {
         bloomFilter.add(entry)
     }
 
+    @inline(never)
     public func contains(_ entry: String) -> Bool {
         bloomFilter.contains(entry)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205931560838491/f
iOS PR: 
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1839
What kind of version bump will this require?: Patch

## Description

Attempts to provide a fix to a crash that's happening in macOS 11.x systems due to BloomFilterWrapper.

## Testing

Just make sure everything builds fine.  There are no logical changes.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
