### PR TITLE
Add NavigationPreferences CustomHeaderFields

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,7 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "7a2476ff03486d6f1c3ec5815a2c75e48a790a30"
+        "revision" : "38ee7284bac7fa12d822fcaf0677ea3969d15fb1",
+        "version" : "4.59.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "38ee7284bac7fa12d822fcaf0677ea3969d15fb1",
-        "version" : "4.59.2"
+        "revision" : "7a2476ff03486d6f1c3ec5815a2c75e48a790a30"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "3.2.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.59.2"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", revision: "7a2476ff03486d6f1c3ec5815a2c75e48a790a30"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/wireguard-apple", exact: "1.1.1"),

--- a/Package.swift
+++ b/Package.swift
@@ -178,6 +178,7 @@ let package = Package(
                 .define("_FRAME_HANDLE_ENABLED", .when(platforms: [.macOS])),
                 .define("PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED", .when(platforms: [.macOS])),
                 .define("TERMINATE_WITH_REASON_ENABLED", .when(platforms: [.macOS])),
+                .define("_WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED", .when(platforms: [.macOS])),
             ],
             plugins: [.plugin(name: "SwiftLintPlugin")]
         ),
@@ -382,6 +383,7 @@ let package = Package(
                 .define("_IS_USER_INITIATED_ENABLED", .when(platforms: [.macOS])),
                 .define("_FRAME_HANDLE_ENABLED", .when(platforms: [.macOS])),
                 .define("PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED", .when(platforms: [.macOS])),
+                .define("_WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED", .when(platforms: [.macOS])),
             ],
             plugins: [.plugin(name: "SwiftLintPlugin")]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "3.2.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", revision: "7a2476ff03486d6f1c3ec5815a2c75e48a790a30"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.59.2"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/wireguard-apple", exact: "1.1.1"),

--- a/Sources/BrowserServicesKit/ContentScopeScript/SpecialPagesUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/SpecialPagesUserScript.swift
@@ -29,7 +29,7 @@ public final class SpecialPagesUserScript: NSObject, UserScript, UserScriptMessa
     public static let context = "specialPages"
 
     // special pages messaging cannot be isolated as we'll want regular page-scripts to be able to communicate
