### PR TITLE
Remove the reconnect/disconnect logic from the connection tester

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -47,7 +47,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     enum TunnelError: LocalizedError {
         case startingTunnelWithoutAuthToken
         case couldNotGenerateTunnelConfiguration(internalError: Error)
-        case couldNotFixConnection
         case simulateTunnelFailureError
 
         var errorDescription: String? {
@@ -58,11 +57,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 return "Failed to generate a tunnel configuration: \(internalError.localizedDescription)"
             case .simulateTunnelFailureError:
                 return "Simulated a tunnel error as requested"
-            default:
-                // This is probably not the most elegant error to show to a user but
-                // it's a great way to get detailed reports for those cases we haven't
-                // provided good descriptions for yet.
-                return "Tunnel error: \(String(describing: self))"
             }
         }
     }
@@ -242,7 +236,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     private var isConnectionTesterEnabled: Bool = true
 
     private lazy var connectionTester: NetworkProtectionConnectionTester = {
-        NetworkProtectionConnectionTester(timerQueue: timerQueue, log: .networkProtectionConnectionTesterLog) { @MainActor [weak self] (result, isStartupTest) in
+        NetworkProtectionConnectionTester(timerQueue: timerQueue, log: .networkProtectionConnectionTesterLog) { @MainActor [weak self] result in
             guard let self else { return }
 
             switch result {
@@ -257,17 +251,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             case .disconnected(let failureCount):
                 self.tunnelHealth.isHavingConnectivityIssues = true
                 self.bandwidthAnalyzer.reset()
-
-                if failureCount == 1 {
-                    self.notificationsPresenter.showReconnectingNotification()
-
-                    // Only do these things if this is not a connection startup test.
-                    if !isStartupTest {
-                        self.fixTunnel()
-                    }
-                } else if failureCount == 2 {
-                    self.stopTunnel(with: TunnelError.couldNotFixConnection)
-                }
             }
         }
     }()
@@ -684,28 +667,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         tunnelHealth.isHavingConnectivityIssues = false
         controllerErrorStore.lastErrorMessage = nil
-    }
-
-    /// Intentionally not async, so that we won't lock whoever called this method.  This method will race against the tester
-    /// to see if it can fix the connection before the next failure.
-    ///
-    private func fixTunnel() {
-        Task {
-            let serverSelectionMethod: NetworkProtectionServerSelectionMethod
-
-            if let lastServerName = lastSelectedServerInfo?.name {
-                serverSelectionMethod = .avoidServer(serverName: lastServerName)
-            } else {
-                assertionFailure("We should not have a situation where the VPN is trying to fix the tunnel and there's no previous server info")
-                serverSelectionMethod = .automatic
-            }
-
-            do {
-                try await updateTunnelConfiguration(environment: settings.selectedEnvironment, serverSelectionMethod: serverSelectionMethod)
-            } catch {
-                return
-            }
-        }
     }
 
     // MARK: - Tunnel Configuration

--- a/Sources/NetworkProtection/Status/ConnectivityIssueObserver/DisabledConnectivityIssueObserver.swift
+++ b/Sources/NetworkProtection/Status/ConnectivityIssueObserver/DisabledConnectivityIssueObserver.swift
@@ -1,0 +1,32 @@
+//
+//  DisabledConnectivityIssueObserver.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+/// This is a convenience temporary disabler for the connectivity issues observer.  Will always report no issues.
+///
+/// This is useful since we decided to momentarily disable connection issue reporting in the UI:
+///     ref: https://app.asana.com/0/0/1206071632962016/1206144227620065/f
+///
+public final class DisabledConnectivityIssueObserver: ConnectivityIssueObserver {
+    public var publisher: AnyPublisher<Bool, Never> = Just(false).eraseToAnyPublisher()
+    public var recentValue = false
+
+    public init() {}
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206173513538620/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2272
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1970
What kind of version bump will this require?: Patch

## Description

Removes the logic that would reconnect / disconnect NetP in case of trouble.

## Testing

See platform-specific PRs for testing instructions.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
