### PR TITLE
Add Autoconsent onByDefault subfeature

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -94,3 +94,11 @@ public enum SyncSubfeature: String, PrivacySubfeature {
     case level2AllowSetupFlows
     case level3AllowCreateAccount
 }
+
+public enum AutoconsentSubfeature: String, PrivacySubfeature {
+    public var parent: PrivacyFeature {
+        .autoconsent
+    }
+
+    case onByDefault
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206474382370291/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2423
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2140
What kind of version bump will this require?: Minor

**Description**:

Adds `onByDefault` subfeature for `autoconsent`, allowing to roll out the new default setting incrementally on iOS.

**Steps to test this PR**: 
No changes in existing behavior. Subfeature will be used in https://github.com/duckduckgo/iOS/pull/2373