### PR TITLE
Use VPNSettings for cohort storage

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -830,7 +830,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 .setNotifyStatusChanges,
                 .setRegistrationKeyValidity,
                 .setSelectedEnvironment,
-                .setShowInMenuBar:
+                .setShowInMenuBar,
+                .setVPNFirstEnabled:
             // Intentional no-op, as some setting changes don't require any further operation
             break
         }

--- a/Sources/NetworkProtection/Settings/Extensions/UserDefaults+vpnFirstEnabled.swift
+++ b/Sources/NetworkProtection/Settings/Extensions/UserDefaults+vpnFirstEnabled.swift
@@ -1,0 +1,41 @@
+//
+//  UserDefaults+showInMenuBar.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+extension UserDefaults {
+    private var vpnFirstEnabledKey: String {
+        "vpnFirstEnabled"
+    }
+
+    @objc
+    dynamic var vpnFirstEnabled: Date? {
+        get {
+            value(forKey: vpnFirstEnabledKey) as? Date
+        }
+
+        set {
+            set(newValue, forKey: vpnFirstEnabledKey)
+        }
+    }
+
+    var vpnFirstEnabledPublisher: AnyPublisher<Date?, Never> {
+        publisher(for: \.vpnFirstEnabled).eraseToAnyPublisher()
+    }
+}

--- a/Sources/NetworkProtection/Settings/VPNSettings.swift
+++ b/Sources/NetworkProtection/Settings/VPNSettings.swift
@@ -19,7 +19,7 @@
 import Combine
 import Foundation
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 
 /// Persists and publishes changes to tunnel settings.
 ///
@@ -169,6 +169,7 @@ public final class VPNSettings {
 
     // MARK: - Applying Changes
 
+    // swiftlint:disable cyclomatic_complexity
     public func apply(change: Change) {
         switch change {
         case .setConnectOnLogin(let connectOnLogin):
@@ -195,6 +196,7 @@ public final class VPNSettings {
             self.vpnFirstEnabled = vpnFirstEnabled
         }
     }
+    // swiftlint:enable cyclomatic_complexity
 
     // MARK: - Connect on Login
 
@@ -401,4 +403,4 @@ public final class VPNSettings {
     }
 }
 
-// swiftlint:enable type_body_length
+// swiftlint:enable type_body_length file_length

--- a/Sources/NetworkProtection/Settings/VPNSettings.swift
+++ b/Sources/NetworkProtection/Settings/VPNSettings.swift
@@ -40,6 +40,7 @@ public final class VPNSettings {
         case setSelectedLocation(_ selectedLocation: SelectedLocation)
         case setSelectedEnvironment(_ selectedEnvironment: SelectedEnvironment)
         case setShowInMenuBar(_ showInMenuBar: Bool)
+        case setVPNFirstEnabled(_ vpnFirstEnabled: Date?)
     }
 
     public enum RegistrationKeyValidity: Codable {
@@ -131,6 +132,10 @@ public final class VPNSettings {
             Change.setShowInMenuBar(showInMenuBar)
         }.eraseToAnyPublisher()
 
+        let vpnFirstEnabledPublisher = vpnFirstEnabledPublisher.map { vpnFirstEnabled in
+            Change.setVPNFirstEnabled(vpnFirstEnabled)
+        }.eraseToAnyPublisher()
+
         return Publishers.MergeMany(
             connectOnLoginPublisher,
             includeAllNetworksPublisher,
@@ -140,7 +145,8 @@ public final class VPNSettings {
             serverChangePublisher,
             locationChangePublisher,
             environmentChangePublisher,
-            showInMenuBarPublisher).eraseToAnyPublisher()
+            showInMenuBarPublisher,
+            vpnFirstEnabledPublisher).eraseToAnyPublisher()
     }()
 
     public init(defaults: UserDefaults) {
@@ -185,6 +191,8 @@ public final class VPNSettings {
             self.selectedEnvironment = selectedEnvironment
         case .setShowInMenuBar(let showInMenuBar):
             self.showInMenuBar = showInMenuBar
+        case .setVPNFirstEnabled(let vpnFirstEnabled):
+            self.vpnFirstEnabled = vpnFirstEnabled
         }
     }
 
@@ -373,6 +381,22 @@ public final class VPNSettings {
             case .range(let range, _):
                 return range
             }
+        }
+    }
+
+    // MARK: - First time VPN is enabled
+
+    public var vpnFirstEnabledPublisher: AnyPublisher<Date?, Never> {
+        defaults.vpnFirstEnabledPublisher
+    }
+
+    public var vpnFirstEnabled: Date? {
+        get {
+            defaults.vpnFirstEnabled
+        }
+
+        set {
+            defaults.vpnFirstEnabled = newValue
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1205948683470036/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2207
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1905
What kind of version bump will this require?: Minor

**Description**:

Stores the netP `cohort` value inside `VPNSettings` so that it can be accessed by both the system extension and the VPN.

**Steps to test this PR**:

See platform-specific PRs.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