-    public let broker = UserScriptMessageBroker(context: SpecialPagesUserScript.context, requiresRunInPageContentWorld: true )
+    public let broker = UserScriptMessageBroker(context: SpecialPagesUserScript.context, requiresRunInPageContentWorld: true)
 
     public let messageNames: [String] = [
         SpecialPagesUserScript.context

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -519,7 +519,6 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
             // regular flow: start .expected navigation
             navigation = expectedNavigation
         } else if webView.url?.isEmpty == false {
-            assert(webView.url?.navigationalScheme == .about, "session restoration happening without NavigationAction")
             navigation = Navigation(identity: NavigationIdentity(wkNavigation), responders: responders, state: .expected(nil), isCurrent: true)
             if let finishedNavigation = wkNavigation?.navigation {
                 assert(finishedNavigation.state == .finished)
@@ -527,7 +526,7 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
                 let navigationAction = NavigationAction(request: finishedNavigation.request, navigationType: finishedNavigation.navigationAction.navigationType, currentHistoryItemIdentity: nil, redirectHistory: nil, isUserInitiated: false, sourceFrame: finishedNavigation.navigationAction.sourceFrame, targetFrame: finishedNavigation.navigationAction.targetFrame, shouldDownload: false, mainFrameNavigation: navigation)
                 navigation.navigationActionReceived(navigationAction)
             } else {
-                navigation.navigationActionReceived(.sessionRestoreNavigation(webView: webView, mainFrameNavigation: navigation))
+                navigation.navigationActionReceived(.alternateHtmlLoadNavigation(webView: webView, mainFrameNavigation: navigation))
             }
             navigation.willStart()
         } else if let wkNavigation {

--- a/Sources/Navigation/Extensions/WKWebpagePreferencesExtension.swift
+++ b/Sources/Navigation/Extensions/WKWebpagePreferencesExtension.swift
@@ -30,6 +30,7 @@ extension WKWebpagePreferences {
         || self.instancesRespond(to: NSSelectorFromString(Self.customHeaderFieldsKey))
     }
 
+    /// used to add custom request headers to `WKNavigationAction` before the request is sent
     public var customHeaderFields: [CustomHeaderFields]? {
         get {
             guard Self.customHeaderFieldsSupported else { return nil }

--- a/Sources/Navigation/Extensions/WKWebpagePreferencesExtension.swift
+++ b/Sources/Navigation/Extensions/WKWebpagePreferencesExtension.swift
@@ -1,0 +1,49 @@
+//
+//  WKWebpagePreferencesExtension.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+
+extension WKWebpagePreferences {
+
+#if _WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED
+
+    private static let customHeaderFieldsKey = "customHeaderFields"
+
+    public static var customHeaderFieldsSupported: Bool {
+        self.instancesRespond(to: NSSelectorFromString("_" + Self.customHeaderFieldsKey))
+        || self.instancesRespond(to: NSSelectorFromString(Self.customHeaderFieldsKey))
+    }
+
+    public var customHeaderFields: [CustomHeaderFields]? {
+        get {
+            guard Self.customHeaderFieldsSupported else { return nil }
+            return value(forKey: Self.customHeaderFieldsKey) as? [CustomHeaderFields]
+        }
+        set {
+            guard Self.customHeaderFieldsSupported else {
+                assertionFailure("custom header fields not supported")
+                return
+            }
+            setValue(newValue as NSArray?, forKey: Self.customHeaderFieldsKey)
+        }
+    }
+
+#endif
+
+}

--- a/Sources/Navigation/NavigationAction.swift
+++ b/Sources/Navigation/NavigationAction.swift
@@ -192,6 +192,16 @@ public struct NavigationPreferences: Equatable {
 
     public static let `default` = NavigationPreferences(userAgent: nil, contentMode: .recommended, javaScriptEnabled: true)
 
+#if _WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED
+    public static var customHeadersSupported: Bool {
+        WKWebpagePreferences.customHeaderFieldsSupported
+    }
+
+    public var customHeaders: [CustomHeaderFields]?
+#else
+    public static var customHeadersSupported: Bool { false }
+#endif
+
     public init(userAgent: String?, contentMode: WKWebpagePreferences.ContentMode, javaScriptEnabled: Bool) {
         self.userAgent = userAgent
         self.contentMode = contentMode
@@ -205,6 +215,11 @@ public struct NavigationPreferences: Equatable {
         } else {
             self.javaScriptEnabledValue = true
         }
+#if _WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED
+        if Self.customHeadersSupported {
+            self.customHeaders = preferences.customHeaderFields
+        }
+#endif
     }
 
     internal func applying(to preferences: WKWebpagePreferences) -> WKWebpagePreferences {
@@ -212,6 +227,11 @@ public struct NavigationPreferences: Equatable {
         if #available(macOS 11.0, iOS 14.0, *) {
             preferences.allowsContentJavaScript = javaScriptEnabled
         }
+#if _WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED
+        if Self.customHeadersSupported, let customHeaders = customHeaders {
+            preferences.customHeaderFields = customHeaders
+        }
+#endif
         return preferences
     }
 

--- a/Sources/Navigation/NavigationAction.swift
+++ b/Sources/Navigation/NavigationAction.swift
@@ -154,6 +154,10 @@ public struct NavigationAction {
         return self.init(request: URLRequest(url: webView.url ?? .empty), navigationType: .sessionRestoration, currentHistoryItemIdentity: nil, redirectHistory: nil, isUserInitiated: false, sourceFrame: .mainFrame(for: webView), targetFrame: .mainFrame(for: webView), shouldDownload: false, mainFrameNavigation: mainFrameNavigation)
     }
 
+    internal static func alternateHtmlLoadNavigation(webView: WKWebView, mainFrameNavigation: Navigation?) -> Self {
+        return self.init(request: URLRequest(url: webView.url ?? .empty), navigationType: .alternateHtmlLoad, currentHistoryItemIdentity: nil, redirectHistory: nil, isUserInitiated: false, sourceFrame: .mainFrame(for: webView), targetFrame: .mainFrame(for: webView), shouldDownload: false, mainFrameNavigation: mainFrameNavigation)
+    }
+
 }
 
 public extension NavigationAction {

--- a/Sources/Navigation/NavigationType.swift
+++ b/Sources/Navigation/NavigationType.swift
@@ -39,6 +39,7 @@ public enum NavigationType: Equatable {
 
     case redirect(RedirectType)
     case sessionRestoration
+    case alternateHtmlLoad
     case sameDocumentNavigation
 
     case other
@@ -186,6 +187,7 @@ extension NavigationType: CustomDebugStringConvertible {
         case .reload: return "reload"
         case .formResubmitted: return "formResubmitted"
         case .sessionRestoration: return "sessionRestoration"
+        case .alternateHtmlLoad: return "alternateHtmlLoad"
         case .other: return "other"
         case .redirect(let redirect):
             return "redirect(\(redirect))"

--- a/Sources/Navigation/WKCustomHeaderFields.swift
+++ b/Sources/Navigation/WKCustomHeaderFields.swift
@@ -19,6 +19,27 @@
 import Foundation
 
 #if _WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED
+/// `_WKCustomHeaderFields` class bridge to use from Swift context
+/// used to add custom request headers to `WKNavigationAction` before the request is sent
+///
+/// Usage within the Navigation framework in `decidePolicy(for: NavigationAction, preferences: inout NavigationPreferences)`
+/// ```
+/// if NavigationPreferences.customHeadersSupported,
+///    let customHeaders = CustomHeaderFields(fields: ["X-Key": "Value"]) {
+///     preferences.customHeaders = [customHeaders]
+/// }
+/// ```
+///
+/// Direct WebKit Usage in `decidePolicy(for: WKNavigationAction, preferences: WKWebpagePreferences)`
+///  ```
+///  if WKWebpagePreferences.customHeaderFieldsSupported,
+///     let customHeaders = CustomHeaderFields(fields: ["X-Key": "Value"]) {
+///      preferences.customHeaderFields = [customHeaders]
+///  }
+///  ```
+///
+///  - Note: Obj-C bridging is used to make this data-storage struct implicitly converted into `_WKCustomHeaderFields` 
+///  when passed to the WK Obj-C layer hiding the `NSClassFromString`-backed object allocation and and setting values by key
 public struct CustomHeaderFields: _ObjectiveCBridgeable, Hashable {
 
     public var fields: [String: String]

--- a/Sources/Navigation/WKCustomHeaderFields.swift
+++ b/Sources/Navigation/WKCustomHeaderFields.swift
@@ -1,0 +1,94 @@
+//
+//  WKCustomHeaderFields.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+#if _WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED
+public struct CustomHeaderFields: _ObjectiveCBridgeable, Hashable {
+
+    public var fields: [String: String]
+    public var thirdPartyDomains: [String]
+
+    public init?(fields: [String: String] = [:], thirdPartyDomains: [String] = []) {
+        guard Self.objcClass != nil else { return nil }
+        self.fields = fields
+        self.thirdPartyDomains = thirdPartyDomains
+    }
+
+    private static let className = "WKCustomHeaderFields"
+    private static let objcClass: AnyClass! = NSClassFromString("_" + Self.className) ?? NSClassFromString(Self.className)
+    private static let fieldsKey = "fields"
+    private static let thirdPartyDomainsKey = "thirdPartyDomains"
+
+    // swiftlint:disable identifier_name
+
+    public func _bridgeToObjectiveC() -> AnyObject {
+        let obj = Self.objcClass.alloc().perform(#selector(NSObject.init)).takeUnretainedValue()
+        if obj.responds(to: NSSelectorFromString(Self.fieldsKey)) {
+            obj.setValue(fields, forKey: Self.fieldsKey)
+        } else {
+            assertionFailure("\(Self.className) does not respond to \(Self.fieldsKey)")
+        }
+        if obj.responds(to: NSSelectorFromString(Self.thirdPartyDomainsKey)) {
+            obj.setValue(thirdPartyDomains, forKey: Self.thirdPartyDomainsKey)
+        } else {
+            assertionFailure("\(Self.className) does not respond to \(Self.thirdPartyDomainsKey)")
+        }
+
+        return obj
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(_ source: AnyObject, result output: inout CustomHeaderFields?) -> Bool {
+        guard source.responds(to: #selector(NSObject.className)),
+              source.className == "_" + Self.className || source.className == Self.className,
+              var result = CustomHeaderFields() else { return false }
+
+        if source.responds(to: NSSelectorFromString(Self.fieldsKey)),
+            let fields = source.value(forKey: Self.fieldsKey) as? [String: String] {
+
+            result.fields = fields
+        } else {
+            assertionFailure("\(Self.className) does not respond to \(Self.fieldsKey)")
+        }
+
+        if source.responds(to: NSSelectorFromString(Self.thirdPartyDomainsKey)),
+           let thirdPartyDomains = source.value(forKey: Self.thirdPartyDomainsKey) as? [String] {
+
+            result.thirdPartyDomains = thirdPartyDomains
+        } else {
+            assertionFailure("\(Self.className) does not respond to \(Self.thirdPartyDomainsKey)")
+        }
+
+        output = result
+        return true
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ source: AnyObject, result: inout CustomHeaderFields?) {
+        _=_conditionallyBridgeFromObjectiveC(source, result: &result)
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: AnyObject?) -> CustomHeaderFields {
+        var result: CustomHeaderFields!
+        _=_conditionallyBridgeFromObjectiveC(source!, result: &result)
+        return result
+    }
+
+    // swiftlint:enable identifier_name
+
+}
+#endif

--- a/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
+++ b/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
@@ -1716,7 +1716,7 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         waitForExpectations(timeout: 5)
 
         assertHistory(ofResponderAt: 0, equalsTo: [
-            .navigationAction(req(urls.local1), .other, src: main()),
+            .navigationAction(req(urls.local1), .other, src: main(responderIdx: 0)),
             .willStart(Nav(action: navAct(1), .approved, isCurrent: false)),
             .didStart(Nav(action: navAct(1), .started)),
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local1, data.html.count, headers: .default + ["Content-Type": "text/html"]))),

--- a/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
+++ b/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
@@ -32,6 +32,53 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
 
     // MARK: - Basic Responder Chain
 
+#if _WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED
+    func testWhenCustomHeadersAreSet_headersAreSent() throws {
+        var shouldAddHeaders = true
+        let headers = ["x-custom-header": "val", "x-another-header": "test"]
+        navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
+        responder(at: 0).onNavigationAction = { _, preferences in
+            if shouldAddHeaders {
+                preferences.customHeaders = [CustomHeaderFields(fields: headers)!]
+            }
+            return .allow
+        }
+        var eDidFinish = expectation(description: "onDidFinish")
+        responder(at: 0).onDidFinish = { nav in
+            eDidFinish.fulfill()
+        }
+
+        var eDidReceiveRequest = expectation(description: "request received")
+        server.middleware = [{ [data] request in
+            eDidReceiveRequest.fulfill()
+            if shouldAddHeaders {
+                XCTAssertEqual(request.headers.filter { headers[$0.key] != nil }, headers)
+            } else {
+                XCTAssertEqual(request.headers.filter { headers[$0.key] != nil }, [:])
+            }
+
+            return .ok(.data(data.html))
+        }]
+
+        // regular navigation from an empty state
+        try server.start(8084)
+        withWebView { webView in
+            _=webView.load(req(urls.local))
+        }
+        waitForExpectations(timeout: 5)
+
+        // send again without headers
+        shouldAddHeaders = false
+        eDidFinish = expectation(description: "onDidFinish 2")
+        eDidReceiveRequest = expectation(description: "request received 2")
+        withWebView { webView in
+            _=webView.load(req(urls.local))
+        }
+        waitForExpectations(timeout: 5)
+
+    }
+#endif
+
     func testWhenNavigationFinished_didFinishIsCalled() throws {
         navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
 

--- a/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
+++ b/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
@@ -412,6 +412,7 @@ extension DistributedNavigationDelegateTestsBase {
             guard event1 != nil || event2 != nil else { continue }
             if let diff = compare(Mirror(reflecting: event1 ?? event2!).children.first!.label!, event1, event2) {
                 printEncoded(responder: responderIdx)
+                let diff2 = compare(Mirror(reflecting: event1 ?? event2!).children.first!.label!, event1, event2)
                 XCTFail("\n#\(idx): " + diff, file: file, line: line)
             }
         }

--- a/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
+++ b/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
@@ -367,8 +367,11 @@ extension DistributedNavigationDelegateTestsBase {
 
     // MARK: FrameInfo mocking
 
-    func main(webView webViewArg: WKWebView? = nil, _ current: URL = .empty, secOrigin: SecurityOrigin? = nil) -> FrameInfo {
-        withWebView { webView in
+    func main(webView webViewArg: WKWebView? = nil, _ current: URL = .empty, secOrigin: SecurityOrigin? = nil, responderIdx: Int? = nil) -> FrameInfo {
+        if let responderIdx, let mainFrame = responder(at: responderIdx).mainFrame {
+            return mainFrame
+        }
+        return withWebView { webView in
             FrameInfo(webView: webViewArg ?? webView, handle: webViewArg?.mainFrameHandle ?? webView.mainFrameHandle, isMainFrame: true, url: current, securityOrigin: secOrigin ?? current.securityOrigin)
         }
     }
@@ -387,6 +390,7 @@ extension DistributedNavigationDelegateTestsBase {
         let lhs = responder(at: responderIdx).history
         var rhs = rhs
         var lastEventLine = line
+        let rhsMap = rhs.enumerated().reduce(into: [Int: TestsNavigationEvent]()) { $0[$1.offset] = $1.element }
         for idx in 0..<max(lhs.count, rhs.count) {
             let event1 = lhs.indices.contains(idx) ? lhs[idx] : nil
             var idx2: Int! = (event1 != nil ? rhs.firstIndex(where: { event2 in compare("", event1, event2) == nil }) : nil)
@@ -394,6 +398,9 @@ extension DistributedNavigationDelegateTestsBase {
                 // events are equal
                 rhs.remove(at: idx2)
                 continue
+            } else if let originalEvent2 = rhsMap[idx], originalEvent2.type == event1?.type,
+                      let idx = rhs.firstIndex(where: { event2 in compare("", originalEvent2, event2) == nil }) {
+                idx2 = idx
             } else {
                 idx2 = idx
             }

--- a/Tests/NavigationTests/Helpers/NavigationResponderMock.swift
+++ b/Tests/NavigationTests/Helpers/NavigationResponderMock.swift
@@ -85,6 +85,15 @@ enum TestsNavigationEvent: TestComparable {
         Mirror(reflecting: Mirror(reflecting: self).children.first!.value).children.first(where: { $0.label == "line" })?.value as! UInt
     }
 
+    var type: String {
+        let descr = String(describing: self)
+        if let idx = descr.range(of: ".")?.lowerBound {
+            return String(descr[..<idx])
+        } else {
+            return descr
+        }
+    }
+
     static func difference(between lhs: TestsNavigationEvent, and rhs: TestsNavigationEvent) -> String? {
         let caseMirror1 = Mirror(reflecting: lhs).children.first!
         let caseMirror2 = Mirror(reflecting: rhs).children.first!
@@ -174,6 +183,18 @@ class NavigationResponderMock: NavigationResponder {
         fatalError("not handled: \($0)")
     }
     var defaultHandler: ((TestsNavigationEvent) -> Void)
+
+    var mainFrame: FrameInfo? {
+        for event in history {
+            if case .navigationAction(let navAction, _, _) = event,
+               // sometimes main frame id is 2
+               [4, 2].contains(navAction.navigationAction.sourceFrame.handle.frameID) {
+
+                return navAction.navigationAction.sourceFrame
+            }
+        }
+        return nil
+    }
 
     init(defaultHandler: @escaping ((TestsNavigationEvent) -> Void) = NavigationResponderMock.defaultHandler) {
         self.defaultHandler = defaultHandler

--- a/Tests/NavigationTests/Helpers/NavigationTestHelpers.swift
+++ b/Tests/NavigationTests/Helpers/NavigationTestHelpers.swift
@@ -754,6 +754,8 @@ extension NavigationType {
             return ".other"
         case .custom(let name):
             return "<##custom: \(name.rawValue)>"
+        case .alternateHtmlLoad:
+            return ".alternateHtmlLoad"
         }
     }
 }

--- a/Tests/NavigationTests/Helpers/NavigationTestHelpers.swift
+++ b/Tests/NavigationTests/Helpers/NavigationTestHelpers.swift
@@ -554,7 +554,7 @@ extension FrameInfo: TestComparable {
     }
 }
 
-extension NavigationPreferences {
+extension NavigationPreferences: TestComparable {
     enum JSDisabled {
         case jsDisabled
     }
@@ -566,6 +566,19 @@ extension NavigationPreferences {
             return nil
         }
         return ".init(\(userAgent ?? "")\(contentMode == .recommended ? "" : ((userAgent == nil ? "" : ",") + (contentMode == .mobile ? ":mobile" : "desktop")))\(javaScriptEnabled == false ? ((userAgent != nil || contentMode != .recommended ? "," : "") + ".jsDisabled") : ""))"
+    }
+
+    static func difference(between lhs: NavigationPreferences, and rhs: NavigationPreferences) -> String? {
+        if let diff = compare("userAgent", lhs.userAgent, rhs.userAgent)
+            ?? compare("contentMode", lhs.contentMode, rhs.contentMode)
+            ?? compare("javaScriptEnabled", lhs.javaScriptEnabled, rhs.javaScriptEnabled) {
+            return diff
+        }
+#if _WEBPAGE_PREFS_CUSTOM_HEADERS_ENABLED
+        return compare("customHeaders", lhs.customHeaders ?? [], rhs.customHeaders ?? [])
+#else
+        return nil
+#endif
     }
 }
 

--- a/Tests/NavigationTests/NavigationAuthChallengeTests.swift
+++ b/Tests/NavigationTests/NavigationAuthChallengeTests.swift
@@ -145,7 +145,7 @@ class NavigationAuthChallengeTests: DistributedNavigationDelegateTestsBase {
             .didReceiveAuthenticationChallenge(.init("localhost", 8084, "http", realm: "localhost", method: "NSURLAuthenticationMethodHTTPBasic"), Nav(action: navAct(1), .started, nil, .gotAuth)),
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local, data.htmlWithIframe3.count), nil, .gotAuth)),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed, .gotAuth)),
-            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
+            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
             .didReceiveAuthenticationChallenge(.init("localhost", 8084, "http", realm: "localhost", method: "NSURLAuthenticationMethodHTTPBasic"), Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed, .gotAuth)),
             .response(.resp(urls.local3, data.html.count, nil, .nonMain), Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed, .gotAuth)),
 
@@ -158,7 +158,7 @@ class NavigationAuthChallengeTests: DistributedNavigationDelegateTestsBase {
             .didStart(Nav(action: navAct(1), .started)),
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local, data.htmlWithIframe3.count), nil, .gotAuth)),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed, .gotAuth)),
-            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
+            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
             .response(.resp(urls.local3, data.html.count, nil, .nonMain), Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed, .gotAuth)),
             .didFinish(Nav(action: navAct(1), .finished, resp: resp(0), .committed, .gotAuth)),
         ])

--- a/Tests/NavigationTests/NavigationBackForwardTests.swift
+++ b/Tests/NavigationTests/NavigationBackForwardTests.swift
@@ -280,12 +280,12 @@ class NavigationBackForwardTests: DistributedNavigationDelegateTestsBase {
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local, data.htmlWithIframe3.count, headers: .default + ["Content-Type": "text/html"]))),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
             // #2 frame nav
