### PR TITLE
Prevents setting `showInMenuBar` without actually changing its value

### DIFF
--- a/Sources/NetworkProtection/Settings/Extensions/UserDefaults+showInMenuBar.swift
+++ b/Sources/NetworkProtection/Settings/Extensions/UserDefaults+showInMenuBar.swift
@@ -33,6 +33,10 @@ extension UserDefaults {
         }
 
         set {
+            guard newValue != networkProtectionSettingShowInMenuBar else {
+                return
+            }
+
             set(newValue, forKey: showInMenuBarKey)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206318102194993/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2317
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2043
What kind of version bump will this require?: Patch

## Description

Title has it... we just prevent triggering change notifications for `showInMenuBar` by setting its value without changing it in user defaults.

## Testing

Test using the macOS PR.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
