### PR TITLE
NetP: Remove port from server address

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -923,7 +923,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     private func handleGetServerAddress(completionHandler: ((Data?) -> Void)? = nil) {
-        let response = lastSelectedServerInfo?.endpoint.map { ExtensionMessageString($0.description) }
+        let response = lastSelectedServerInfo?.endpoint.map { ExtensionMessageString($0.host.description) }
         completionHandler?(response?.rawValue)
     }
 

--- a/Sources/NetworkProtection/WireGuardKit/Endpoint.swift
+++ b/Sources/NetworkProtection/WireGuardKit/Endpoint.swift
@@ -30,16 +30,7 @@ extension Endpoint: Hashable {
 extension Endpoint: CustomStringConvertible {
 
     public var description: String {
-        switch host {
-        case .name(let hostname, _):
-            return "\(hostname):\(port)"
-        case .ipv4(let address):
-            return "\(address):\(port)"
-        case .ipv6(let address):
-            return "[\(address)]:\(port)"
-        @unknown default:
-            fatalError()
-        }
+        "\(host):\(port)"
     }
 
     public init?(from string: String) {
@@ -83,6 +74,21 @@ extension Endpoint {
             return true
         case .ipv6:
             return true
+        @unknown default:
+            fatalError()
+        }
+    }
+}
+
+extension NWEndpoint.Host: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .name(let hostname, _):
+            return hostname
+        case .ipv4(let address):
+            return "\(address)"
+        case .ipv6(let address):
+            return "\(address)"
         @unknown default:
             fatalError()
         }


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206056874665890/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2214
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1916
What kind of version bump will this require?: Minor

**Description**:

During the NetP iOS ship review, there was feedback that the server IP address labels should not feature the port. So now, rather than sending the host + port as the server address, I’m just sending the host.

**Steps to test this PR**:
1. Launch NetP
2. Check the status view and make sure the IP Address does not include the port

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
