### PR TITLE
Avoid sending latency immediately after the monitor starts

### DIFF
--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionLatencyMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionLatencyMonitor.swift
@@ -92,6 +92,8 @@ public actor NetworkProtectionLatencyMonitor {
     public func start(serverIP: IPv4Address, callback: @escaping (Result) -> Void) {
         os_log("⚫️ Starting latency monitor", log: .networkProtectionLatencyMonitorLog)
 
+        lastLatencyReported = Date()
+
         latencyCancellable = latencySubject.eraseToAnyPublisher()
             .receive(on: DispatchQueue.main)
             .scan(ExponentialGeometricAverage()) { measurements, latency in


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206412872188595/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2368
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2103
What kind of version bump will this require?: Patch

**Description**:

This PR fixes a bug in the latency monitor. See parent task for more info.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check out this branch and set it up in each of the client apps, but put an extra log in `NetworkProtectionLatencyMonitor` line 117 to print when the app is reporting latency back
2. Change the `let reportThreshold: TimeInterval` line to use 1 minute instead of 10 minutes
1. Run NetP and check that the app does **not** report latency immediately
2. Wait 1 minute
3. Check that you get a log that latency has been reported

If you want to test this behaviour before, simply comment out line 95 and test again - you will see that the app is sending its very first measurement as a pixel, instead of collecting an average.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
