### PR TITLE
Add errorEvent handling to location list repo

### DIFF
--- a/Sources/NetworkProtection/Repositories/NetworkProtectionLocationListRepository.swift
+++ b/Sources/NetworkProtection/Repositories/NetworkProtectionLocationListRepository.swift
@@ -29,7 +29,9 @@ final public class NetworkProtectionLocationListCompositeRepository: NetworkProt
     private let tokenStore: NetworkProtectionTokenStore
     private let errorEvents: EventMapping<NetworkProtectionError>
 
-    convenience public init(environment: VPNSettings.SelectedEnvironment, tokenStore: NetworkProtectionTokenStore, errorEvents: EventMapping<NetworkProtectionError>) {
+    convenience public init(environment: VPNSettings.SelectedEnvironment, 
+                            tokenStore: NetworkProtectionTokenStore,
+                            errorEvents: EventMapping<NetworkProtectionError>) {
         self.init(
             client: NetworkProtectionBackendClient(environment: environment),
             tokenStore: tokenStore,
@@ -37,7 +39,9 @@ final public class NetworkProtectionLocationListCompositeRepository: NetworkProt
         )
     }
 
-    init(client: NetworkProtectionClient, tokenStore: NetworkProtectionTokenStore, errorEvents: EventMapping<NetworkProtectionError>) {
+    init(client: NetworkProtectionClient, 
+         tokenStore: NetworkProtectionTokenStore,
+         errorEvents: EventMapping<NetworkProtectionError>) {
         self.client = client
         self.tokenStore = tokenStore
         self.errorEvents = errorEvents

--- a/Sources/NetworkProtection/Repositories/NetworkProtectionLocationListRepository.swift
+++ b/Sources/NetworkProtection/Repositories/NetworkProtectionLocationListRepository.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import Common
 
 public protocol NetworkProtectionLocationListRepository {
     func fetchLocationList() async throws -> [NetworkProtectionLocation]
@@ -26,17 +27,20 @@ final public class NetworkProtectionLocationListCompositeRepository: NetworkProt
     @MainActor private static var locationList: [NetworkProtectionLocation] = []
     private let client: NetworkProtectionClient
     private let tokenStore: NetworkProtectionTokenStore
+    private let errorEvents: EventMapping<NetworkProtectionError>
 
-    convenience public init(environment: VPNSettings.SelectedEnvironment, tokenStore: NetworkProtectionTokenStore) {
+    convenience public init(environment: VPNSettings.SelectedEnvironment, tokenStore: NetworkProtectionTokenStore, errorEvents: EventMapping<NetworkProtectionError>) {
         self.init(
             client: NetworkProtectionBackendClient(environment: environment),
-            tokenStore: tokenStore
+            tokenStore: tokenStore,
+            errorEvents: errorEvents
         )
     }
 
-    init(client: NetworkProtectionClient, tokenStore: NetworkProtectionTokenStore) {
+    init(client: NetworkProtectionClient, tokenStore: NetworkProtectionTokenStore, errorEvents: EventMapping<NetworkProtectionError>) {
         self.client = client
         self.tokenStore = tokenStore
+        self.errorEvents = errorEvents
     }
 
     @MainActor
@@ -50,11 +54,15 @@ final public class NetworkProtectionLocationListCompositeRepository: NetworkProt
             }
             Self.locationList = try await client.getLocations(authToken: authToken).get()
         } catch let error as NetworkProtectionErrorConvertible {
+            errorEvents.fire(error.networkProtectionError)
             throw error.networkProtectionError
         } catch let error as NetworkProtectionError {
+            errorEvents.fire(error)
             throw error
         } catch {
-            throw NetworkProtectionError.unhandledError(function: #function, line: #line, error: error)
+            let unhandledError = NetworkProtectionError.unhandledError(function: #function, line: #line, error: error)
+            errorEvents.fire(unhandledError)
+            throw unhandledError
         }
         return Self.locationList
     }

--- a/Tests/NetworkProtectionTests/Repositories/NetworkProtectionLocationListCompositeRepositoryTests.swift
+++ b/Tests/NetworkProtectionTests/Repositories/NetworkProtectionLocationListCompositeRepositoryTests.swift
@@ -132,7 +132,7 @@ class NetworkProtectionLocationListCompositeRepositoryTests: XCTestCase {
     func testFetchLocationList_fetchThrows_sendsErrorEvent() async {
         client.stubGetLocations = .failure(.failedToFetchLocationList(nil))
         var didReceiveError: Bool = false
-        verifyErrorEvent = { error in
+        verifyErrorEvent = { _ in
             didReceiveError = true
             // Matching errors is not working for some reason, so just checking for any error
         }


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206107031155633/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2222
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1933
What kind of version bump will this require?: Major

**Description**:

Just adds error handling to the NetP location list repository

**Steps to test this PR**:
- See iOS

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
