### PR TITLE
Update autofill to 10.0.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "5597bc17709c8acf454ecaad4f4082007986242a",
-        "version" : "10.0.2"
+        "revision" : "b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
+        "version" : "10.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .plugin(name: "SwiftLintPlugin", targets: ["SwiftLintPlugin"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "10.0.2"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "10.0.3"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.2"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206327382038432/1206327382038432
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.3


## Description
Updates Autofill to version [10.0.3](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.3).

### Autofill 10.0.3 release notes
## What's Changed
* Use the default branch when checking out repos by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/444
* Password update flows by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/453
* Bump @types/jest from 29.5.5 to 29.5.11 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/439
* Update password-related json files (2023-12-21) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/454
* Move test forms out of src by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/457
* Move integration tests around by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/455
* Fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/467
* Update password-related json files (2024-01-11) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/466


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.2...10.0.3

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).