### PR TITLE
Add explicit mapping of SyncError to error code

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "bb027f14bec7fbb1a85d308139e7a66686da160e",
-        "version" : "4.59.0"
+        "revision" : "0b68b0d404d8d4f32296cd84fa160b18b0aeaf44",
+        "version" : "4.59.1"
       }
     },
     {

--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -336,7 +336,7 @@ public class DDGSync: DDGSyncing {
         } catch {
             // swiftlint:disable:next line_length
             os_log(.error, log: dependencies.log, "Failed to delete account upon unauthenticated server response: %{public}s", error.localizedDescription)
-            if let syncError = error as? SyncError {
+            if error is SyncError {
                 throw error
             }
         }

--- a/Sources/DDGSync/SyncError.swift
+++ b/Sources/DDGSync/SyncError.swift
@@ -140,3 +140,50 @@ public enum SyncError: Error, Equatable {
         }
     }
 }
+
+extension SyncError: CustomNSError {
+
+    /**
+     * The mapping here can't be changed, or it will skew usage metrics.
+     */
+    public var errorCode: Int {
+        switch self {
+        case .noToken: return 13
+
+        case .failedToMigrate: return 14
+        case .failedToLoadAccount: return 15
+        case .failedToSetupEngine: return 16
+
+        case .failedToCreateAccountKeys: return 0
+        case .accountNotFound: return 17
+        case .accountAlreadyExists: return 18
+        case .invalidRecoveryKey: return 19
+
+        case .noFeaturesSpecified: return 20
+        case .noResponseBody: return 21
+        case .unexpectedStatusCode: return 1
+        case .unexpectedResponseBody: return 22
+        case .unableToEncodeRequestBody: return 2
+        case .unableToDecodeResponse: return 3
+        case .invalidDataInResponse: return 4
+        case .accountRemoved: return 23
+
+        case .failedToEncryptValue: return 5
+        case .failedToDecryptValue: return 6
+        case .failedToPrepareForConnect: return 7
+        case .failedToOpenSealedBox: return 8
+        case .failedToSealData: return 9
+
+        case .failedToWriteSecureStore: return 10
+        case .failedToReadSecureStore: return 11
+        case .failedToRemoveSecureStore: return 12
+
+        case .credentialsMetadataMissingBeforeFirstSync: return 24
+        case .receivedCredentialsWithoutUUID: return 25
+        case .emailProtectionUsernamePresentButTokenMissing: return 26
+        case .settingsMetadataNotPresent: return 27
+        case .unauthenticatedWhileLoggedIn: return 28
+        }
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201493110486074/1205369529923362/f
iOS PR: N/A
macOS PR: N/A
What kind of version bump will this require?: Patch
CC: @bwaresiak 

**Description**:
Map SyncError cases to error codes, preserving existing compiler-defined
mapping to ensure that our metrics aren't skewed.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Add a test like this, e.g. to DDGSyncTests.swift:
<details><summary>Expand to see the code</summary>
<p><code>
func testSyncErrorCodes() {
    print(SyncError.noToken.errorParameters[SyncError.noToken.syncErrorString]!, (SyncError.noToken as NSError).code)
    print(SyncError.failedToMigrate.errorParameters[SyncError.failedToMigrate.syncErrorString]!, (SyncError.failedToMigrate as NSError).code)
    print(SyncError.failedToLoadAccount.errorParameters[SyncError.failedToLoadAccount.syncErrorString]!, (SyncError.failedToLoadAccount as NSError).code)
    print(SyncError.failedToSetupEngine.errorParameters[SyncError.failedToSetupEngine.syncErrorString]!, (SyncError.failedToSetupEngine as NSError).code)
    print(SyncError.failedToCreateAccountKeys("").errorParameters[SyncError.failedToCreateAccountKeys("").syncErrorString]!, (SyncError.failedToCreateAccountKeys("") as NSError).code)
    print(SyncError.accountNotFound.errorParameters[SyncError.accountNotFound.syncErrorString]!, (SyncError.accountNotFound as NSError).code)
    print(SyncError.accountAlreadyExists.errorParameters[SyncError.accountAlreadyExists.syncErrorString]!, (SyncError.accountAlreadyExists as NSError).code)
    print(SyncError.invalidRecoveryKey.errorParameters[SyncError.invalidRecoveryKey.syncErrorString]!, (SyncError.invalidRecoveryKey as NSError).code)
    print(SyncError.noFeaturesSpecified.errorParameters[SyncError.noFeaturesSpecified.syncErrorString]!, (SyncError.noFeaturesSpecified as NSError).code)
    print(SyncError.noResponseBody.errorParameters[SyncError.noResponseBody.syncErrorString]!, (SyncError.noResponseBody as NSError).code)
    print(SyncError.unexpectedStatusCode(1).errorParameters[SyncError.unexpectedStatusCode(1).syncErrorString]!, (SyncError.unexpectedStatusCode(1) as NSError).code)
    print(SyncError.unexpectedResponseBody.errorParameters[SyncError.unexpectedResponseBody.syncErrorString]!, (SyncError.unexpectedResponseBody as NSError).code)
    print(SyncError.unableToEncodeRequestBody("").errorParameters[SyncError.unableToEncodeRequestBody("").syncErrorString]!, (SyncError.unableToEncodeRequestBody("") as NSError).code)
    print(SyncError.unableToDecodeResponse("").errorParameters[SyncError.unableToDecodeResponse("").syncErrorString]!, (SyncError.unableToDecodeResponse("") as NSError).code)
    print(SyncError.invalidDataInResponse("").errorParameters[SyncError.invalidDataInResponse("").syncErrorString]!, (SyncError.invalidDataInResponse("") as NSError).code)
    print(SyncError.accountRemoved.errorParameters[SyncError.accountRemoved.syncErrorString]!, (SyncError.accountRemoved as NSError).code)
    print(SyncError.failedToEncryptValue("").errorParameters[SyncError.failedToEncryptValue("").syncErrorString]!, (SyncError.failedToEncryptValue("") as NSError).code)
    print(SyncError.failedToDecryptValue("").errorParameters[SyncError.failedToDecryptValue("").syncErrorString]!, (SyncError.failedToDecryptValue("") as NSError).code)
    print(SyncError.failedToPrepareForConnect("").errorParameters[SyncError.failedToPrepareForConnect("").syncErrorString]!, (SyncError.failedToPrepareForConnect("") as NSError).code)
    print(SyncError.failedToOpenSealedBox("").errorParameters[SyncError.failedToOpenSealedBox("").syncErrorString]!, (SyncError.failedToOpenSealedBox("") as NSError).code)
    print(SyncError.failedToSealData("").errorParameters[SyncError.failedToSealData("").syncErrorString]!, (SyncError.failedToSealData("") as NSError).code)
    print(SyncError.failedToWriteSecureStore(status: 1).errorParameters[SyncError.failedToWriteSecureStore(status: 1).syncErrorString]!, (SyncError.failedToWriteSecureStore(status: 1) as NSError).code)
    print(SyncError.failedToReadSecureStore(status: 1).errorParameters[SyncError.failedToReadSecureStore(status: 1).syncErrorString]!, (SyncError.failedToReadSecureStore(status: 1) as NSError).code)
    print(SyncError.failedToRemoveSecureStore(status: 1).errorParameters[SyncError.failedToRemoveSecureStore(status: 1).syncErrorString]!, (SyncError.failedToRemoveSecureStore(status: 1) as NSError).code)
    print(SyncError.credentialsMetadataMissingBeforeFirstSync.errorParameters[SyncError.credentialsMetadataMissingBeforeFirstSync.syncErrorString]!, (SyncError.credentialsMetadataMissingBeforeFirstSync as NSError).code)
    print(SyncError.receivedCredentialsWithoutUUID.errorParameters[SyncError.receivedCredentialsWithoutUUID.syncErrorString]!, (SyncError.receivedCredentialsWithoutUUID as NSError).code)
    print(SyncError.settingsMetadataNotPresent.errorParameters[SyncError.settingsMetadataNotPresent.syncErrorString]!, (SyncError.settingsMetadataNotPresent as NSError).code)
    print(SyncError.unauthenticatedWhileLoggedIn.errorParameters[SyncError.unauthenticatedWhileLoggedIn.syncErrorString]!, (SyncError.unauthenticatedWhileLoggedIn as NSError).code)
}
</code></p>
</details>

2. Run the test and capture the output
3. Comment out the entire `extension SyncError: CustomNSError` in SyncError.swift
4. Run the test again and capture the output
5. Verify that the two captured outputs are the same.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
