### PR TITLE
Remove isSubscriptionEnabled check when attempting to delete NetP token

### DIFF
--- a/Sources/NetworkProtection/KeyManagement/NetworkProtectionTokenStore.swift
+++ b/Sources/NetworkProtection/KeyManagement/NetworkProtectionTokenStore.swift
@@ -92,7 +92,11 @@ public final class NetworkProtectionKeychainTokenStore: NetworkProtectionTokenSt
     public func deleteToken() throws {
         do {
             // Skip deleting DDG-access-token as it's used for entitlement validity check
-            guard isSubscriptionEnabled, let token = try? fetchToken(), !Self.isSubscriptionAccessToken(token) else { return }
+            // todo - https://app.asana.com/0/0/1206541966681608/f
+            if let token = try? fetchToken(), Self.isSubscriptionAccessToken(token) {
+                return
+            }
+
             try keychainStore.deleteAll()
         } catch {
             handle(error)

--- a/Tests/NetworkProtectionTests/Mocks/NetworkProtectionTokenStoreMocks.swift
+++ b/Tests/NetworkProtectionTests/Mocks/NetworkProtectionTokenStoreMocks.swift
@@ -32,7 +32,9 @@ final class NetworkProtectionTokenStoreMock: NetworkProtectionTokenStore {
     }
 
     func deleteToken() {
-        guard let token = fetchToken(), !Self.isSubscriptionAccessToken(token) else { return }
+        if let token = fetchToken(), Self.isSubscriptionAccessToken(token) {
+            return
+        }
         self.token = nil
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203137811378537/1206780414627528/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2548
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2332
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
