### PR TITLE
Add option to disable rekeying

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -156,11 +156,16 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     private func rekey() async {
+        providerEvents.fire(.userBecameActive)
+
+        // Experimental option to disable rekeying.
+        guard !settings.disableRekeying else {
+            return
+        }
+
         os_log("Rekeying...", log: .networkProtectionKeyManagement)
 
-        providerEvents.fire(.userBecameActive)
         providerEvents.fire(.rekeyCompleted)
-
         self.resetRegistrationKey()
 
         do {
@@ -831,7 +836,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 .setRegistrationKeyValidity,
                 .setSelectedEnvironment,
                 .setShowInMenuBar,
-                .setVPNFirstEnabled:
+                .setVPNFirstEnabled,
+                .setDisableRekeying:
             // Intentional no-op, as some setting changes don't require any further operation
             break
         }

--- a/Sources/NetworkProtection/Settings/Extensions/UserDefaults+disableRekeying.swift
+++ b/Sources/NetworkProtection/Settings/Extensions/UserDefaults+disableRekeying.swift
@@ -1,0 +1,47 @@
+//
+//  UserDefaults+disableRekeying.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+extension UserDefaults {
+    private var disableRekeyingKey: String {
+        "networkProtectionSettingDisableRekeying"
+    }
+
+    static let disableRekeyingDefaultValue = false
+
+    @objc
+    dynamic var networkProtectionSettingDisableRekeying: Bool {
+        get {
+            value(forKey: disableRekeyingKey) as? Bool ?? Self.disableRekeyingDefaultValue
+        }
+
+        set {
+            set(newValue, forKey: disableRekeyingKey)
+        }
+    }
+
+    var networkProtectionSettingDisableRekeyingPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.networkProtectionSettingDisableRekeying).eraseToAnyPublisher()
+    }
+
+    func resetNetworkProtectionSettingDisableRekeying() {
+        removeObject(forKey: disableRekeyingKey)
+    }
+}

--- a/Sources/NetworkProtection/Settings/VPNSettings.swift
+++ b/Sources/NetworkProtection/Settings/VPNSettings.swift
@@ -41,6 +41,7 @@ public final class VPNSettings {
         case setSelectedEnvironment(_ selectedEnvironment: SelectedEnvironment)
         case setShowInMenuBar(_ showInMenuBar: Bool)
         case setVPNFirstEnabled(_ vpnFirstEnabled: Date?)
+        case setDisableRekeying(_ disableRekeying: Bool)
     }
 
     public enum RegistrationKeyValidity: Codable {
@@ -136,6 +137,10 @@ public final class VPNSettings {
             Change.setVPNFirstEnabled(vpnFirstEnabled)
         }.eraseToAnyPublisher()
 
+        let disableRekeyingPublisher = disableRekeyingPublisher.map { disableRekeying in
+            Change.setDisableRekeying(disableRekeying)
+        }.eraseToAnyPublisher()
+
         return Publishers.MergeMany(
             connectOnLoginPublisher,
             includeAllNetworksPublisher,
@@ -146,7 +151,8 @@ public final class VPNSettings {
             locationChangePublisher,
             environmentChangePublisher,
             showInMenuBarPublisher,
-            vpnFirstEnabledPublisher).eraseToAnyPublisher()
+            vpnFirstEnabledPublisher,
+            disableRekeyingPublisher).eraseToAnyPublisher()
     }()
 
     public init(defaults: UserDefaults) {
@@ -194,6 +200,8 @@ public final class VPNSettings {
             self.showInMenuBar = showInMenuBar
         case .setVPNFirstEnabled(let vpnFirstEnabled):
             self.vpnFirstEnabled = vpnFirstEnabled
+        case .setDisableRekeying(let disableRekeying):
+            self.disableRekeying = disableRekeying
         }
     }
     // swiftlint:enable cyclomatic_complexity
@@ -399,6 +407,22 @@ public final class VPNSettings {
 
         set {
             defaults.vpnFirstEnabled = newValue
+        }
+    }
+
+    // MARK: - Disable Rekeying
+
+    public var disableRekeyingPublisher: AnyPublisher<Bool, Never> {
+        defaults.networkProtectionSettingDisableRekeyingPublisher
+    }
+
+    public var disableRekeying: Bool {
+        get {
+            defaults.networkProtectionSettingDisableRekeying
+        }
+
+        set {
+            defaults.networkProtectionSettingDisableRekeying = newValue
         }
     }
 }


### PR DESCRIPTION
This is intended for internal use only.

<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199333091098016/1206100276423377/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2219
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1922
What kind of version bump will this require?: Major

**Optional**:

Tech Design URL:
CC:

**Description**:

This PR adds a setting to disable rekeying.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
