### PR TITLE
Update autofill to 10.0.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "93677cc02cfe650ce7f417246afd0e8e972cd83e",
-        "version" : "10.0.0"
+        "revision" : "dbecae0df07650a21b5632a92fa2e498c96af7b5",
+        "version" : "10.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "10.0.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "10.0.1"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206111598841006/1206111598841006
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.1


## Description
Updates Autofill to version [10.0.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.1).

### Autofill 10.0.1 release notes
## What's Changed
* Tweak pulldown menu copy on desktop by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/433
* Update password-related json files (2023-12-06) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/434


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.0...10.0.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).