### PR TITLE
Add configurable subscription environment

### DIFF
--- a/Sources/Subscription/Services/AuthService.swift
+++ b/Sources/Subscription/Services/AuthService.swift
@@ -25,7 +25,15 @@ public struct AuthService: APIService {
         let configuration = URLSessionConfiguration.ephemeral
         return URLSession(configuration: configuration)
     }()
-    public static let baseURL = URL(string: "https://quackdev.duckduckgo.com/api/auth")!
+
+    public static var baseURL: URL {
+        switch SubscriptionPurchaseEnvironment.currentServiceEnvironment {
+        case .production:
+            URL(string: "https://quack.duckduckgo.com/api/auth")!
+        case .staging:
+            URL(string: "https://quackdev.duckduckgo.com/api/auth")!
+        }
+    }
 
     // MARK: -
 

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -25,7 +25,15 @@ public struct SubscriptionService: APIService {
         let configuration = URLSessionConfiguration.ephemeral
         return URLSession(configuration: configuration)
     }()
-    public static let baseURL = URL(string: "https://subscriptions-dev.duckduckgo.com/api")!
+
+    public static var baseURL: URL {
+        switch SubscriptionPurchaseEnvironment.currentServiceEnvironment {
+        case .production:
+            URL(string: "https://subscriptions.duckduckgo.com/api")!
+        case .staging:
+            URL(string: "https://subscriptions-dev.duckduckgo.com/api")!
+        }
+    }
 
     // MARK: -
 

--- a/Sources/Subscription/SubscriptionPurchaseEnvironment.swift
+++ b/Sources/Subscription/SubscriptionPurchaseEnvironment.swift
@@ -21,6 +21,22 @@ import Common
 
 public final class SubscriptionPurchaseEnvironment {
 
+    public enum ServiceEnvironment: String, Codable {
+        case production
+        case staging
+
+        public static var `default`: ServiceEnvironment = .staging
+
+        public var description: String {
+            switch self {
+            case .production: return "Production"
+            case .staging: return "Staging"
+            }
+        }
+    }
+
+    public static var currentServiceEnvironment: ServiceEnvironment = .default
+
     public enum Environment: String {
         case appStore, stripe
     }

--- a/Sources/Subscription/SubscriptionPurchaseEnvironment.swift
+++ b/Sources/Subscription/SubscriptionPurchaseEnvironment.swift
@@ -25,7 +25,7 @@ public final class SubscriptionPurchaseEnvironment {
         case production
         case staging
 
-        public static var `default`: ServiceEnvironment = .staging
+        public static var `default`: ServiceEnvironment = .production
 
         public var description: String {
             switch self {

--- a/Sources/Subscription/URL+Subscription.swift
+++ b/Sources/Subscription/URL+Subscription.swift
@@ -21,7 +21,12 @@ import Foundation
 public extension URL {
 
     static var subscriptionBaseURL: URL {
-        URL(string: "https://abrown.duckduckgo.com/subscriptions")!
+        switch SubscriptionPurchaseEnvironment.currentServiceEnvironment {
+        case .production:
+            URL(string: "https://duckduckgo.com/subscriptions")!
+        case .staging:
+            URL(string: "https://abrown.duckduckgo.com/subscriptions")!
+        }
     }
 
     static var subscriptionPurchase: URL {


### PR DESCRIPTION


Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206704698161521/f
iOS PR: -
macOS PR: -
What kind of version bump will this require?: Minor

**Description**:
Add configurable subscription environment


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
