### PR TITLE
Fix `site:` queries escaping with iOS 17 SDK (#640)

### DIFF
--- a/Sources/Common/Extensions/URLExtension.swift
+++ b/Sources/Common/Extensions/URLExtension.swift
@@ -158,10 +158,9 @@ extension URL {
             s = scheme.separated() + s.dropFirst(scheme.separated().count - 1)
         }
 
-#if os(macOS)
         let url: URL?
         let urlWithScheme: URL?
-        if #available(macOS 14.0, *) {
+        if #available(macOS 14.0, iOS 17.0, *) {
             // Making sure string is strictly valid according to the RFC
             url = URL(string: s, encodingInvalidCharacters: false)
             urlWithScheme = URL(string: NavigationalScheme.http.separated() + s, encodingInvalidCharacters: false)
@@ -169,10 +168,6 @@ extension URL {
             url = URL(string: s)
             urlWithScheme = URL(string: NavigationalScheme.http.separated() + s)
         }
-#else
-        let url = URL(string: s)
-        let urlWithScheme = URL(string: NavigationalScheme.http.separated() + s)
-#endif
 
         if let url {
             // if URL has domain:port or user:password@domain mistakengly interpreted as a scheme


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1206343150540010/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2402
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2130
What kind of version bump will this require?: Patch

**Description**:

Linking to iOS 17 SDK modifies how URLs are being parsed and escaped (see [release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes)). This change re-uses the solution done for macOS.

**Steps to test this PR**:
1. Open a new tab
2. Search for `site:drivingline.com cummins`
4. SERP with results from `drivingline.com` should appear

**OS Testing**:

* [ ] iOS 16
* [ ] iOS 17
