### PR TITLE
Make the authorizeURL use env based endpoint

### DIFF
--- a/Sources/NetworkProtection/Networking/NetworkProtectionClient.swift
+++ b/Sources/NetworkProtection/Networking/NetworkProtectionClient.swift
@@ -118,7 +118,6 @@ final class NetworkProtectionBackendClient: NetworkProtectionClient {
     enum Constants {
         static let productionEndpoint = URL(string: "https://controller.netp.duckduckgo.com")!
         static let stagingEndpoint = URL(string: "https://staging.netp.duckduckgo.com")!
-        static let subscriptionEndpoint = URL(string: "https://staging1.netp.duckduckgo.com")!
     }
 
     private enum DecoderError: Error {
@@ -142,7 +141,7 @@ final class NetworkProtectionBackendClient: NetworkProtectionClient {
     }
 
     var authorizeURL: URL {
-        Constants.subscriptionEndpoint.appending("/authorize")
+        endpointURL.appending("/authorize")
     }
 
     private let decoder: JSONDecoder = {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206715072958928/f
iOS PR: -
macOS PR: -
What kind of version bump will this require?: Patch

**Description**:
When authenticating to subscription we attempt to exchange the subscription token to network protection token. This fails as the endpoint used for exchanging the token is fixed to staging environment.

The authorize endpoint should be based on the current environment.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
