### PR TITLE
Fix VPN IPv6 connectivity

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -989,7 +989,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     private func handleGetServerAddress(completionHandler: ((Data?) -> Void)? = nil) {
-        let response = lastSelectedServerInfo?.endpoint.map { ExtensionMessageString($0.host.description) }
+        let response = lastSelectedServerInfo?.endpoint.map { ExtensionMessageString($0.host.hostWithoutPort) }
         completionHandler?(response?.rawValue)
     }
 

--- a/Sources/NetworkProtection/WireGuardKit/Endpoint.swift
+++ b/Sources/NetworkProtection/WireGuardKit/Endpoint.swift
@@ -30,7 +30,16 @@ extension Endpoint: Hashable {
 extension Endpoint: CustomStringConvertible {
 
     public var description: String {
-        "\(host):\(port)"
+        switch host {
+        case .name(let hostname, _):
+            return "\(hostname):\(port)"
+        case .ipv4(let address):
+            return "\(address):\(port)"
+        case .ipv6(let address):
+            return "[\(address)]:\(port)"
+        @unknown default:
+            fatalError()
+        }
     }
 
     public init?(from string: String) {
@@ -80,8 +89,8 @@ extension Endpoint {
     }
 }
 
-extension NWEndpoint.Host: CustomStringConvertible {
-    public var description: String {
+extension NWEndpoint.Host {
+    public var hostWithoutPort: String {
         switch self {
         case .name(let hostname, _):
             return hostname

--- a/Tests/NetworkProtectionTests/EndpointTests.swift
+++ b/Tests/NetworkProtectionTests/EndpointTests.swift
@@ -1,0 +1,73 @@
+//
+//  File.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Network
+@testable import NetworkProtection
+
+final class EndpointTests: XCTestCase {
+
+    func testEndpointWithHostName_ShouldIncludePort() {
+        let endpoint = self.endpointWithHostName()
+        XCTAssertEqual(endpoint.description, "https://duckduckgo.com:443")
+    }
+
+    func testEndpointWithIPv4Address_ShouldIncludePort() {
+        let endpoint = self.endpointWithIPv4()
+        XCTAssertEqual(endpoint.description, "52.250.42.157:443")
+    }
+
+    func testEndpointWithIPv6Address_ShouldIncludePort() {
+        let endpoint = self.endpointWithIPv6()
+        XCTAssertEqual(endpoint.description, "[2001:db8:85a3::8a2e:370:7334]:443")
+    }
+
+    func testParsingEndpointFromIPv4Address() {
+        let address = "52.250.42.157:443"
+        let endpoint = Endpoint(from: address)!
+        XCTAssertEqual(endpoint.description, address)
+    }
+
+    func testParsingEndpointFromIPv6Address() {
+        let address = "[2001:0db8:85a3:0000:0000:8a2e:0370]:443"
+        let endpoint = Endpoint(from: address)!
+        XCTAssertEqual(endpoint.description, "2001:0db8:85a3:0000:0000:8a2e:0370:443")
+    }
+
+    private func endpointWithHostName() -> Endpoint {
+        let host = NWEndpoint.Host.name("https://duckduckgo.com", nil)
+        let port = NWEndpoint.Port.https
+        return Endpoint(host: host, port: port)
+    }
+
+    private func endpointWithIPv4() -> Endpoint {
+        let address = IPv4Address("52.250.42.157")!
+        let host = NWEndpoint.Host.ipv4(address)
+        let port = NWEndpoint.Port.https
+        return Endpoint(host: host, port: port)
+    }
+
+    private func endpointWithIPv6() -> Endpoint {
+        let address = IPv6Address("2001:0db8:85a3:0000:0000:8a2e:0370:7334")!
+        let host = NWEndpoint.Host.ipv6(address)
+        let port = NWEndpoint.Port.https
+        return Endpoint(host: host, port: port)
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206136376883995/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2258
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1954
What kind of version bump will this require?: Major

**Description**:

This PR fixes a regression related to IPv6.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make sure NetP connects on each of the platform PRs, and that the IP address does not include the port

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