-            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
+            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
             .response(.resp(urls.local3, data.html.count, headers: .default + ["Content-Type": "text/html"], .nonMain), Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
             .didFinish(Nav(action: navAct(1), .finished, resp: resp(0), .committed)),
 
             // #3 js frame nav
-            .navigationAction(req(urls.local1, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameID, urls.local3)),
+            .navigationAction(req(urls.local1, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameID, urls.local3)),
             .response(.resp(urls.local1, data.html.count, headers: .default + ["Content-Type": "text/html"], .nonMain), nil),
 
             // #3 -> #1 goBack in frame
@@ -371,12 +371,12 @@ class NavigationBackForwardTests: DistributedNavigationDelegateTestsBase {
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local, data.htmlWithIframe3.count, headers: .default + ["Content-Type": "text/html"]))),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
             // #2 frame nav
-            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
+            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main().handle.frameID, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
             .response(.resp(urls.local3, data.html.count, headers: .default + ["Content-Type": "text/html"], .nonMain), Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
             .didFinish(Nav(action: navAct(1), .finished, resp: resp(0), .committed)),
 
             // #3 js frame nav
-            .navigationAction(req(urls.local1, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameID, urls.local3)),
+            .navigationAction(req(urls.local1, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main().handle.frameID, urls.local), targ: frame(frameID, urls.local3)),
             .response(.resp(urls.local1, data.html.count, headers: .default + ["Content-Type": "text/html"], .nonMain), nil),
 
             // #3 -> #1 goBack in frame

--- a/Tests/NavigationTests/NavigationDownloadsTests.swift
+++ b/Tests/NavigationTests/NavigationDownloadsTests.swift
@@ -101,7 +101,7 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local, data.htmlWithIframe3.count, headers: .default + ["Content-Type": "text/html"]))),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
 
