### PR TITLE
Display different copy in alerts when a flag is enabled in a newer version

### DIFF
--- a/Sources/DDGSync/SyncFeatureFlags.swift
+++ b/Sources/DDGSync/SyncFeatureFlags.swift
@@ -24,6 +24,7 @@ import Foundation
  */
 public struct SyncFeatureFlags: OptionSet {
     public let rawValue: Int
+    public var unavailableReason: PrivacyConfigurationFeatureDisabledReason?
 
     public init(rawValue: Int) {
         self.rawValue = rawValue
@@ -68,20 +69,43 @@ public struct SyncFeatureFlags: OptionSet {
     // MARK: -
 
     init(privacyConfig: PrivacyConfiguration) {
-        guard privacyConfig.isEnabled(featureKey: .sync) else {
+        var offFlag: SyncSubfeature?
+        let syncState = privacyConfig.stateFor(featureKey: .sync)
+        switch syncState {
+
+        case .enabled:
+            if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level0ShowSync) {
+                offFlag = .level0ShowSync
+                self = .unavailable
+            } else if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level1AllowDataSyncing) {
+                offFlag = .level1AllowDataSyncing
+                self = .level0ShowSync
+            } else if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level2AllowSetupFlows) {
+                offFlag = .level2AllowSetupFlows
+                self = .level1AllowDataSyncing
+            } else if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level3AllowCreateAccount) {
+                offFlag = SyncSubfeature.level3AllowCreateAccount
+                self = .level2AllowSetupFlows
+            } else {
+                self = .level3AllowCreateAccount
+            }
+        case .disabled(let reason):
+            if reason == .appVersionNotSupported {
+                unavailableReason = reason
+            }
             self = .unavailable
-            return
         }
-        if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level0ShowSync) {
-            self = .unavailable
-        } else if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level1AllowDataSyncing) {
-            self = .level0ShowSync
-        } else if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level2AllowSetupFlows) {
-            self = .level1AllowDataSyncing
-        } else if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level3AllowCreateAccount) {
-            self = .level2AllowSetupFlows
-        } else {
-            self = .level3AllowCreateAccount
+
+        if let offFlag {
+            let state = privacyConfig.stateFor(offFlag)
+            switch state {
+            case .enabled:
+                break
+            case .disabled(let reason):
+                if reason == .appVersionNotSupported {
+                    unavailableReason = reason
+                }
+            }
         }
     }
 }

--- a/Sources/DDGSync/SyncFeatureFlags.swift
+++ b/Sources/DDGSync/SyncFeatureFlags.swift
@@ -90,9 +90,7 @@ public struct SyncFeatureFlags: OptionSet {
                 self = .level3AllowCreateAccount
             }
         case .disabled(let reason):
-            if reason == .appVersionNotSupported {
-                unavailableReason = reason
-            }
+            unavailableReason = reason
             self = .unavailable
         }
 
@@ -102,9 +100,7 @@ public struct SyncFeatureFlags: OptionSet {
             case .enabled:
                 break
             case .disabled(let reason):
-                if reason == .appVersionNotSupported {
-                    unavailableReason = reason
-                }
+                unavailableReason = reason
             }
         }
     }

--- a/Sources/DDGSync/SyncFeatureFlags.swift
+++ b/Sources/DDGSync/SyncFeatureFlags.swift
@@ -24,7 +24,7 @@ import Foundation
  */
 public struct SyncFeatureFlags: OptionSet {
     public let rawValue: Int
-    public var unavailableReason: PrivacyConfigurationFeatureDisabledReason?
+    public private(set) var unavailableReason: PrivacyConfigurationFeatureDisabledReason?
 
     public init(rawValue: Int) {
         self.rawValue = rawValue
@@ -69,22 +69,22 @@ public struct SyncFeatureFlags: OptionSet {
     // MARK: -
 
     init(privacyConfig: PrivacyConfiguration) {
-        var offFlag: SyncSubfeature?
+        var disabledSubfeature: SyncSubfeature?
         let syncState = privacyConfig.stateFor(featureKey: .sync)
         switch syncState {
 
         case .enabled:
             if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level0ShowSync) {
-                offFlag = .level0ShowSync
+                disabledSubfeature = .level0ShowSync
                 self = .unavailable
             } else if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level1AllowDataSyncing) {
-                offFlag = .level1AllowDataSyncing
+                disabledSubfeature = .level1AllowDataSyncing
                 self = .level0ShowSync
             } else if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level2AllowSetupFlows) {
-                offFlag = .level2AllowSetupFlows
+                disabledSubfeature = .level2AllowSetupFlows
                 self = .level1AllowDataSyncing
             } else if !privacyConfig.isSubfeatureEnabled(SyncSubfeature.level3AllowCreateAccount) {
-                offFlag = SyncSubfeature.level3AllowCreateAccount
+                disabledSubfeature = SyncSubfeature.level3AllowCreateAccount
                 self = .level2AllowSetupFlows
             } else {
                 self = .level3AllowCreateAccount
@@ -94,14 +94,8 @@ public struct SyncFeatureFlags: OptionSet {
             self = .unavailable
         }
 
-        if let offFlag {
-            let state = privacyConfig.stateFor(offFlag)
-            switch state {
-            case .enabled:
-                break
-            case .disabled(let reason):
-                unavailableReason = reason
-            }
+        if let disabledSubfeature, case .disabled(let reason) = privacyConfig.stateFor(disabledSubfeature) {
+            unavailableReason = reason
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/72649045549333/1206310394453442/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2374
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2114
What kind of version bump will this require?: Major/Minor/Patch

**Description**: Shows a different copy in alerts when a sync flag is enabled in a newer version and the user needs to update the app

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. in the PrivacyConfig file increase the min version for the sync feature and each subfeature one at a time.
2. In both sync the enabled and disabled sync setting version (if visible) check that the right alert is shown (asking user to upgrade)
3. Disable completely the flags one at a time,  and check and go to the sync settings and check the alert is the generic sync is unavailable one


<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
