### PR TITLE
fix bundle name in breakByRaisingSigInt

### DIFF
--- a/Sources/Common/Debug.swift
+++ b/Sources/Common/Debug.swift
@@ -51,7 +51,7 @@ public func callingSymbol() -> String {
     repeat {
         // caller for the procedure
         callingSymbolIdx += 1
-        let line = stackTrace[callingSymbolIdx].replacingOccurrences(of: Bundle.main.name!, with: "DDG")
+        let line = stackTrace[callingSymbolIdx].replacingOccurrences(of: Bundle.main.executableURL!.lastPathComponent, with: "DDG")
         symbolName = String(line.split(separator: " ", maxSplits: 3)[3]).components(separatedBy: " + ")[0]
     } while stackTrace[callingSymbolIdx - 1].contains(symbolName.dropping(suffix: "To")) // skip objc wrappers
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1177771139624306/1206752972667935/f
iOS PR: not affected
macOS PR: 
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
- fixes bundle name stripping from symbols in `breakByRaisingSigInt`

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate there‘s no sigint raised when navigating to a website in the App Store DEBUG build (localized?)