-            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
+            .navigationAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameID, .empty, secOrigin: urls.local.securityOrigin)),
             .navActionWillBecomeDownload(navAct(2)),
 
             .navActionBecameDownload(navAct(2), urls.local3),
@@ -199,7 +199,7 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
         waitForExpectations(timeout: 5)
 
         assertHistory(ofResponderAt: 0, equalsTo: [
-            .navigationAction(req(urls.local1, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameID, urls.local3)),
+            .navigationAction(req(urls.local1, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameID, urls.local3)),
             .response(.resp(urls.local1, data.html.count, headers: .default + ["Content-Type": "text/html"], .nonMain), nil),
             .navResponseWillBecomeDownload(2),
             .navResponseBecameDownload(2, urls.local1),
@@ -246,15 +246,15 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local, data.htmlWith3iFrames.count, headers: .default + ["Content-Type": "text/html"]))),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
 
-            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local2.path], .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameIDs[urls.local2.path], .empty, secOrigin: urls.local.securityOrigin))),
             .navActionWillBecomeDownload(navAct(2)),
             .navActionBecameDownload(navAct(2), urls.local2),
 
-            .navigationAction(NavAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local3.path], .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameIDs[urls.local3.path], .empty, secOrigin: urls.local.securityOrigin))),
             .navActionWillBecomeDownload(navAct(3)),
             .navActionBecameDownload(navAct(3), urls.local3),
 
