### PR TITLE
Improve VPN rekeying reliability

### DIFF
--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionConnectionTester.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionConnectionTester.swift
@@ -134,6 +134,7 @@ final class NetworkProtectionConnectionTester {
     func stop() async {
         os_log("🔴 Stopping connection tester", log: log)
         await stopScheduledTimer()
+        isRunning = false
     }
 
     // MARK: - Obtaining the interface
@@ -197,12 +198,10 @@ final class NetworkProtectionConnectionTester {
             self?.timer = nil
         }
 
-        isRunning = true
         timer.resume()
     }
 
     private func stopScheduledTimer() async {
-        isRunning = false
         cancelTimerImmediately()
     }
 

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionConnectionTester.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionConnectionTester.swift
@@ -197,6 +197,7 @@ final class NetworkProtectionConnectionTester {
             self?.timer = nil
         }
 
+        isRunning = true
         timer.resume()
     }
 
@@ -242,7 +243,7 @@ final class NetworkProtectionConnectionTester {
         let onlyVPNIsDown = simulateFailure || (!vpnIsConnected && localIsConnected)
         simulateFailure = false
 
-        // After completing the conection tests we check if the tester is still supposed to be running
+        // After completing the connection tests we check if the tester is still supposed to be running
         // to avoid giving results when it should not be running.
         guard isRunning else {
             os_log("Tester skipped returning results as it was stopped while running the tests", log: log, type: .info)

--- a/Sources/NetworkProtection/KeyManagement/NetworkProtectionKeyStore.swift
+++ b/Sources/NetworkProtection/KeyManagement/NetworkProtectionKeyStore.swift
@@ -111,7 +111,10 @@ public final class NetworkProtectionKeychainKeyStore: NetworkProtectionKeyStore 
     }
 
     public func newKeyPair() -> KeyPair {
-        return newCurrentKeyPair()
+        let newPrivateKey = PrivateKey()
+        let newExpirationDate = Date().addingTimeInterval(validityInterval)
+
+        return KeyPair(privateKey: newPrivateKey, expirationDate: newExpirationDate)
     }
 
     private var validityInterval = Defaults.validityInterval

--- a/Sources/NetworkProtection/KeyManagement/NetworkProtectionKeyStore.swift
+++ b/Sources/NetworkProtection/KeyManagement/NetworkProtectionKeyStore.swift
@@ -25,19 +25,26 @@ public protocol NetworkProtectionKeyStore {
     ///
     func currentKeyPair() -> KeyPair
 
+    /// Create a new `KeyPair`.
+    ///
+    func newKeyPair() -> KeyPair
+
     /// Sets the validity interval for keys
     ///
-
     func setValidityInterval(_ validityInterval: TimeInterval?)
+
+    /// Updates the existing KeyPair.
+    ///
+    func updateKeyPair(_ newKeyPair: KeyPair)
 
     /// Updates the current `KeyPair` to have the specified expiration date
     ///
     /// - Parameters:
-    ///     - newExpirationDate: the new expiration date for the keypair
+    ///     - newExpirationDate: the new expiration date for the KeyPair
     ///
-    /// - Returns: a new keypair with the specified updates
+    /// - Returns: a new KeyPair with the specified updates
     ///
-    func updateCurrentKeyPair(newExpirationDate: Date) -> KeyPair
+    func updateKeyPairExpirationDate(_ newDate: Date) -> KeyPair
 
     /// Resets the current `KeyPair` so a new one will be generated when requested.
     ///
@@ -103,6 +110,10 @@ public final class NetworkProtectionKeychainKeyStore: NetworkProtectionKeyStore 
         return KeyPair(privateKey: currentPrivateKey, expirationDate: currentExpirationDate)
     }
 
+    public func newKeyPair() -> KeyPair {
+        return newCurrentKeyPair()
+    }
+
     private var validityInterval = Defaults.validityInterval
 
     public func setValidityInterval(_ validityInterval: TimeInterval?) {
@@ -123,8 +134,13 @@ public final class NetworkProtectionKeychainKeyStore: NetworkProtectionKeyStore 
         return KeyPair(privateKey: currentPrivateKey, expirationDate: currentExpirationDate)
     }
 
-    public func updateCurrentKeyPair(newExpirationDate: Date) -> KeyPair {
-        currentExpirationDate = newExpirationDate
+    public func updateKeyPair(_ newKeyPair: KeyPair) {
+        self.currentPrivateKey = newKeyPair.privateKey
+        self.currentExpirationDate = newKeyPair.expirationDate
+    }
+
+    public func updateKeyPairExpirationDate(_ newDate: Date) -> KeyPair {
+        self.currentExpirationDate = Date().addingTimeInterval(.seconds(30)) // newDate
         return currentKeyPair()
     }
 

--- a/Sources/NetworkProtection/Models/NetworkProtectionServer.swift
+++ b/Sources/NetworkProtection/Models/NetworkProtectionServer.swift
@@ -45,7 +45,7 @@ public struct NetworkProtectionServer: Codable, Equatable, Sendable {
 
     /// The last date at which registration took place. This may be used to determine whether a key needs to be refreshed.
     public let registrationDate = Date()
-    public let expirationDate: Date
+    public let expirationDate: Date?
 
     public let serverInfo: NetworkProtectionServerInfo
 
@@ -58,7 +58,7 @@ public struct NetworkProtectionServer: Codable, Equatable, Sendable {
         case expirationDate = "expiresAt"
     }
 
-    init(registeredPublicKey: String?, allowedIPs: [String]?, serverInfo: NetworkProtectionServerInfo, expirationDate: Date) {
+    init(registeredPublicKey: String?, allowedIPs: [String]?, serverInfo: NetworkProtectionServerInfo, expirationDate: Date?) {
         self.registeredPublicKey = registeredPublicKey
         self.allowedIPs = allowedIPs
         self.expirationDate = expirationDate

--- a/Sources/NetworkProtection/Models/NetworkProtectionServer.swift
+++ b/Sources/NetworkProtection/Models/NetworkProtectionServer.swift
@@ -45,7 +45,7 @@ public struct NetworkProtectionServer: Codable, Equatable, Sendable {
 
     /// The last date at which registration took place. This may be used to determine whether a key needs to be refreshed.
     public let registrationDate = Date()
-    public let expirationDate: Date?
+    public let expirationDate: Date
 
     public let serverInfo: NetworkProtectionServerInfo
 
@@ -58,7 +58,7 @@ public struct NetworkProtectionServer: Codable, Equatable, Sendable {
         case expirationDate = "expiresAt"
     }
 
-    init(registeredPublicKey: String?, allowedIPs: [String]?, serverInfo: NetworkProtectionServerInfo, expirationDate: Date?) {
+    init(registeredPublicKey: String?, allowedIPs: [String]?, serverInfo: NetworkProtectionServerInfo, expirationDate: Date) {
         self.registeredPublicKey = registeredPublicKey
         self.allowedIPs = allowedIPs
         self.expirationDate = expirationDate

--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -138,10 +138,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
         let (selectedServer, newExpiration) = try await register(keyPair: keyPair, selectionMethod: selectionMethod)
         os_log("Server registration successul", log: .networkProtection)
 
-        // If we're regenerating the key, then we know at this point it has been successfully registered. It's now safe to replace the old key.
-        if regenerateKey {
-            keyStore.updateKeyPair(keyPair)
-        }
+        keyStore.updateKeyPair(keyPair)
 
         if let newExpiration {
             keyPair = KeyPair(privateKey: keyPair.privateKey, expirationDate: newExpiration)

--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -132,10 +132,11 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
         if regenerateKey {
             keyPair = keyStore.newKeyPair()
         } else {
-            keyPair = keyStore.currentKeyPair()
+            keyPair = keyStore.currentKeyPair() ?? keyStore.newKeyPair()
         }
 
         let (selectedServer, newExpiration) = try await register(keyPair: keyPair, selectionMethod: selectionMethod)
+        os_log("Server registration successul", log: .networkProtection)
 
         // If we're regenerating the key, then we know at this point it has been successfully registered. It's now safe to replace the old key.
         if regenerateKey {
@@ -143,7 +144,8 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
         }
 
         if let newExpiration {
-            keyPair = keyStore.updateKeyPairExpirationDate(newExpiration)
+            keyPair = KeyPair(privateKey: keyPair.privateKey, expirationDate: newExpiration)
+            keyStore.updateKeyPair(keyPair)
         }
 
         do {

--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -223,6 +223,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             }
 
             selectedServer = registeredServer
+            return (selectedServer, selectedServer.expirationDate)
         case .failure(let error):
             handle(clientError: error)
 
@@ -230,7 +231,6 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             return (cachedServer, nil)
         }
     }
-    // swiftlint:enable cyclomatic_complexity
 
     /// Retrieves the first cached server that's registered with the specified key pair.
     ///

--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -45,7 +45,8 @@ public protocol NetworkProtectionDeviceManagement {
     func generateTunnelConfiguration(selectionMethod: NetworkProtectionServerSelectionMethod,
                                      includedRoutes: [IPAddressRange],
                                      excludedRoutes: [IPAddressRange],
-                                     isKillSwitchEnabled: Bool) async throws -> (TunnelConfiguration, NetworkProtectionServerInfo)
+                                     isKillSwitchEnabled: Bool,
+                                     regenerateKey: Bool) async throws -> (TunnelConfiguration, NetworkProtectionServerInfo)
 
 }
 
@@ -124,9 +125,26 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
     public func generateTunnelConfiguration(selectionMethod: NetworkProtectionServerSelectionMethod,
                                             includedRoutes: [IPAddressRange],
                                             excludedRoutes: [IPAddressRange],
-                                            isKillSwitchEnabled: Bool) async throws -> (TunnelConfiguration, NetworkProtectionServerInfo) {
+                                            isKillSwitchEnabled: Bool,
+                                            regenerateKey: Bool) async throws -> (TunnelConfiguration, NetworkProtectionServerInfo) {
+        var keyPair: KeyPair
 
-        let (selectedServer, keyPair) = try await register(selectionMethod: selectionMethod)
+        if regenerateKey {
+            keyPair = keyStore.newKeyPair()
+        } else {
+            keyPair = keyStore.currentKeyPair()
+        }
+
+        let (selectedServer, newExpiration) = try await register(keyPair: keyPair, selectionMethod: selectionMethod)
+
+        // If we're regenerating the key, then we know at this point it has been successfully registered. It's now safe to replace the old key.
+        if regenerateKey {
+            keyStore.updateKeyPair(keyPair)
+        }
+
+        if let newExpiration {
+            keyPair = keyStore.updateKeyPairExpirationDate(newExpiration)
+        }
 
         do {
             let configuration = try tunnelConfiguration(interfacePrivateKey: keyPair.privateKey,
@@ -152,13 +170,11 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
     //     - keyPair: the key pair that was used to register with the server, and that should be used to configure the tunnel
     //
     // - Throws:`NetworkProtectionError`
-    // This cannot be a doc comment because of the swiftlint command below
-    // swiftlint:disable cyclomatic_complexity
-    private func register(selectionMethod: NetworkProtectionServerSelectionMethod) async throws -> (server: NetworkProtectionServer,
-                                                                                                    keyPair: KeyPair) {
+    private func register(keyPair: KeyPair,
+                          selectionMethod: NetworkProtectionServerSelectionMethod) async throws -> (server: NetworkProtectionServer,
+                                                                                                    newExpiration: Date?) {
 
         guard let token = try? tokenStore.fetchToken() else { throw NetworkProtectionError.noAuthTokenFound }
-        var keyPair = keyStore.currentKeyPair()
 
         let serverSelection: RegisterServerSelection
         let excludedServerName: String?
@@ -203,26 +219,15 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
                 errorEvents?.fire(NetworkProtectionError.serverListInconsistency)
 
                 let cachedServer = try cachedServer(registeredWith: keyPair)
-                return (cachedServer, keyPair)
+                return (cachedServer, nil)
             }
 
             selectedServer = registeredServer
-
-            // We should not need this IF condition here, because we know registered servers will give us an expiration date,
-            // but since the structure we're currently using makes the expiration date optional we need to have it.
-            // We should consider changing our server structure to not allow a missing expiration date here.
-            if let serverExpirationDate = selectedServer.expirationDate,
-               keyPair.expirationDate > serverExpirationDate {
-
-                keyPair = keyStore.updateCurrentKeyPair(newExpirationDate: serverExpirationDate)
-            }
-
-            return (selectedServer, keyPair)
         case .failure(let error):
             handle(clientError: error)
 
             let cachedServer = try cachedServer(registeredWith: keyPair)
-            return (cachedServer, keyPair)
+            return (cachedServer, nil)
         }
     }
     // swiftlint:enable cyclomatic_complexity

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1204,3 +1204,5 @@ extension WireGuardAdapterError: LocalizedError, CustomDebugStringConvertible {
     }
 
 }
+
+// swiftlint:enable file_length

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -203,12 +203,12 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         Task {
             await updateBandwidthAnalyzer()
 
+            // This provides a more frequent active user pixel check
+            providerEvents.fire(.userBecameActive)
+
             guard self.bandwidthAnalyzer.isConnectionIdle() else {
                 return
             }
-
-            // This provides a more frequent active user pixel check
-            providerEvents.fire(.userBecameActive)
 
             await rekeyIfExpired()
         }

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -148,7 +148,11 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     private var isKeyExpired: Bool {
-        keyStore.currentKeyPair().expirationDate <= Date()
+        guard let currentExpirationDate = keyStore.currentExpirationDate else {
+            return true
+        }
+
+        return currentExpirationDate <= Date()
     }
 
     private func rekeyIfExpired() async {

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -19,6 +19,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2021 WireGuard LLC. All Rights Reserved.
 
+// swiftlint:disable file_length
+
 import Combine
 import Common
 import Foundation
@@ -150,7 +152,10 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     private func rekeyIfExpired() async {
+        os_log("Checking if rekey is necessary...", log: .networkProtectionKeyManagement)
+
         guard isKeyExpired else {
+            os_log("The key is not expired", log: .networkProtectionKeyManagement)
             return
         }
 
@@ -162,6 +167,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         // Experimental option to disable rekeying.
         guard !settings.disableRekeying else {
+            os_log("Rekeying disabled", log: .networkProtectionKeyManagement)
             return
         }
 
@@ -756,7 +762,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         switch message {
         case .request(let request):
-            handleRequest(request)
+            handleRequest(request, completionHandler: completionHandler)
         case .expireRegistrationKey:
             handleExpireRegistrationKey(completionHandler: completionHandler)
         case .getLastErrorMessage:
@@ -862,7 +868,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 .setNetworkPathChange,
                 .setDisableRekeying:
             // Intentional no-op, as some setting changes don't require any further operation
-            break
+            completionHandler?(nil)
         }
     }
 

--- a/Tests/NetworkProtectionTests/Mocks/NetworkProtectionKeyStoreMocks.swift
+++ b/Tests/NetworkProtectionTests/Mocks/NetworkProtectionKeyStoreMocks.swift
@@ -26,14 +26,8 @@ final class NetworkProtectionKeyStoreMock: NetworkProtectionKeyStore {
 
     // MARK: - NetworkProtectionKeyStore
 
-    func currentKeyPair() -> NetworkProtection.KeyPair {
-        if let keyPair = self.keyPair {
-            return keyPair
-        } else {
-            let keyPair = KeyPair(privateKey: PrivateKey(), expirationDate: Date().addingTimeInterval(.day))
-            self.keyPair = keyPair
-            return keyPair
-        }
+    func currentKeyPair() -> NetworkProtection.KeyPair? {
+        keyPair
     }
 
     func newKeyPair() -> NetworkProtection.KeyPair {

--- a/Tests/NetworkProtectionTests/Mocks/NetworkProtectionKeyStoreMocks.swift
+++ b/Tests/NetworkProtectionTests/Mocks/NetworkProtectionKeyStoreMocks.swift
@@ -36,7 +36,15 @@ final class NetworkProtectionKeyStoreMock: NetworkProtectionKeyStore {
         }
     }
 
-    func updateCurrentKeyPair(newExpirationDate: Date) -> NetworkProtection.KeyPair {
+    func newKeyPair() -> NetworkProtection.KeyPair {
+        return KeyPair(privateKey: PrivateKey(), expirationDate: Date().addingTimeInterval(.day))
+    }
+
+    public func updateKeyPair(_ newKeyPair: KeyPair) {
+        self.keyPair = newKeyPair
+    }
+
+    func updateKeyPairExpirationDate(_ newExpirationDate: Date) -> NetworkProtection.KeyPair {
         let keyPair = KeyPair(privateKey: keyPair?.privateKey ?? PrivateKey(), expirationDate: newExpirationDate)
         self.keyPair = keyPair
         return keyPair

--- a/Tests/NetworkProtectionTests/Mocks/NetworkProtectionServerMocks.swift
+++ b/Tests/NetworkProtectionTests/Mocks/NetworkProtectionServerMocks.swift
@@ -67,7 +67,7 @@ extension NetworkProtectionServerInfo {
 
 extension NetworkProtectionServer {
 
-    static let mockBaseServer = NetworkProtectionServer(registeredPublicKey: nil, allowedIPs: nil, serverInfo: .mock, expirationDate: nil)
+    static let mockBaseServer = NetworkProtectionServer(registeredPublicKey: nil, allowedIPs: nil, serverInfo: .mock, expirationDate: Date())
     static let mockRegisteredServer = NetworkProtectionServer(registeredPublicKey: "ovn9RpzUuvQ4XLQt6B3RKuEXGIxa5QpTnehjduZlcSE=",
                                                               allowedIPs: ["0.0.0.0/0", "::/0"],
                                                               serverInfo: .mock,

--- a/Tests/NetworkProtectionTests/NetworkProtectionDeviceManagerTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionDeviceManagerTests.swift
@@ -63,7 +63,7 @@ final class NetworkProtectionDeviceManagerTests: XCTestCase {
         let configuration: (TunnelConfiguration, NetworkProtectionServerInfo)
 
         do {
-            configuration = try await manager.generateTunnelConfiguration(selectionMethod: .automatic)
+            configuration = try await manager.generateTunnelConfiguration(selectionMethod: .automatic, regenerateKey: false)
         } catch {
             XCTFail("Unexpected error \(error.localizedDescription)")
             return
@@ -89,7 +89,7 @@ final class NetworkProtectionDeviceManagerTests: XCTestCase {
         XCTAssertEqual(try? serverListStore.storedNetworkProtectionServerList(), [])
         XCTAssertNil(networkClient.spyRegister)
 
-        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic)
+        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic, regenerateKey: false)
 
         XCTAssertNotNil(try? keyStore.storedPrivateKey())
         XCTAssertEqual(try? serverListStore.storedNetworkProtectionServerList(), [registeredServer])
@@ -101,7 +101,7 @@ final class NetworkProtectionDeviceManagerTests: XCTestCase {
         networkClient.stubRegister = .success([server])
 
         let preferredLocation = NetworkProtectionSelectedLocation(country: "Some country", city: "Some city")
-        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .preferredLocation(preferredLocation))
+        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .preferredLocation(preferredLocation), regenerateKey: false)
 
         XCTAssertEqual(networkClient.spyRegister?.requestBody.city, preferredLocation.city)
         XCTAssertEqual(networkClient.spyRegister?.requestBody.country, preferredLocation.country)
@@ -111,7 +111,7 @@ final class NetworkProtectionDeviceManagerTests: XCTestCase {
         let server = NetworkProtectionServer.mockBaseServer
         networkClient.stubRegister = .success([server])
 
-        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .preferredServer(serverName: server.serverName))
+        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .preferredServer(serverName: server.serverName), regenerateKey: false)
 
         XCTAssertEqual(networkClient.spyRegister?.requestBody.server, server.serverName)
     }
@@ -122,7 +122,7 @@ final class NetworkProtectionDeviceManagerTests: XCTestCase {
 
         XCTAssertNotNil(tokenStore.token)
 
-        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic)
+        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic, regenerateKey: false)
 
         XCTAssertNil(tokenStore.token)
     }
@@ -132,7 +132,7 @@ final class NetworkProtectionDeviceManagerTests: XCTestCase {
 
         XCTAssertNotNil(tokenStore.token)
 
-        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic)
+        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic, regenerateKey: false)
 
         XCTAssertNil(tokenStore.token)
     }
@@ -145,17 +145,68 @@ final class NetworkProtectionDeviceManagerTests: XCTestCase {
         XCTAssertEqual(servers2.count, 6)
     }
 
+    func testWhenGeneratingTunnelConfiguration_AndKeyIsStillValid_AndKeyIsNotRegenerated_ThenKeyDoesNotChange() async {
+        let server = NetworkProtectionServer.mockBaseServer
+        let registeredServer = NetworkProtectionServer.mockRegisteredServer
+
+        networkClient.stubGetServers = .success([server])
+        networkClient.stubRegister = .success([registeredServer])
+
+        XCTAssertNil(try? keyStore.storedPrivateKey())
+        XCTAssertEqual(try? serverListStore.storedNetworkProtectionServerList(), [])
+        XCTAssertNil(networkClient.spyRegister)
+        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic, regenerateKey: false)
+
+        let firstKey = try? keyStore.storedPrivateKey()
+        XCTAssertNotNil(firstKey)
+        XCTAssertEqual(try? serverListStore.storedNetworkProtectionServerList(), [registeredServer])
+        XCTAssertNotNil(networkClient.spyRegister)
+        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic, regenerateKey: false)
+
+        let secondKey = try? keyStore.storedPrivateKey()
+        XCTAssertNotNil(secondKey)
+        XCTAssertEqual(firstKey, secondKey) // Check that the key did NOT change
+        XCTAssertEqual(try? serverListStore.storedNetworkProtectionServerList(), [registeredServer])
+        XCTAssertNotNil(networkClient.spyRegister)
+    }
+
+    func testWhenGeneratingTunnelConfiguration_AndKeyIsStillValid_AndKeyIsRegenerated_ThenKeyChanges() async {
+        let server = NetworkProtectionServer.mockBaseServer
+        let registeredServer = NetworkProtectionServer.mockRegisteredServer
+
+        networkClient.stubGetServers = .success([server])
+        networkClient.stubRegister = .success([registeredServer])
+
+        XCTAssertNil(try? keyStore.storedPrivateKey())
+        XCTAssertEqual(try? serverListStore.storedNetworkProtectionServerList(), [])
+        XCTAssertNil(networkClient.spyRegister)
+        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic, regenerateKey: false)
+
+        let firstKey = try? keyStore.storedPrivateKey()
+        XCTAssertNotNil(firstKey)
+        XCTAssertEqual(try? serverListStore.storedNetworkProtectionServerList(), [registeredServer])
+        XCTAssertNotNil(networkClient.spyRegister)
+        _ = try? await manager.generateTunnelConfiguration(selectionMethod: .automatic, regenerateKey: true)
+
+        let secondKey = try? keyStore.storedPrivateKey()
+        XCTAssertNotNil(secondKey)
+        XCTAssertNotEqual(firstKey, secondKey) // Check that the key changed
+        XCTAssertEqual(try? serverListStore.storedNetworkProtectionServerList(), [registeredServer])
+        XCTAssertNotNil(networkClient.spyRegister)
+    }
+
 }
 
 extension NetworkProtectionDeviceManager {
 
-    func generateTunnelConfiguration(selectionMethod: NetworkProtectionServerSelectionMethod) async throws -> (TunnelConfiguration, NetworkProtectionServerInfo) {
+    func generateTunnelConfiguration(selectionMethod: NetworkProtectionServerSelectionMethod,
+                                     regenerateKey: Bool) async throws -> (TunnelConfiguration, NetworkProtectionServerInfo) {
         try await generateTunnelConfiguration(
             selectionMethod: selectionMethod,
             includedRoutes: [],
             excludedRoutes: [],
             isKillSwitchEnabled: false,
-            regenerateKey: false
+            regenerateKey: regenerateKey
         )
     }
 

--- a/Tests/NetworkProtectionTests/NetworkProtectionDeviceManagerTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionDeviceManagerTests.swift
@@ -150,7 +150,13 @@ final class NetworkProtectionDeviceManagerTests: XCTestCase {
 extension NetworkProtectionDeviceManager {
 
     func generateTunnelConfiguration(selectionMethod: NetworkProtectionServerSelectionMethod) async throws -> (TunnelConfiguration, NetworkProtectionServerInfo) {
-        try await generateTunnelConfiguration(selectionMethod: selectionMethod, includedRoutes: [], excludedRoutes: [], isKillSwitchEnabled: false)
+        try await generateTunnelConfiguration(
+            selectionMethod: selectionMethod,
+            includedRoutes: [],
+            excludedRoutes: [],
+            isKillSwitchEnabled: false,
+            regenerateKey: false
+        )
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1206607513978260/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2478
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2207
What kind of version bump will this require?: Major

**Description**:

This PR fixes three issues:

1. The rekeying implementation was deleting the old key, and _then_ registering a new one - however, if the registration call failed, then it got left in a confused state with a connection that didn't work
2. The connection tester is what is responsible for triggering rekeying and the DAU pixel, but it was accidentally setting `isRunning` to false even when it was running just fine
3. The DAU event was sent only when the connection was idle, which isn't necessary

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make sure client PRs run and connect to NetP, try switching servers etc., generally just smoke test NetP
2. Check out this branch in one of the clients and change the `validityInterval ` in `NetworkProtectionKeyStore` to something shorter, like 30 seconds
3. Edit the `updateKeyPairExpirationDate` function to also set a date of only 30 seconds in the future, so that you can test more frequent rekeying
4. Run NetP, then watch the Console logs and check that rekeying is succeeding frequently (make sure you stop other network traffic so that the network is idle and rekeying can complete)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
