### PR TITLE
Update autofill to 10.0.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "dbecae0df07650a21b5632a92fa2e498c96af7b5",
-        "version" : "10.0.1"
+        "revision" : "5597bc17709c8acf454ecaad4f4082007986242a",
+        "version" : "10.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "SecureStorage", targets: ["SecureStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "10.0.1"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "10.0.2"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.2"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206157971479455/1206157971479455
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.2


## Description
Updates Autofill to version [10.0.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.2).

### Autofill 10.0.2 release notes
## What's Changed
* Copy change by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/443
* Update password-related json files (2023-12-13) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/442


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.1...10.0.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).