-            .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local4.path], .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameIDs[urls.local4.path], .empty, secOrigin: urls.local.securityOrigin))),
             .navActionWillBecomeDownload(navAct(4)),
             .navActionBecameDownload(navAct(4), urls.local4),
 
@@ -308,9 +308,9 @@ class NavigationDownloadsTests: DistributedNavigationDelegateTestsBase {
             .response(Nav(action: navAct(1), .responseReceived, resp: .resp(urls.local, data.htmlWith3iFrames.count, headers: .default + ["Content-Type": "text/html"]))),
             .didCommit(Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
 
-            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local2.path], .empty, secOrigin: urls.local.securityOrigin))),
-            .navigationAction(NavAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local3.path], .empty, secOrigin: urls.local.securityOrigin))),
-            .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(WKFrameInfo.defaultMainFrameHandle, urls.local), targ: frame(frameIDs[urls.local4.path], .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local2, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameIDs[urls.local2.path], .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local3, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameIDs[urls.local3.path], .empty, secOrigin: urls.local.securityOrigin))),
+            .navigationAction(NavAction(req(urls.local4, defaultHeaders + ["Referer": urls.local.separatedString]), .other, from: history[1], src: frame(main(responderIdx: 0).handle.frameID, urls.local), targ: frame(frameIDs[urls.local4.path], .empty, secOrigin: urls.local.securityOrigin))),
 
             .response(.resp(urls.local2, data.html.count, headers: .default + ["Content-Type": "text/html"], .nonMain), Nav(action: navAct(1), .responseReceived, resp: resp(0), .committed)),
             .navResponseWillBecomeDownload(1),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206426619289877/f
iOS PR: not affected
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2147
What kind of version bump will this require?: Minor

**Description**:
- adds support for `WKWebpagePreferences` customHeaderFields

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate GPC header is passed to https://globalprivacycontrol.org/  when protections is on without a redirect
2. Validate `X-DuckDuckGo-Client` header is passed to SERP (e.g. by adding `|| navigationAction.url.host == "myhttpheader.com` at `SerpHeadersNavigationResponder.swift:30` and navigating to https://myhttpheader.com/

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
