### PR TITLE
Bump C-S-S to 4.64.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "3.2.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.61.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "4.64.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/wireguard-apple", exact: "1.1.1"),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206623258776053/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/2483
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2188
What kind of version bump will this require?: Minor

**Description**:
Update C-S-S library

**Steps to test this PR**
Instructions on the individual PRs for macOS and iOS
