### PR TITLE
Require full IPv4 address string to be treated as valid URL

### DIFF
--- a/Sources/Common/Extensions/URLExtension.swift
+++ b/Sources/Common/Extensions/URLExtension.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import Network
 
 extension URL {
 
@@ -192,6 +193,12 @@ extension URL {
                 guard hostname.contains(".") || String(hostname) == .localhost else {
                     // could be a local domain but user needs to use the protocol to specify that
                     return nil
+                }
+                if IPv4Address(String(hostname)) != nil {
+                    // Require 4 octets specified explicitly for an IPv4 address (avoid 1.4 -> 1.0.0.4 expansion)
+                    guard hostname.split(separator: ".").count == 4 else {
+                        return nil
+                    }
                 }
             } else {
                 return nil

--- a/Tests/CommonTests/Extensions/URLExtensionTests.swift
+++ b/Tests/CommonTests/Extensions/URLExtensionTests.swift
@@ -89,6 +89,16 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertNil("localdomain".url)
     }
 
+    func testThatIPv4AddressMustContainFourOctets() {
+        XCTAssertNil("1.4".url)
+        XCTAssertNil("1.4/3.4".url)
+        XCTAssertNil("1.0.4".url)
+        XCTAssertNil("127.0.1".url)
+
+        XCTAssertEqual("127.0.0.1".url?.absoluteString, "http://127.0.0.1")
+        XCTAssertEqual("1.0.0.4/3.4".url?.absoluteString, "http://1.0.0.4/3.4")
+    }
+
     func testWhenNakedIsCalled_ThenURLWithNoSchemeWWWPrefixAndLastSlashIsReturned() {
         let url = URL(string: "http://duckduckgo.com")!
         let duplicate = URL(string: "https://www.duckduckgo.com/")!


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206262563462715/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2298
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2012
What kind of version bump will this require?: Patch

**Description**:
When an IPv4-like string is passed to URL constructor, require that it contains 4 octets and otherwise return nil.
This allows clients to fall back to treating the string as search query and constructing search URLs, instead
of making most likely unwanted navigation to an IP address where missing octets are filled with zeros
(e.g. 1.4 -> 1.0.0.4).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Input `1.4/3.4` in the search bar.
2. Verify that SERP is displayed (with calculator) and that you're not redirected to `http://1.0.0.4/3.4`.


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
