### PR TITLE
Fix some issues with handling when the adapter is started up

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "063b560e59a50e03d9b00b88a7fcb2ed2b562395",
-        "version" : "4.61.0"
+        "revision" : "36ddba2cbac52a41b9a9275af06d32fa8a56d2d7",
+        "version" : "4.64.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "36ddba2cbac52a41b9a9275af06d32fa8a56d2d7",
-        "version" : "4.64.0"
+        "revision" : "063b560e59a50e03d9b00b88a7fcb2ed2b562395",
+        "version" : "4.61.0"
       }
     },
     {

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -862,7 +862,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             Task { @MainActor in
                 if case .connected = connectionStatus {
-                    os_log("⚫️🔴 1", log: .networkProtectionPixel, type: .debug)
                     try? await updateTunnelConfiguration(environment: settings.selectedEnvironment, serverSelectionMethod: serverSelectionMethod, reassert: true)
                 }
                 completionHandler?(nil)
@@ -879,7 +878,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             Task { @MainActor in
                 if case .connected = connectionStatus {
-                    os_log("⚫️🔴 4", log: .networkProtectionPixel, type: .debug)
                     try? await updateTunnelConfiguration(environment: settings.selectedEnvironment, serverSelectionMethod: serverSelectionMethod, reassert: true)
                 }
                 completionHandler?(nil)
@@ -962,7 +960,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                     settings.selectedServer = .automatic
 
                     if case .connected = connectionStatus {
-                        os_log("⚫️🔴 2", log: .networkProtectionPixel, type: .debug)
                         try? await updateTunnelConfiguration(reassert: true)
                     }
                 }
@@ -977,7 +974,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             settings.selectedServer = .endpoint(serverName)
             if case .connected = connectionStatus {
-                os_log("⚫️🔴 3", log: .networkProtectionPixel, type: .debug)
                 try? await updateTunnelConfiguration(environment: settings.selectedEnvironment, serverSelectionMethod: .preferredServer(serverName: serverName), reassert: true)
             }
             completionHandler?(nil)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206634919441353/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2496
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2251

What kind of version bump will this require?: Patch

## Description

Fixes how we handle the event of the tunnel adapter started.  More broadly, this PR tries to ensure we don't "histerically" start and stop our monitors, since that could result in a lot of noise in our metrics.

## Testing
 
See platform specific PRs for testing instructions.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
