### PR TITLE
Add Autoconsent onByDefault subfeature

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -94,3 +94,11 @@ public enum SyncSubfeature: String, PrivacySubfeature {
     case level2AllowSetupFlows
     case level3AllowCreateAccount
 }
+
+public enum AutoconsentSubfeature: String, PrivacySubfeature {
+    public var parent: PrivacyFeature {
+        .autoconsent
+    }
+
+    case onByDefault
+}


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/1206264112133008/1206441673559117/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2373
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2137
What kind of version bump will this require?: Minor

**Description**:

Adds `onByDefault` subfeature for `autoconsent`, allowing to roll out the new default setting incrementally on iOS.

**Steps to test this PR**: 
macOS: 
No changes in existing behavior.

iOS:
See https://github.com/duckduckgo/iOS/pull/2373 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
