### PR TITLE
Increase the tunnel monitor check interval to 1 minute

### DIFF
--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionTunnelFailureMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionTunnelFailureMonitor.swift
@@ -40,7 +40,7 @@ public actor NetworkProtectionTunnelFailureMonitor {
         }
     }
 
-    private static let monitoringInterval: TimeInterval = .seconds(10)
+    private static let monitoringInterval: TimeInterval = .minutes(1)
 
     private var task: Task<Never, Error>? {
         willSet {
@@ -114,10 +114,12 @@ public actor NetworkProtectionTunnelFailureMonitor {
             if failureReported {
                 os_log("⚫️ Tunnel failure already reported", log: .networkProtectionTunnelFailureMonitorLog, type: .debug)
             } else {
+                os_log("⚫️ Tunnel failure reported", log: .networkProtectionTunnelFailureMonitorLog, type: .debug)
                 callback(.failureDetected)
                 failureReported = true
             }
         } else if difference <= Result.failureRecovered.threshold, failureReported {
+            os_log("⚫️ Tunnel failure recovery", log: .networkProtectionTunnelFailureMonitorLog, type: .debug)
             callback(.failureRecovered)
             failureReported = false
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199333091098016/1206567515074116/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2467
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2190
What kind of version bump will this require?: Patch

**Description**:

This PR increases the tunnel monitor check interval from 10 seconds to 1 minute.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the client PRs and verify that the tunnel monitor checks in the Console.app logs now occur every minute
2. Run the branch for a few minutes and check that tunnel failure doesn't occur

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
