### PR TITLE
Update latency & tunnel failure monitors implementation

### DIFF
--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionLatencyMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionLatencyMonitor.swift
@@ -99,7 +99,7 @@ public actor NetworkProtectionLatencyMonitor {
 
     @MainActor
     public func start(serverIP: IPv4Address, callback: @escaping (Result) -> Void) {
-        os_log("⚫️ Starting latency monitor", log: .networkProtectionPixel)
+        os_log("⚫️ Starting latency monitor", log: .networkProtectionLatencyMonitorLog)
 
         self.serverIP = serverIP
 
@@ -107,12 +107,12 @@ public actor NetworkProtectionLatencyMonitor {
             .scan(ExponentialGeometricAverage()) { measurements, latency in
                 if latency >= 0 {
                     measurements.addMeasurement(latency)
-                    os_log("⚫️ Latency: %{public}f milliseconds", log: .networkProtectionPixel, type: .debug, latency)
+                    os_log("⚫️ Latency: %{public}f milliseconds", log: .networkProtectionLatencyMonitorLog, type: .debug, latency)
                 } else {
                     callback(.error)
                 }
 
-                os_log("⚫️ Average: %{public}f milliseconds", log: .networkProtectionPixel, type: .debug, measurements.average)
+                os_log("⚫️ Average: %{public}f milliseconds", log: .networkProtectionLatencyMonitorLog, type: .debug, measurements.average)
 
                 return measurements
             }
@@ -133,7 +133,7 @@ public actor NetworkProtectionLatencyMonitor {
 
     @MainActor
     public func stop() {
-        os_log("⚫️ Stopping latency monitor", log: .networkProtectionPixel)
+        os_log("⚫️ Stopping latency monitor", log: .networkProtectionLatencyMonitorLog)
 
         latencyCancellable = nil
         task = nil
@@ -148,15 +148,15 @@ public actor NetworkProtectionLatencyMonitor {
             return
         }
 
-        os_log("⚫️ Pinging %{public}s", log: .networkProtectionPixel, type: .debug, serverIP.debugDescription)
+        os_log("⚫️ Pinging %{public}s", log: .networkProtectionLatencyMonitorLog, type: .debug, serverIP.debugDescription)
 
-        let result = await Pinger(ip: serverIP, timeout: Self.pingTimeout, log: .networkProtectionPixel).ping()
+        let result = await Pinger(ip: serverIP, timeout: Self.pingTimeout, log: .networkProtectionLatencyMonitorLog).ping()
 
         switch result {
         case .success(let pingResult):
             latencySubject.send(pingResult.time * 1000)
         case .failure(let error):
-            os_log("⚫️ Ping error: %{public}s", log: .networkProtectionPixel, type: .debug, error.localizedDescription)
+            os_log("⚫️ Ping error: %{public}s", log: .networkProtectionLatencyMonitorLog, type: .debug, error.localizedDescription)
             latencySubject.send(Self.unknownLatency)
         }
     }

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionLatencyMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionLatencyMonitor.swift
@@ -81,9 +81,6 @@ public actor NetworkProtectionLatencyMonitor {
     private var lastLatencyReported: Date = .distantPast
 
     @MainActor
-    private var ignoreThreshold = false
-
-    @MainActor
     private(set) var serverIP: IPv4Address?
 
     // MARK: - Init & deinit
@@ -123,7 +120,7 @@ public actor NetworkProtectionLatencyMonitor {
             .sink { [weak self] quality in
                 let now = Date()
                 if let self,
-                    (now.timeIntervalSince1970 - self.lastLatencyReported.timeIntervalSince1970 >= Self.reportThreshold) || ignoreThreshold {
+                   now.timeIntervalSince1970 - self.lastLatencyReported.timeIntervalSince1970 >= Self.reportThreshold {
                     callback(.quality(quality))
                     self.lastLatencyReported = now
                 }
@@ -166,9 +163,7 @@ public actor NetworkProtectionLatencyMonitor {
 
     @MainActor
     public func simulateLatency(_ timeInterval: TimeInterval) {
-        ignoreThreshold = true
         latencySubject.send(timeInterval)
-        ignoreThreshold = false
     }
 }
 

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionLatencyMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionLatencyMonitor.swift
@@ -75,8 +75,6 @@ public actor NetworkProtectionLatencyMonitor {
 
     private var lastLatencyReported: Date = .distantPast
 
-    private(set) var serverIP: IPv4Address?
-
     // MARK: - Init & deinit
 
     init() {
@@ -93,8 +91,6 @@ public actor NetworkProtectionLatencyMonitor {
 
     public func start(serverIP: IPv4Address, callback: @escaping (Result) -> Void) {
         os_log("⚫️ Starting latency monitor", log: .networkProtectionLatencyMonitorLog)
-
-        self.serverIP = serverIP
 
         latencyCancellable = latencySubject.eraseToAnyPublisher()
             .receive(on: DispatchQueue.main)
@@ -141,7 +137,7 @@ public actor NetworkProtectionLatencyMonitor {
     // MARK: - Latency monitor
 
     private func measureLatency(to ip: IPv4Address) async {
-        os_log("⚫️ Pinging %{public}s", log: .networkProtectionLatencyMonitorLog, type: .debug, serverIP.debugDescription)
+        os_log("⚫️ Pinging %{public}s", log: .networkProtectionLatencyMonitorLog, type: .debug, ip.debugDescription)
 
         let result = await Pinger(ip: ip, timeout: Self.pingTimeout, log: .networkProtectionLatencyMonitorLog).ping()
 

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionTunnelFailureMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionTunnelFailureMonitor.swift
@@ -77,7 +77,7 @@ public actor NetworkProtectionTunnelFailureMonitor {
 
     @MainActor
     func start(callback: @escaping (Result) -> Void) {
-        os_log("⚫️ Starting tunnel failure monitor", log: .networkProtectionPixel)
+        os_log("⚫️ Starting tunnel failure monitor", log: .networkProtectionTunnelFailureMonitorLog)
 
         failureReported = false
 
@@ -88,7 +88,7 @@ public actor NetworkProtectionTunnelFailureMonitor {
 
     @MainActor
     func stop() {
-        os_log("⚫️ Stopping tunnel failure monitor", log: .networkProtectionPixel)
+        os_log("⚫️ Stopping tunnel failure monitor", log: .networkProtectionTunnelFailureMonitorLog)
 
         task = nil
     }
@@ -100,11 +100,11 @@ public actor NetworkProtectionTunnelFailureMonitor {
         let mostRecentHandshake = await tunnelProvider.mostRecentHandshake() ?? 0
 
         let difference = Date().timeIntervalSince1970 - mostRecentHandshake
-        os_log("⚫️ Last handshake: %{public}f seconds ago", log: .networkProtectionPixel, type: .debug, difference)
+        os_log("⚫️ Last handshake: %{public}f seconds ago", log: .networkProtectionTunnelFailureMonitorLog, type: .debug, difference)
 
         if difference > Result.failureDetected.threshold, isConnected {
             if failureReported {
-                os_log("⚫️ Tunnel failure already reported", log: .networkProtectionPixel, type: .debug)
+                os_log("⚫️ Tunnel failure already reported", log: .networkProtectionTunnelFailureMonitorLog, type: .debug)
             } else {
                 callback(.failureDetected)
                 failureReported = true

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionTunnelFailureMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionTunnelFailureMonitor.swift
@@ -39,14 +39,12 @@ public actor NetworkProtectionTunnelFailureMonitor {
 
     private static let monitoringInterval: TimeInterval = .seconds(10)
 
-    @MainActor
     private var task: Task<Never, Error>? {
         willSet {
             task?.cancel()
         }
     }
 
-    @MainActor
     var isStarted: Bool {
         task?.isCancelled == false
     }
@@ -54,7 +52,6 @@ public actor NetworkProtectionTunnelFailureMonitor {
     private let tunnelProvider: PacketTunnelProvider
     private let networkMonitor = NWPathMonitor()
 
-    @MainActor
     private var failureReported = false
 
     // MARK: - Init & deinit
@@ -75,7 +72,6 @@ public actor NetworkProtectionTunnelFailureMonitor {
 
     // MARK: - Start/Stop monitoring
 
-    @MainActor
     func start(callback: @escaping (Result) -> Void) {
         os_log("⚫️ Starting tunnel failure monitor", log: .networkProtectionTunnelFailureMonitorLog)
 
@@ -86,7 +82,6 @@ public actor NetworkProtectionTunnelFailureMonitor {
         }
     }
 
-    @MainActor
     func stop() {
         os_log("⚫️ Stopping tunnel failure monitor", log: .networkProtectionTunnelFailureMonitorLog)
 
@@ -95,7 +90,6 @@ public actor NetworkProtectionTunnelFailureMonitor {
 
     // MARK: - Handshake monitor
 
-    @MainActor
     private func monitorHandshakes(callback: @escaping (Result) -> Void) async {
         let mostRecentHandshake = await tunnelProvider.mostRecentHandshake() ?? 0
 
@@ -115,7 +109,6 @@ public actor NetworkProtectionTunnelFailureMonitor {
         }
     }
 
-    @MainActor
     private var isConnected: Bool {
         let path = networkMonitor.currentPath
         let connectionType = NetworkConnectionType(nwPath: path)

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionTunnelFailureMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionTunnelFailureMonitor.swift
@@ -49,7 +49,7 @@ public actor NetworkProtectionTunnelFailureMonitor {
         task?.isCancelled == false
     }
 
-    private let tunnelProvider: PacketTunnelProvider
+    private weak var tunnelProvider: PacketTunnelProvider?
     private let networkMonitor = NWPathMonitor()
 
     private var failureReported = false
@@ -91,7 +91,7 @@ public actor NetworkProtectionTunnelFailureMonitor {
     // MARK: - Handshake monitor
 
     private func monitorHandshakes(callback: @escaping (Result) -> Void) async {
-        let mostRecentHandshake = await tunnelProvider.mostRecentHandshake() ?? 0
+        let mostRecentHandshake = await tunnelProvider?.mostRecentHandshake() ?? 0
 
         let difference = Date().timeIntervalSince1970 - mostRecentHandshake
         os_log("⚫️ Last handshake: %{public}f seconds ago", log: .networkProtectionTunnelFailureMonitorLog, type: .debug, difference)

--- a/Sources/NetworkProtection/Logging/Logging.swift
+++ b/Sources/NetworkProtection/Logging/Logging.swift
@@ -29,6 +29,14 @@ extension OSLog {
         Logging.networkProtectionBandwidthAnalysisLoggingEnabled ? Logging.networkProtectionBandwidthAnalysis : .disabled
     }
 
+    public static var networkProtectionLatencyMonitorLog: OSLog {
+        Logging.networkProtectionLatencyMonitorLoggingEnabled ? Logging.networkProtectionLatencyMonitor : .disabled
+    }
+    
+    public static var networkProtectionTunnelFailureMonitorLog: OSLog {
+        Logging.networkProtectionTunnelFailureMonitorLoggingEnabled ? Logging.networkProtectionTunnelFailureMonitor : .disabled
+    }
+
     public static var networkProtectionConnectionTesterLog: OSLog {
         Logging.networkProtectionConnectionTesterLoggingEnabled ? Logging.networkProtectionConnectionTesterLog : .disabled
     }
@@ -72,6 +80,12 @@ struct Logging {
 
     fileprivate static let networkProtectionBandwidthAnalysisLoggingEnabled = true
     fileprivate static let networkProtectionBandwidthAnalysis: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Bandwidth Analysis")
+    
+    fileprivate static let networkProtectionLatencyMonitorLoggingEnabled = true
+    fileprivate static let networkProtectionLatencyMonitor: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Latency Monitor")
+
+    fileprivate static let networkProtectionTunnelFailureMonitorLoggingEnabled = true
+    fileprivate static let networkProtectionTunnelFailureMonitor: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Tunnel Failure Monitor")
 
     fileprivate static let networkProtectionConnectionTesterLoggingEnabled = true
     fileprivate static let networkProtectionConnectionTesterLog: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Connection Tester")

--- a/Sources/NetworkProtection/Logging/Logging.swift
+++ b/Sources/NetworkProtection/Logging/Logging.swift
@@ -32,7 +32,7 @@ extension OSLog {
     public static var networkProtectionLatencyMonitorLog: OSLog {
         Logging.networkProtectionLatencyMonitorLoggingEnabled ? Logging.networkProtectionLatencyMonitor : .disabled
     }
-    
+
     public static var networkProtectionTunnelFailureMonitorLog: OSLog {
         Logging.networkProtectionTunnelFailureMonitorLoggingEnabled ? Logging.networkProtectionTunnelFailureMonitor : .disabled
     }
@@ -80,7 +80,7 @@ struct Logging {
 
     fileprivate static let networkProtectionBandwidthAnalysisLoggingEnabled = true
     fileprivate static let networkProtectionBandwidthAnalysis: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Bandwidth Analysis")
-    
+
     fileprivate static let networkProtectionLatencyMonitorLoggingEnabled = true
     fileprivate static let networkProtectionLatencyMonitor: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Latency Monitor")
 

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1041,9 +1041,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             return
         }
         if await latencyMonitor.isStarted {
-            if await latencyMonitor.serverIP == ip {
-                return
-            }
             await latencyMonitor.stop()
         }
 

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1025,31 +1025,29 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     // MARK: - Monitors
 
-    @MainActor
-    private func startTunnelFailureMonitor() {
-        if tunnelFailureMonitor.isStarted {
-            tunnelFailureMonitor.stop()
+    private func startTunnelFailureMonitor() async {
+        if await tunnelFailureMonitor.isStarted {
+            await tunnelFailureMonitor.stop()
         }
 
-        tunnelFailureMonitor.start { [weak self] result in
+        await tunnelFailureMonitor.start { [weak self] result in
             self?.providerEvents.fire(.reportTunnelFailure(result: result))
         }
     }
 
-    @MainActor
-    private func startLatencyMonitor() {
+    private func startLatencyMonitor() async {
         guard let ip = lastSelectedServerInfo?.ipv4 else {
-            latencyMonitor.stop()
+            await latencyMonitor.stop()
             return
         }
-        if latencyMonitor.isStarted {
-            if latencyMonitor.serverIP == ip {
+        if await latencyMonitor.isStarted {
+            if await latencyMonitor.serverIP == ip {
                 return
             }
-            latencyMonitor.stop()
+            await latencyMonitor.stop()
         }
 
-        latencyMonitor.start(serverIP: ip) { [weak self] result in
+        await latencyMonitor.start(serverIP: ip) { [weak self] result in
             switch result {
             case .error:
                 self?.providerEvents.fire(.reportLatency(result: .error))

--- a/Tests/NetworkProtectionTests/NetworkProtectionLatencyMonitorTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionLatencyMonitorTests.swift
@@ -27,30 +27,16 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        monitor = NetworkProtectionLatencyMonitor(serverIP: { nil }, log: .disabled)
+        monitor = NetworkProtectionLatencyMonitor()
     }
 
     override func tearDown() async throws {
         await monitor?.stop()
     }
 
-    func testInvalidIP() async {
-        let expectation = XCTestExpectation(description: "Invalid IP reported")
-        await monitor?.start { result in
-            switch result {
-            case .error:
-                expectation.fulfill()
-            case .quality:
-                break
-            }
-        }
-        await monitor?.measureLatency()
-        await fulfillment(of: [expectation], timeout: 1)
-    }
-
     func testPingFailure() async {
         let expectation = XCTestExpectation(description: "Ping failure reported")
-        await monitor?.start { result in
+        await monitor?.start(serverIP: .init("127.0.0.1")!) { result in
             switch result {
             case .error:
                 expectation.fulfill()
@@ -76,10 +62,10 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
     }
 
     private func testConnectionLatency(_ timeInterval: TimeInterval, expecting expectedQuality: NetworkProtectionLatencyMonitor.ConnectionQuality) async {
-        let monitor = NetworkProtectionLatencyMonitor(serverIP: { .init("127.0.0.1") }, log: .disabled)
+        let monitor = NetworkProtectionLatencyMonitor()
 
         var reportedQuality = NetworkProtectionLatencyMonitor.ConnectionQuality.unknown
-        await monitor.start { result in
+        await monitor.start(serverIP: .init("127.0.0.1")!) { result in
             switch result {
             case .quality(let quality):
                 reportedQuality = quality

--- a/Tests/NetworkProtectionTests/NetworkProtectionLatencyMonitorTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionLatencyMonitorTests.swift
@@ -27,9 +27,7 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        monitor = NetworkProtectionLatencyMonitor(serverIP: { nil }, log: .networkProtectionPixel)
-
-        try await monitor?.start()
+        monitor = NetworkProtectionLatencyMonitor(serverIP: { nil }, log: .disabled)
     }
 
     override func tearDown() async throws {
@@ -38,30 +36,28 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
 
     func testInvalidIP() async {
         let expectation = XCTestExpectation(description: "Invalid IP reported")
-        cancellable = monitor?.publisher
-            .sink { result in
-                switch result {
-                case .error:
-                    expectation.fulfill()
-                case .quality:
-                    break
-                }
+        await monitor?.start { result in
+            switch result {
+            case .error:
+                expectation.fulfill()
+            case .quality:
+                break
             }
+        }
         await monitor?.measureLatency()
         await fulfillment(of: [expectation], timeout: 1)
     }
 
     func testPingFailure() async {
         let expectation = XCTestExpectation(description: "Ping failure reported")
-        cancellable = monitor?.publisher
-            .sink { result in
-                switch result {
-                case .error:
-                    expectation.fulfill()
-                case .quality:
-                    break
-                }
+        await monitor?.start { result in
+            switch result {
+            case .error:
+                expectation.fulfill()
+            case .quality:
+                break
             }
+        }
         await monitor?.simulateLatency(-1)
         await fulfillment(of: [expectation], timeout: 1)
     }
@@ -80,20 +76,17 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
     }
 
     private func testConnectionLatency(_ timeInterval: TimeInterval, expecting expectedQuality: NetworkProtectionLatencyMonitor.ConnectionQuality) async {
-        let monitor = NetworkProtectionLatencyMonitor(serverIP: { .init("127.0.0.1") }, log: .networkProtectionPixel)
+        let monitor = NetworkProtectionLatencyMonitor(serverIP: { .init("127.0.0.1") }, log: .disabled)
 
         var reportedQuality = NetworkProtectionLatencyMonitor.ConnectionQuality.unknown
-        cancellable = monitor.publisher
-            .sink { result in
-                switch result {
-                case .quality(let quality):
-                    reportedQuality = quality
-                case .error:
-                    XCTFail("Unexpected result")
-                }
+        await monitor.start { result in
+            switch result {
+            case .quality(let quality):
+                reportedQuality = quality
+            case .error:
+                XCTFail("Unexpected result")
             }
-
-        try? await monitor.start()
+        }
         await monitor.simulateLatency(timeInterval)
         await monitor.stop()
 

--- a/Tests/NetworkProtectionTests/NetworkProtectionLatencyMonitorTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionLatencyMonitorTests.swift
@@ -27,7 +27,7 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        monitor = NetworkProtectionLatencyMonitor(serverIP: { nil }, timerQueue: DispatchQueue.main, log: .networkProtectionPixel)
+        monitor = NetworkProtectionLatencyMonitor(serverIP: { nil }, log: .networkProtectionPixel)
 
         try await monitor?.start()
     }
@@ -62,7 +62,7 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
                     break
                 }
             }
-        monitor?.simulateLatency(-1)
+        await monitor?.simulateLatency(-1)
         await fulfillment(of: [expectation], timeout: 1)
     }
 
@@ -80,7 +80,7 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
     }
 
     private func testConnectionLatency(_ timeInterval: TimeInterval, expecting expectedQuality: NetworkProtectionLatencyMonitor.ConnectionQuality) async {
-        let monitor = NetworkProtectionLatencyMonitor(serverIP: { nil }, timerQueue: DispatchQueue.main, log: .networkProtectionPixel)
+        let monitor = NetworkProtectionLatencyMonitor(serverIP: { .init("127.0.0.1") }, log: .networkProtectionPixel)
 
         var reportedQuality = NetworkProtectionLatencyMonitor.ConnectionQuality.unknown
         cancellable = monitor.publisher
@@ -94,7 +94,7 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
             }
 
         try? await monitor.start()
-        monitor.simulateLatency(timeInterval)
+        await monitor.simulateLatency(timeInterval)
         await monitor.stop()
 
         XCTAssertEqual(expectedQuality, reportedQuality)

--- a/Tests/NetworkProtectionTests/NetworkProtectionLatencyMonitorTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionLatencyMonitorTests.swift
@@ -69,13 +69,12 @@ final class NetworkProtectionLatencyMonitorTests: XCTestCase {
             switch result {
             case .quality(let quality):
                 reportedQuality = quality
+                XCTAssertEqual(expectedQuality, reportedQuality)
             case .error:
                 XCTFail("Unexpected result")
             }
         }
         await monitor.simulateLatency(timeInterval)
         await monitor.stop()
-
-        XCTAssertEqual(expectedQuality, reportedQuality)
     }
 }


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206209663744590/f and https://app.asana.com/0/0/1206212872939262/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2290
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2005
What kind of version bump will this require?: Patch

**Description**:

Updates the monitor implementation to use Task to address situations when timer is launched multiple times. This affects macOS where it may have caused pixel anomalies due.

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
