### PR TITLE
No longer excluding the 10.0.0.0/8 range

### DIFF
--- a/Sources/NetworkProtection/Settings/RoutingRange.swift
+++ b/Sources/NetworkProtection/Settings/RoutingRange.swift
@@ -28,7 +28,7 @@ public enum RoutingRange {
         // server's IP address lives in this range.
         // Ref: https://app.asana.com/0/1203708860857015/1206099277258514/f
         //
-        //.range("10.0.0.0/8"     /* 255.0.0.0 */, description: "disabled for enforceRoutes"),
+        // .range("10.0.0.0/8"     /* 255.0.0.0 */, description: "disabled for enforceRoutes"),
         .range("100.64.0.0/16"  /* 255.255.0.0 */, description: "Shared Address Space"),
         .range("127.0.0.0/8"    /* 255.0.0.0 */, description: "Loopback"),
         .range("169.254.0.0/16" /* 255.255.0.0 */, description: "Link-local"),

--- a/Sources/NetworkProtection/Settings/RoutingRange.swift
+++ b/Sources/NetworkProtection/Settings/RoutingRange.swift
@@ -24,7 +24,11 @@ public enum RoutingRange {
 
     public static let alwaysExcludedIPv4Ranges: [RoutingRange] = [
         .section("IPv4 - Always Excluded"),
-        .range("10.0.0.0/8"     /* 255.0.0.0 */, description: "disabled for enforceRoutes"),
+        // This is disabled because excluded routes seem to trump included routes, and our DNS
+        // server's IP address lives in this range.
+        // Ref: https://app.asana.com/0/1203708860857015/1206099277258514/f
+        //
+        //.range("10.0.0.0/8"     /* 255.0.0.0 */, description: "disabled for enforceRoutes"),
         .range("100.64.0.0/16"  /* 255.255.0.0 */, description: "Shared Address Space"),
         .range("127.0.0.0/8"    /* 255.0.0.0 */, description: "Loopback"),
         .range("169.254.0.0/16" /* 255.255.0.0 */, description: "Link-local"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206114617364818/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2239
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1934

## Description

We no longer exclude 10.0.0.0/8 from the VPN since it was causing our DNS to be excluded as well.

## Testing:

Test through the platform specific PRs.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
