### PR TITLE
Add HTTP errors and status codes to site breakage reports

### DIFF
--- a/Sources/PrivacyDashboard/WebsiteBreakage/WebsiteBreakage.swift
+++ b/Sources/PrivacyDashboard/WebsiteBreakage/WebsiteBreakage.swift
@@ -175,7 +175,7 @@ public struct WebsiteBreakage {
                 let error = $0 as NSError
                 return "\(error.code) - \(error.localizedDescription)"
             }
-            result["errorDescription"] = errorDescriptions.joined(separator: ",")
+            result["errorDescriptions"] = errorDescriptions.joined(separator: ",")
         }
 
 #if os(iOS)

--- a/Sources/PrivacyDashboard/WebsiteBreakage/WebsiteBreakage.swift
+++ b/Sources/PrivacyDashboard/WebsiteBreakage/WebsiteBreakage.swift
@@ -52,8 +52,8 @@ public struct WebsiteBreakage {
     let reportFlow: Source
     let protectionsState: Bool
     var lastSentDay: String?
-    let error: Error?
-    let httpStatusCode: Int?
+    let errors: [Error]?
+    let httpStatusCodes: [Int]?
 #if os(iOS)
     let siteType: SiteType // ?? not in documentation
     let atb: String
@@ -76,8 +76,8 @@ public struct WebsiteBreakage {
         urlParametersRemoved: Bool,
         protectionsState: Bool,
         reportFlow: Source,
-        error: Error?,
-        httpStatusCode: Int?
+        errors: [Error]?,
+        httpStatusCodes: [Int]?
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -93,8 +93,8 @@ public struct WebsiteBreakage {
         self.protectionsState = protectionsState
         self.urlParametersRemoved = urlParametersRemoved
         self.reportFlow = reportFlow
-        self.error = error
-        self.httpStatusCode = httpStatusCode
+        self.errors = errors
+        self.httpStatusCodes = httpStatusCodes
     }
 #endif
 
@@ -117,8 +117,8 @@ public struct WebsiteBreakage {
         siteType: SiteType,
         atb: String,
         model: String,
-        error: Error?,
-        httpStatusCode: Int?
+        errors: [Error]?,
+        httpStatusCodes: [Int]?
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -137,8 +137,8 @@ public struct WebsiteBreakage {
         self.siteType = siteType
         self.atb = atb
         self.model = model
-        self.error = error
-        self.httpStatusCode = httpStatusCode
+        self.errors = errors
+        self.httpStatusCodes = httpStatusCodes
     }
 #endif
 
@@ -165,15 +165,17 @@ public struct WebsiteBreakage {
             result["lastSentDay"] = lastSentDay
         }
 
-        if let httpStatusCode {
-            result["httpErrorCode"] = String(httpStatusCode)
+        if let httpStatusCodes {
+            let codes: [String] = httpStatusCodes.map { String($0) }
+            result["httpErrorCodes"] = codes.joined(separator: ",")
         }
 
-        if let error = error as NSError? {
-            let errorDescription = "\(error.code) - \(error.localizedDescription)"
-            result["errorDescription"] = errorDescription
-        } else if let error {
-            result["errorDescription"] = error.localizedDescription
+        if let errors {
+            let errorDescriptions: [String] = errors.map {
+                let error = $0 as NSError
+                return "\(error.code) - \(error.localizedDescription)"
+            }
+            result["errorDescription"] = errorDescriptions.joined(separator: ",")
         }
 
 #if os(iOS)

--- a/Sources/PrivacyDashboard/WebsiteBreakage/WebsiteBreakage.swift
+++ b/Sources/PrivacyDashboard/WebsiteBreakage/WebsiteBreakage.swift
@@ -173,7 +173,7 @@ public struct WebsiteBreakage {
         if let errors {
             let errorDescriptions: [String] = errors.map {
                 let error = $0 as NSError
-                return "\(error.code) - \(error.localizedDescription)"
+                return "\(error.code) - \(error.domain):\(error.localizedDescription)"
             }
             result["errorDescriptions"] = errorDescriptions.joined(separator: ",")
         }

--- a/Tests/PrivacyDashboardTests/WebsiteBreakageMoks.swift
+++ b/Tests/PrivacyDashboardTests/WebsiteBreakageMoks.swift
@@ -36,8 +36,8 @@ struct WebsiteBreakageMoks {
                         urlParametersRemoved: true,
                         protectionsState: true,
                         reportFlow: .appMenu,
-                        error: nil,
-                        httpStatusCode: nil)
+                        errors: nil,
+                        httpStatusCodes: nil)
     }
 
     static var testBreakage2: WebsiteBreakage {
@@ -55,8 +55,8 @@ struct WebsiteBreakageMoks {
                         urlParametersRemoved: true,
                         protectionsState: true,
                         reportFlow: .appMenu,
-                        error: nil,
-                        httpStatusCode: nil)
+                        errors: nil,
+                        httpStatusCodes: nil)
     }
 
     static var testBreakage3: WebsiteBreakage {
@@ -74,7 +74,7 @@ struct WebsiteBreakageMoks {
                         urlParametersRemoved: true,
                         protectionsState: true,
                         reportFlow: .appMenu,
-                        error: nil,
-                        httpStatusCode: nil)
+                        errors: nil,
+                        httpStatusCodes: nil)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1163321984198618/1206216637366790/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2477
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2205
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
This PR updates the `error` and `httpStatusCode` fields in the breakage report to be arrays. This aligns Apple platforms with other products.
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See platform PRs
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
