### PR TITLE
Check subfeature state before reading rollout data

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -195,27 +195,24 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         let subfeatures = subfeatures(for: subfeature.parent)
         let subfeatureData = subfeatures[subfeature.rawValue]
 
-        // Handle Rollouts
-        if let rollout = subfeatureData?.rollout {
-            if !isRolloutEnabled(subfeature: subfeature, rolloutSteps: rollout.steps, randomizer: randomizer) {
-                return .disabled(.stillInRollout)
-            }
-        }
-
         let satisfiesMinVersion = satisfiesMinVersion(subfeatureData?.minSupportedVersion, versionProvider: versionProvider)
 
         switch subfeatureData?.state {
         case PrivacyConfigurationData.State.enabled:
             guard satisfiesMinVersion else { return .disabled(.appVersionNotSupported) }
-
-            return .enabled
         case PrivacyConfigurationData.State.internal:
             guard internalUserDecider.isInternalUser else { return .disabled(.limitedToInternalUsers) }
             guard satisfiesMinVersion else { return .disabled(.appVersionNotSupported) }
-
-            return .enabled
         default: return .disabled(.disabledInConfig)
         }
+
+        // Handle Rollouts
+        if let rollout = subfeatureData?.rollout,
+           !isRolloutEnabled(subfeature: subfeature, rolloutSteps: rollout.steps, randomizer: randomizer) {
+            return .disabled(.stillInRollout)
+        }
+
+        return .enabled
     }
 
     private func subfeatures(for feature: PrivacyFeature) -> PrivacyConfigurationData.PrivacyFeature.Features {

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
@@ -880,8 +880,8 @@ class AppPrivacyConfigurationTests: XCTestCase {
         let config = manager.privacyConfig
 
         clearRolloutData(feature: "autofill", subFeature: "accessCredentialManagement")
-        XCTAssertFalse(config.isSubfeatureEnabled(AutofillSubfeature.accessCredentialManagement), "Subfeature should be enabled if rollouts array is empty")
-        XCTAssertEqual(config.stateFor(AutofillSubfeature.accessCredentialManagement), .disabled(.disabledInConfig))
+        XCTAssertFalse(config.isSubfeatureEnabled(AutofillSubfeature.accessCredentialManagement, randomizer: mockRandom(in:)), "Subfeature should be disabled by state setting")
+        XCTAssertEqual(config.stateFor(AutofillSubfeature.accessCredentialManagement, randomizer: mockRandom(in:)), .disabled(.disabledInConfig))
     }
 
     func testWhenCheckingSubfeatureStateWithRolloutsAndSubfeatureDisabledWhenPreviouslyInRollout_SubfeatureShouldBeDisabled() {

--- a/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
+++ b/Tests/BrowserServicesKitTests/PrivacyConfig/AppPrivacyConfigurationTests.swift
@@ -881,7 +881,7 @@ class AppPrivacyConfigurationTests: XCTestCase {
 
         clearRolloutData(feature: "autofill", subFeature: "accessCredentialManagement")
         XCTAssertFalse(config.isSubfeatureEnabled(AutofillSubfeature.accessCredentialManagement), "Subfeature should be enabled if rollouts array is empty")
-        XCTAssertEqual(config.stateFor(AutofillSubfeature.accessCredentialManagement), .disabled(.stillInRollout))
+        XCTAssertEqual(config.stateFor(AutofillSubfeature.accessCredentialManagement), .disabled(.disabledInConfig))
     }
 
     func exampleTrackerAllowlistConfig(with state: String) -> Data {


### PR DESCRIPTION
Asana task(s): https://app.asana.com/0/414235014887631/1206494747562366/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2426
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2152

**Description:**
This fix comprises of two parts:

##### Fix subfeature state resolution logic
Rollout state is checked before the global subfeature state, resulting in reporting invalid reason for it being disabled. This rearranges the rollout check so it’s performed as the last one.

##### Fix (flaky) test
Because the test subject was given a real randomizer, it produced mixed results - in 85% of chances leaning towards an invalid value. Passing mocked randomizer makes it stable.

**Steps to test this PR:**
1. Ensure CI is green