### PR TITLE
Integrate confirm entitlements endpoint

### DIFF
--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -230,7 +230,7 @@ public class AccountManager: AccountManaging {
 
         guard let token = accessToken else { return }
 
-        if case .success(let subscription) = await SubscriptionService.getSubscriptionDetails(token: token) {
+        if case .success(let subscription) = await SubscriptionService.getSubscription(accessToken: token) {
             if !subscription.isActive {
                 signOut()
             }

--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -230,8 +230,8 @@ public class AccountManager: AccountManaging {
 
         guard let token = accessToken else { return }
 
-        if case .success(let response) = await SubscriptionService.getSubscriptionDetails(token: token) {
-            if !response.isSubscriptionActive {
+        if case .success(let subscription) = await SubscriptionService.getSubscriptionDetails(token: token) {
+            if !subscription.isActive {
                 signOut()
             }
         }

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -56,8 +56,10 @@ public final class AppStorePurchaseFlow {
                                             features: features))
     }
 
+    public typealias TransactionJWS = String
+
     // swiftlint:disable cyclomatic_complexity
-    public static func purchaseSubscription(with subscriptionIdentifier: String, emailAccessToken: String?) async -> Result<Void, AppStorePurchaseFlow.Error> {
+    public static func purchaseSubscription(with subscriptionIdentifier: String, emailAccessToken: String?) async -> Result<TransactionJWS, AppStorePurchaseFlow.Error> {
         os_log(.info, log: .subscription, "[AppStorePurchaseFlow] purchaseSubscription")
 
         let accountManager = AccountManager()
@@ -95,8 +97,8 @@ public final class AppStorePurchaseFlow {
 
         // Make the purchase
         switch await PurchaseManager.shared.purchaseSubscription(with: subscriptionIdentifier, externalID: externalID) {
-        case .success:
-            return .success(())
+        case .success(let transactionJWS):
+            return .success(transactionJWS)
         case .failure(let error):
             os_log(.error, log: .subscription, "[AppStorePurchaseFlow] purchaseSubscription error: %{public}s", String(reflecting: error))
             AccountManager().signOut()
@@ -108,14 +110,24 @@ public final class AppStorePurchaseFlow {
             }
         }
     }
-    // swiftlint:enable cyclomatic_complexity
 
+    // swiftlint:enable cyclomatic_complexity
     @discardableResult
-    public static func completeSubscriptionPurchase() async -> Result<PurchaseUpdate, AppStorePurchaseFlow.Error> {
+    public static func completeSubscriptionPurchase(with transactionJWS: TransactionJWS) async -> Result<PurchaseUpdate, AppStorePurchaseFlow.Error> {
         os_log(.info, log: .subscription, "[AppStorePurchaseFlow] completeSubscriptionPurchase")
 
-        let result = await AccountManager.checkForEntitlements(wait: 2.0, retry: 20)
+        guard let accessToken = AccountManager().accessToken else { return .failure(.missingEntitlements) }
+
+        let result: Bool
+
+        switch await SubscriptionService.confirmPurchase(accessToken: accessToken, signature: transactionJWS) {
+        case .success(let response):
+            result = true
+        case .failure(let error):
+            result = false
+        }
 
         return result ? .success(PurchaseUpdate(type: "completed")) : .failure(.missingEntitlements)
     }
+
 }

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -118,7 +118,7 @@ public final class AppStorePurchaseFlow {
 
         guard let accessToken = AccountManager().accessToken else { return .failure(.missingEntitlements) }
 
-        let result = await callWithRetries(wait: 0.5, retry: 3) {
+        let result = await callWithRetries(retry: 5, wait: 2.0) {
             switch await SubscriptionService.confirmPurchase(accessToken: accessToken, signature: transactionJWS) {
             case .success:
                 return true
@@ -130,7 +130,7 @@ public final class AppStorePurchaseFlow {
         return result ? .success(PurchaseUpdate(type: "completed")) : .failure(.missingEntitlements)
     }
 
-    private static func callWithRetries(wait waitTime: Double, retry retryCount: Int, conditionToCheck: () async -> Bool) async -> Bool {
+    private static func callWithRetries(retry retryCount: Int, wait waitTime: Double, conditionToCheck: () async -> Bool) async -> Bool {
         var count = 0
         var successful = false
 

--- a/Sources/Subscription/Flows/AppStore/AppStoreRestoreFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStoreRestoreFlow.swift
@@ -78,7 +78,7 @@ public final class AppStoreRestoreFlow {
 
         var isSubscriptionActive = false
 
-        switch await SubscriptionService.getSubscriptionDetails(token: accessToken) {
+        switch await SubscriptionService.getSubscription(accessToken: accessToken) {
         case .success(let subscription):
             isSubscriptionActive = subscription.isActive
         case .failure:

--- a/Sources/Subscription/Flows/AppStore/AppStoreRestoreFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStoreRestoreFlow.swift
@@ -79,8 +79,8 @@ public final class AppStoreRestoreFlow {
         var isSubscriptionActive = false
 
         switch await SubscriptionService.getSubscriptionDetails(token: accessToken) {
-        case .success(let response):
-            isSubscriptionActive = response.isSubscriptionActive
+        case .success(let subscription):
+            isSubscriptionActive = subscription.isActive
         case .failure:
             os_log(.error, log: .subscription, "[AppStoreRestoreFlow] Error: failedToFetchSubscriptionDetails")
             return .failure(.failedToFetchSubscriptionDetails)

--- a/Sources/Subscription/Services/Model/Entitlement.swift
+++ b/Sources/Subscription/Services/Model/Entitlement.swift
@@ -1,0 +1,24 @@
+//
+//  Entitlement.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct Entitlement: Decodable {
+    let name: String
+    let product: String
+}

--- a/Sources/Subscription/Services/Model/Subscription.swift
+++ b/Sources/Subscription/Services/Model/Subscription.swift
@@ -1,0 +1,65 @@
+//
+//  Subscription.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct Subscription: Codable {
+    public let productId: String
+    public let name: String
+    public let billingPeriod: BillingPeriod
+    public let startedAt: Date
+    public let expiresOrRenewsAt: Date
+    public let platform: Platform
+    public let status: Status
+
+    public enum BillingPeriod: String, Codable {
+        case monthly = "Monthly"
+        case yearly = "Yearly"
+        case unknown
+
+        public init(from decoder: Decoder) throws {
+            self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+        }
+    }
+
+    public enum Platform: String, Codable {
+        case apple, google, stripe
+        case unknown
+
+        public init(from decoder: Decoder) throws {
+            self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+        }
+    }
+
+    public enum Status: String, Codable {
+        case autoRenewable = "Auto-Renewable"
+        case notAutoRenewable = "Not Auto-Renewable"
+        case gracePeriod = "Grace Period"
+        case inactive = "Inactive"
+        case expired = "Expired"
+        case unknown
+
+        public init(from decoder: Decoder) throws {
+            self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+        }
+    }
+
+    public var isActive: Bool {
+        status != .expired && status != .inactive
+    }
+}

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -50,51 +50,7 @@ public struct SubscriptionService: APIService {
         return result
     }
 
-    public struct GetSubscriptionDetailsResponse: Decodable {
-        public let productId: String
-        public let name: String
-        public let billingPeriod: BillingPeriod
-        public let startedAt: Date
-        public let expiresOrRenewsAt: Date
-        public let platform: Platform
-        public let status: Status
-
-        public var isSubscriptionActive: Bool {
-            status != .expired && status != .inactive
-        }
-
-        public enum BillingPeriod: String, Codable {
-            case monthly = "Monthly"
-            case yearly = "Yearly"
-            case unknown
-
-            public init(from decoder: Decoder) throws {
-                self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
-            }
-        }
-
-        public enum Platform: String, Codable {
-            case apple, google, stripe
-            case unknown
-
-            public init(from decoder: Decoder) throws {
-                self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
-            }
-        }
-
-        public enum Status: String, Codable {
-            case autoRenewable = "Auto-Renewable"
-            case notAutoRenewable = "Not Auto-Renewable"
-            case gracePeriod = "Grace Period"
-            case inactive = "Inactive"
-            case expired = "Expired"
-            case unknown
-
-            public init(from decoder: Decoder) throws {
-                self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
-            }
-        }
-    }
+    public typealias GetSubscriptionDetailsResponse = Subscription
 
     public static var cachedSubscriptionDetailsResponse: GetSubscriptionDetailsResponse?
 
@@ -139,11 +95,6 @@ public struct SubscriptionService: APIService {
     public struct ConfirmPurchaseResponse: Decodable {
         public let email: String?
         public let entitlements: [Entitlement]
-        public let subscription: GetSubscriptionDetailsResponse
-
-        public struct Entitlement: Decodable {
-            let name: String
-            let product: String
-        }
+        public let subscription: Subscription
     }
 }

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -37,22 +37,22 @@ public struct SubscriptionService: APIService {
 
     // MARK: -
 
-    public static func getSubscriptionDetails(token: String) async -> Result<GetSubscriptionDetailsResponse, APIServiceError> {
-        let result: Result<GetSubscriptionDetailsResponse, APIServiceError> = await executeAPICall(method: "GET", endpoint: "subscription", headers: makeAuthorizationHeader(for: token))
+    public static func getSubscription(accessToken: String) async -> Result<GetSubscriptionResponse, APIServiceError> {
+        let result: Result<GetSubscriptionResponse, APIServiceError> = await executeAPICall(method: "GET", endpoint: "subscription", headers: makeAuthorizationHeader(for: accessToken))
 
         switch result {
         case .success(let response):
-            cachedSubscriptionDetailsResponse = response
+            cachedGetSubscriptionResponse = response
         case .failure:
-            cachedSubscriptionDetailsResponse = nil
+            cachedGetSubscriptionResponse = nil
         }
 
         return result
     }
 
-    public typealias GetSubscriptionDetailsResponse = Subscription
+    public typealias GetSubscriptionResponse = Subscription
 
-    public static var cachedSubscriptionDetailsResponse: GetSubscriptionDetailsResponse?
+    public static var cachedGetSubscriptionResponse: GetSubscriptionResponse?
 
     // MARK: -
 

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -52,17 +52,42 @@ public struct SubscriptionService: APIService {
 
     public struct GetSubscriptionDetailsResponse: Decodable {
         public let productId: String
+        public let name: String
+        public let billingPeriod: BillingPeriod
         public let startedAt: Date
         public let expiresOrRenewsAt: Date
         public let platform: Platform
-        public let status: String
+        public let status: Status
 
         public var isSubscriptionActive: Bool {
-            status.lowercased() != "expired" && status.lowercased() != "inactive"
+            status != .expired && status != .inactive
+        }
+
+        public enum BillingPeriod: String, Codable {
+            case monthly = "Monthly"
+            case yearly = "Yearly"
+            case unknown
+
+            public init(from decoder: Decoder) throws {
+                self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+            }
         }
 
         public enum Platform: String, Codable {
             case apple, google, stripe
+            case unknown
+
+            public init(from decoder: Decoder) throws {
+                self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+            }
+        }
+
+        public enum Status: String, Codable {
+            case autoRenewable = "Auto-Renewable"
+            case notAutoRenewable = "Not Auto-Renewable"
+            case gracePeriod = "Grace Period"
+            case inactive = "Inactive"
+            case expired = "Expired"
             case unknown
 
             public init(from decoder: Decoder) throws {

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -126,4 +126,24 @@ public struct SubscriptionService: APIService {
         public let customerPortalUrl: String
     }
 
+    // MARK: -
+
+    public static func confirmPurchase(accessToken: String, signature: String) async -> Result<ConfirmPurchaseResponse, APIServiceError> {
+        let headers = makeAuthorizationHeader(for: accessToken)
+        let bodyDict = ["signedTransactionInfo": signature]
+
+        guard let bodyData = try? JSONEncoder().encode(bodyDict) else { return .failure(.encodingError) }
+        return await executeAPICall(method: "POST", endpoint: "purchase/confirm/apple", headers: headers, body: bodyData)
+    }
+
+    public struct ConfirmPurchaseResponse: Decodable {
+        public let email: String?
+        public let entitlements: [Entitlement]
+        public let subscription: GetSubscriptionDetailsResponse
+
+        public struct Entitlement: Decodable {
+            let name: String
+            let product: String
+        }
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206773931481624/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2541
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2325
What kind of version bump will this require?: Major

**Description**:
Integrate confirm entitlements endpoint for macOS App Store purchase with additional retries in case of failure.

**Steps to test this PR**:
See iOS and macOS PRs.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
