### PR TITLE
Purchase Cancelled By User

### DIFF
--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -108,7 +108,9 @@ public final class AppStorePurchaseFlow {
             }
         }
     }
-    // swiftlint:enable:next cyclomatic_complexity
+    // swiftlint:enable cyclomatic_complexity
+    
+    
 
     @discardableResult
     public static func completeSubscriptionPurchase() async -> Result<PurchaseUpdate, AppStorePurchaseFlow.Error> {

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -109,8 +109,6 @@ public final class AppStorePurchaseFlow {
         }
     }
     // swiftlint:enable cyclomatic_complexity
-    
-    
 
     @discardableResult
     public static func completeSubscriptionPurchase() async -> Result<PurchaseUpdate, AppStorePurchaseFlow.Error> {

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -56,6 +56,7 @@ public final class AppStorePurchaseFlow {
                                             features: features))
     }
 
+    // swiftlint:disable cyclomatic_complexity
     public static func purchaseSubscription(with subscriptionIdentifier: String, emailAccessToken: String?) async -> Result<Void, AppStorePurchaseFlow.Error> {
         os_log(.info, log: .subscription, "[AppStorePurchaseFlow] purchaseSubscription")
 
@@ -107,6 +108,7 @@ public final class AppStorePurchaseFlow {
             }
         }
     }
+    // swiftlint:disable:next cyclomatic_complexity
 
     @discardableResult
     public static func completeSubscriptionPurchase() async -> Result<PurchaseUpdate, AppStorePurchaseFlow.Error> {

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -29,6 +29,7 @@ public final class AppStorePurchaseFlow {
         case authenticatingWithTransactionFailed
         case accountCreationFailed
         case purchaseFailed
+        case cancelledByUser
         case missingEntitlements
     }
 
@@ -98,7 +99,12 @@ public final class AppStorePurchaseFlow {
         case .failure(let error):
             os_log(.error, log: .subscription, "[AppStorePurchaseFlow] purchaseSubscription error: %{public}s", String(reflecting: error))
             AccountManager().signOut()
-            return .failure(.purchaseFailed)
+            switch error {
+            case .purchaseCancelledByUser:
+                return .failure(.cancelledByUser)
+            default:
+                return .failure(.purchaseFailed)
+            }
         }
     }
 

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -108,7 +108,7 @@ public final class AppStorePurchaseFlow {
             }
         }
     }
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:enable:next cyclomatic_complexity
 
     @discardableResult
     public static func completeSubscriptionPurchase() async -> Result<PurchaseUpdate, AppStorePurchaseFlow.Error> {

--- a/Sources/Subscription/PurchaseManager.swift
+++ b/Sources/Subscription/PurchaseManager.swift
@@ -28,7 +28,7 @@ public enum StoreError: Error {
     case failedVerification
 }
 
-enum PurchaseManagerError: Error {
+public enum PurchaseManagerError: Error {
     case productNotFound
     case externalIDisNotAValidUUID
     case purchaseFailed
@@ -165,7 +165,7 @@ public final class PurchaseManager: ObservableObject {
     }
 
     @MainActor
-    public func purchaseSubscription(with identifier: String, externalID: String) async -> Result<Void, Error> {
+    public func purchaseSubscription(with identifier: String, externalID: String) async -> Result<Void, PurchaseManagerError> {
 
         guard let product = availableProducts.first(where: { $0.id == identifier }) else { return .failure(PurchaseManagerError.productNotFound) }
 


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/1204099484721401/1206707680638894/f
What kind of version bump will this require?: Minor

iOS PR: https://github.com/duckduckgo/iOS/pull/2508
macOS PR: TBD

**Description**:
- Sends a proper error when the user cancels the purchase flow.

*Steps to test this PR**:
- Build iOS App
- Breakpoint [here](https://github.com/duckduckgo/BrowserServicesKit/pull/684/files#diff-36f394a1f52bde1c80509db2b510c8950d05f259d79cf0db76a4f829c07eed38R102)
- Purchase a Subscription
- Once the apple dialog appears, hit cancel
- .`purchaseCancelledByUser:` should be triggered, and no Error should appear in the iOS app
