### PR TITLE
Improve energy performance of ContentBlockerRulesUserScript

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/ContentBlockerRulesUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/ContentBlockerRulesUserScript.swift
@@ -105,10 +105,17 @@ open class ContentBlockerRulesUserScript: NSObject, UserScript {
     
     public weak var delegate: ContentBlockerRulesUserScriptDelegate?
 
+    private var _temporaryUnprotectedDomainsCache = [String: [String]]()
+
     var temporaryUnprotectedDomains: [String] {
+        if let domains = _temporaryUnprotectedDomainsCache[configuration.privacyConfiguration.identifier] {
+            return domains
+        }
+
         let privacyConfiguration = configuration.privacyConfiguration
         var temporaryUnprotectedDomains = privacyConfiguration.tempUnprotectedDomains.filter { !$0.trimmingWhitespace().isEmpty }
         temporaryUnprotectedDomains.append(contentsOf: privacyConfiguration.exceptionsList(forFeature: .contentBlocking))
+        _temporaryUnprotectedDomainsCache = [configuration.privacyConfiguration.identifier: temporaryUnprotectedDomains]
         return temporaryUnprotectedDomains
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206018890798709/f
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
Cache the calculated temporary unprotected domains property in ContentBlockerRulesUserScript.

**Steps to test this PR**:
1. Drop this into macOS and iOS apps
2. Browse to a few pages, ensure blocking is still working and privacy dashboard is showing expected trackers
    e.g. cnn.com should have a lot of trackers, wikipedia.org should have few to none 
4. Add breakpoint to `ContentBlockerRulesUserScript` `temporaryUnprotectedDomains` 
5. Use a proxy or some other method to force a change to the exceptions list of `contentBlocking` in the privacy config
    * iOS: use Xcode debug > trigger background fetch
    * macOS: use debug menu to reload the config 
7. Ensure that new exceptions list is being used 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
