### PR TITLE
Ensure that LinkPresentation framework is called on main thread

### DIFF
--- a/Sources/Bookmarks/FaviconsFetcher/FaviconFetcher.swift
+++ b/Sources/Bookmarks/FaviconsFetcher/FaviconFetcher.swift
@@ -31,7 +31,7 @@ public final class FaviconFetcher: NSObject, FaviconFetching {
         let metadataFetcher = LPMetadataProvider()
 
         // Allow LinkPresentation to fail so that we can fall back to fetching hardcoded paths
-        let metadata: LPLinkMetadata? = await {
+        let metadata: LPLinkMetadata? = await { @MainActor in
             if #available(iOS 15.0, macOS 12.0, *) {
                 var request = URLRequest(url: url)
                 request.attribution = .user


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201493110486074/1206113035171145/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2241
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1935
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
