### PR TITLE
Improved tunnel session access

### DIFF
--- a/Sources/NetworkProtection/Controllers/TunnelController.swift
+++ b/Sources/NetworkProtection/Controllers/TunnelController.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import NetworkExtension
 
 /// This protocol offers an interface to control the tunnel.
 ///
@@ -35,4 +36,13 @@ public protocol TunnelController {
     /// Whether the tunnel is connected
     ///
     var isConnected: Bool { get async }
+}
+
+/// A convenience tunnel session provider protocol.
+///
+/// This should eventually be unified onto `TunnelController`, so that all these requests can be made
+/// directly or through IPC, but this protocol is added to avoid having to tackle that right now..
+///
+public protocol TunnelSessionProvider {
+    func activeSession() async -> NETunnelProviderSession?
 }

--- a/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
+++ b/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
@@ -22,6 +22,57 @@ import NetworkExtension
 /// These are only usable from the App that owns the tunnel.
 ///
 public class ConnectionSessionUtilities {
+
+    /// This has been deprecated in macOS to avoid making multiple calls to
+    /// `NEPacketTunnelProviderManager.loadAllFromPreferences` since it causes notification
+    /// degradation issues over time.  Also, I tried removing this for both platforms, but iOS doesn't have
+    /// good ways to pass the tunnel controller where we need the session.
+    ///
+    /// Ref: https://app.asana.com/0/1203137811378537/1206513608690551/f
+    ///
+    @available(macOS, deprecated: 10.0, message: "Use NetworkProtectionTunnelController.activeSession instead.")
+    public static func activeSession(networkExtensionBundleID: String) async throws -> NETunnelProviderSession? {
+        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+
+        guard let manager = managers.first(where: {
+            ($0.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier == networkExtensionBundleID
+        }) else {
+            // No active connection, this is acceptable
+            return nil
+        }
+
+        guard let session = manager.connection as? NETunnelProviderSession else {
+            // The active connection is not running, so there's no session, this is acceptable
+            return nil
+        }
+
+        return session
+    }
+
+    /// This has been deprecated in macOS to avoid making multiple calls to
+    /// `NEPacketTunnelProviderManager.loadAllFromPreferences` since it causes notification
+    /// degradation issues over time.  Also, I tried removing this for both platforms, but iOS doesn't have
+    /// good ways to pass the tunnel controller where we need the session.
+    ///
+    /// Ref: https://app.asana.com/0/1203137811378537/1206513608690551/f
+    ///
+    @available(macOS, deprecated: 10.0, message: "Use NetworkProtectionTunnelController.activeSession instead.")
+    public static func activeSession() async throws -> NETunnelProviderSession? {
+        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+
+        guard let manager = managers.first else {
+            // No active connection, this is acceptable
+            return nil
+        }
+
+        guard let session = manager.connection as? NETunnelProviderSession else {
+            // The active connection is not running, so there's no session, this is acceptable
+            return nil
+        }
+
+        return session
+    }
+
     /// Retrieves a session from a `NEVPNStatusDidChange` notification.
     ///
     public static func session(from notification: Notification) -> NETunnelProviderSession? {

--- a/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
+++ b/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
@@ -23,6 +23,8 @@ import NetworkExtension
 ///
 public class ConnectionSessionUtilities {
 
+    /// Ideally we should remove these for iOS too.
+    ///
     /// This has been deprecated in macOS to avoid making multiple calls to
     /// `NEPacketTunnelProviderManager.loadAllFromPreferences` since it causes notification
     /// degradation issues over time.  Also, I tried removing this for both platforms, but iOS doesn't have
@@ -49,6 +51,8 @@ public class ConnectionSessionUtilities {
         return session
     }
 
+    /// Ideally we should remove these for iOS too.
+    ///
     /// This has been deprecated in macOS to avoid making multiple calls to
     /// `NEPacketTunnelProviderManager.loadAllFromPreferences` since it causes notification
     /// degradation issues over time.  Also, I tried removing this for both platforms, but iOS doesn't have

--- a/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
+++ b/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
@@ -22,6 +22,7 @@ import NetworkExtension
 /// These are only usable from the App that owns the tunnel.
 ///
 public class ConnectionSessionUtilities {
+    /*
     public static func activeSession(networkExtensionBundleID: String) async throws -> NETunnelProviderSession? {
         let managers = try await NETunnelProviderManager.loadAllFromPreferences()
 
@@ -54,7 +55,7 @@ public class ConnectionSessionUtilities {
         }
 
         return session
-    }
+    }*/
 
     /// Retrieves a session from a `NEVPNStatusDidChange` notification.
     ///

--- a/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
+++ b/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
@@ -22,41 +22,6 @@ import NetworkExtension
 /// These are only usable from the App that owns the tunnel.
 ///
 public class ConnectionSessionUtilities {
-    /*
-    public static func activeSession(networkExtensionBundleID: String) async throws -> NETunnelProviderSession? {
-        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-
-        guard let manager = managers.first(where: {
-            ($0.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier == networkExtensionBundleID
-        }) else {
-            // No active connection, this is acceptable
-            return nil
-        }
-
-        guard let session = manager.connection as? NETunnelProviderSession else {
-            // The active connection is not running, so there's no session, this is acceptable
-            return nil
-        }
-
-        return session
-    }
-
-    public static func activeSession() async throws -> NETunnelProviderSession? {
-        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-
-        guard let manager = managers.first else {
-            // No active connection, this is acceptable
-            return nil
-        }
-
-        guard let session = manager.connection as? NETunnelProviderSession else {
-            // The active connection is not running, so there's no session, this is acceptable
-            return nil
-        }
-
-        return session
-    }*/
-
     /// Retrieves a session from a `NEVPNStatusDidChange` notification.
     ///
     public static func session(from notification: Notification) -> NETunnelProviderSession? {

--- a/Sources/NetworkProtection/Status/ConnectionErrorObserver/ConnectionErrorObserverThroughSession.swift
+++ b/Sources/NetworkProtection/Status/ConnectionErrorObserver/ConnectionErrorObserverThroughSession.swift
@@ -33,6 +33,7 @@ public class ConnectionErrorObserverThroughSession: ConnectionErrorObserver {
 
     // MARK: - Notifications
 
+    private let tunnelSessionProvider: TunnelSessionProvider
     private let notificationCenter: NotificationCenter
     private let platformNotificationCenter: NotificationCenter
     private let platformDidWakeNotification: Notification.Name
@@ -44,7 +45,8 @@ public class ConnectionErrorObserverThroughSession: ConnectionErrorObserver {
 
     // MARK: - Initialization
 
-    public init(notificationCenter: NotificationCenter = .default,
+    public init(tunnelSessionProvider: TunnelSessionProvider,
+                notificationCenter: NotificationCenter = .default,
                 platformNotificationCenter: NotificationCenter,
                 platformDidWakeNotification: Notification.Name,
                 log: OSLog = .networkProtection) {
@@ -52,6 +54,7 @@ public class ConnectionErrorObserverThroughSession: ConnectionErrorObserver {
         self.notificationCenter = notificationCenter
         self.platformNotificationCenter = platformNotificationCenter
         self.platformDidWakeNotification = platformDidWakeNotification
+        self.tunnelSessionProvider = tunnelSessionProvider
         self.log = log
 
         start()
@@ -72,7 +75,7 @@ public class ConnectionErrorObserverThroughSession: ConnectionErrorObserver {
     private func handleDidWake(_ notification: Notification) {
         Task {
             do {
-                guard let session = try await ConnectionSessionUtilities.activeSession() else {
+                guard let session = await tunnelSessionProvider.activeSession() else {
                     return
                 }
 

--- a/Sources/NetworkProtection/Status/ConnectionStatusObserver/ConnectionStatusObserverThroughSession.swift
+++ b/Sources/NetworkProtection/Status/ConnectionStatusObserver/ConnectionStatusObserverThroughSession.swift
@@ -70,20 +70,6 @@ public class ConnectionStatusObserverThroughSession: ConnectionStatusObserver {
     }
 
     private func startObservers() {
-        notificationCenter.publisher(for: .NEVPNConfigurationChange).sink { _ in
-            Task {
-                // As crazy as it seems, this calls fixes an issue with tunnel session
-                // having a nil manager, when in theory it should never be `nil`.  I don't know
-                // why this happens, but I believe it may be because we run multiple instances
-                // of our App controlling the session, and if any modification is made to the
-                // session, other instances should reload it from preferences.
-                //
-                // For better or worse, this line ensures the session's manager is not nil.
-                //
-                try? await NETunnelProviderManager.loadAllFromPreferences()
-            }
-        }.store(in: &cancellables)
-
         notificationCenter.publisher(for: .NEVPNStatusDidChange).sink { [weak self] notification in
             self?.handleStatusChangeNotification(notification)
         }.store(in: &cancellables)
@@ -162,6 +148,8 @@ public class ConnectionStatusObserverThroughSession: ConnectionStatusObserver {
     // MARK: - Logging
 
     private func logStatusChanged(status: ConnectionStatus) {
-        os_log("%{public}@: connection status is now %{public}@", log: log, type: .debug, String(describing: self), String(describing: status))
+        let unmanagedObject = Unmanaged.passUnretained(self)
+        let address = unmanagedObject.toOpaque()
+        os_log("%{public}@<%{public}@>: connection status is now %{public}@", log: log, type: .debug, String(describing: self), String(describing: address), String(describing: status))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1206513608690551/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2448
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2174

What kind of version bump will this require?: Patch

## Description

Adds support for improved `NETunnelProviderSession` access in our macOS app (and potentially in our iOS app too, in the future).

## Testing:

Refer to the platform-specific PRs for testing  instructions.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
