### PR TITLE
Prevent VPN server list persistence failures

### DIFF
--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionError.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionError.swift
@@ -61,7 +61,7 @@ public enum NetworkProtectionError: LocalizedError {
 
     // Wireguard errors
     case wireGuardCannotLocateTunnelFileDescriptor
-    case wireGuardInvalidState
+    case wireGuardInvalidState(reason: String)
     case wireGuardDnsResolution
     case wireGuardSetNetworkSettings(Error)
     case startWireGuardBackend(Int32)

--- a/Sources/NetworkProtection/Diagnostics/WireGuardAdapterError+NetworkProtectionErrorConvertible.swift
+++ b/Sources/NetworkProtection/Diagnostics/WireGuardAdapterError+NetworkProtectionErrorConvertible.swift
@@ -23,8 +23,8 @@ extension WireGuardAdapterError: NetworkProtectionErrorConvertible {
         switch self {
         case .cannotLocateTunnelFileDescriptor:
             return .wireGuardCannotLocateTunnelFileDescriptor
-        case .invalidState:
-            return .wireGuardInvalidState
+        case .invalidState(let reason):
+            return .wireGuardInvalidState(reason: reason.rawValue)
         case .dnsResolution:
             return .wireGuardDnsResolution
         case .setNetworkSettings(let error):

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -891,7 +891,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         resetRegistrationKey()
 
         let serverCache = NetworkProtectionServerListFileSystemStore(errorEvents: nil)
-        try? serverCache.removeServerList()
+        serverCache.removeServerList()
 
         try? tokenStore.deleteToken()
 

--- a/Sources/NetworkProtection/Storage/NetworkProtectionServerListStore.swift
+++ b/Sources/NetworkProtection/Storage/NetworkProtectionServerListStore.swift
@@ -163,7 +163,7 @@ public class NetworkProtectionServerListFileSystemStore: NetworkProtectionServer
         do {
             data = try Data(contentsOf: fileURL)
         } catch {
-            try removeServerList()
+            removeServerList()
             throw NetworkProtectionServerListStoreError.failedToReadServerList(error)
         }
 

--- a/Sources/NetworkProtection/Storage/NetworkProtectionServerListStore.swift
+++ b/Sources/NetworkProtection/Storage/NetworkProtectionServerListStore.swift
@@ -170,19 +170,19 @@ public class NetworkProtectionServerListFileSystemStore: NetworkProtectionServer
         do {
             return try JSONDecoder().decode([NetworkProtectionServer].self, from: data)
         } catch {
-            try removeServerList()
+            removeServerList()
             throw NetworkProtectionServerListStoreError.failedToDecodeServerList(error)
         }
     }
 
-    public func removeServerList() throws {
-        if FileManager.default.fileExists(atPath: fileURL.relativePath) {
-            try FileManager.default.removeItem(at: fileURL)
+    public func removeServerList() {
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try? FileManager.default.removeItem(at: fileURL)
         }
     }
 
     private func replaceServerList(with newList: [NetworkProtectionServer]) throws {
-        try removeServerList()
+        removeServerList()
 
         let serializedJSONData: Data
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206201299599597/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2275
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1985
What kind of version bump will this require?: Major

**Description**:

This PR makes two changes:

1. The WireGuard invalid state error has been given a `reason` field, to allow insight into what state is invalid exactly
2. The server list store no longer prevents the file from being stored if the old one can't be removed; this appears to be a major source of unhandled errors

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
