### PR TITLE
Move vpnFirstEnabled and networkPathChange out of VPNSettings

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -931,8 +931,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 .setRegistrationKeyValidity,
                 .setSelectedEnvironment,
                 .setShowInMenuBar,
-                .setVPNFirstEnabled,
-                .setNetworkPathChange,
                 .setDisableRekeying:
             // Intentional no-op, as some setting changes don't require any further operation
             completionHandler?(nil)

--- a/Sources/NetworkProtection/Settings/Extensions/UserDefaults+networkPathChange.swift
+++ b/Sources/NetworkProtection/Settings/Extensions/UserDefaults+networkPathChange.swift
@@ -41,7 +41,7 @@ extension UserDefaults {
     }
 
     @objc
-    private(set) dynamic var networkPathChange: NetworkPathChange? {
+    public dynamic var networkPathChange: NetworkPathChange? {
         get {
             guard let data = data(forKey: networkPathChangeKey) else { return nil }
             return try? JSONDecoder().decode(NetworkPathChange.self, from: data)

--- a/Sources/NetworkProtection/Settings/Extensions/UserDefaults+networkPathChange.swift
+++ b/Sources/NetworkProtection/Settings/Extensions/UserDefaults+networkPathChange.swift
@@ -41,7 +41,7 @@ extension UserDefaults {
     }
 
     @objc
-    dynamic var networkPathChange: NetworkPathChange? {
+    private(set) dynamic var networkPathChange: NetworkPathChange? {
         get {
             guard let data = data(forKey: networkPathChangeKey) else { return nil }
             return try? JSONDecoder().decode(NetworkPathChange.self, from: data)
@@ -53,7 +53,8 @@ extension UserDefaults {
         }
     }
 
-    var networkPathChangePublisher: AnyPublisher<NetworkPathChange?, Never> {
-        publisher(for: \.networkPathChange).eraseToAnyPublisher()
+    public func updateNetworkPath(with newPath: String?) {
+        networkPathChange = NetworkPathChange(oldPath: networkPathChange?.newPath ?? "unknown",
+                                              newPath: newPath ?? "unknown")
     }
 }

--- a/Sources/NetworkProtection/Settings/Extensions/UserDefaults+vpnFirstEnabled.swift
+++ b/Sources/NetworkProtection/Settings/Extensions/UserDefaults+vpnFirstEnabled.swift
@@ -25,7 +25,7 @@ extension UserDefaults {
     }
 
     @objc
-    dynamic var vpnFirstEnabled: Date? {
+    public dynamic var vpnFirstEnabled: Date? {
         get {
             value(forKey: vpnFirstEnabledKey) as? Date
         }
@@ -33,9 +33,5 @@ extension UserDefaults {
         set {
             set(newValue, forKey: vpnFirstEnabledKey)
         }
-    }
-
-    var vpnFirstEnabledPublisher: AnyPublisher<Date?, Never> {
-        publisher(for: \.vpnFirstEnabled).eraseToAnyPublisher()
     }
 }

--- a/Sources/NetworkProtection/Settings/VPNSettings.swift
+++ b/Sources/NetworkProtection/Settings/VPNSettings.swift
@@ -39,8 +39,6 @@ public final class VPNSettings {
         case setSelectedLocation(_ selectedLocation: SelectedLocation)
         case setSelectedEnvironment(_ selectedEnvironment: SelectedEnvironment)
         case setShowInMenuBar(_ showInMenuBar: Bool)
-        case setVPNFirstEnabled(_ vpnFirstEnabled: Date?)
-        case setNetworkPathChange(_ newPath: String?)
         case setDisableRekeying(_ disableRekeying: Bool)
     }
 
@@ -163,20 +161,6 @@ public final class VPNSettings {
                 Change.setShowInMenuBar(showInMenuBar)
             }.eraseToAnyPublisher()
 
-        let vpnFirstEnabledPublisher = vpnFirstEnabledPublisher
-            .dropFirst()
-            .removeDuplicates()
-            .map { vpnFirstEnabled in
-                Change.setVPNFirstEnabled(vpnFirstEnabled)
-            }.eraseToAnyPublisher()
-
-        let networkPathChangePublisher = networkPathChangePublisher
-            .dropFirst()
-            .removeDuplicates()
-            .map { networkPathChange in
-                Change.setNetworkPathChange(networkPathChange?.newPath)
-            }.eraseToAnyPublisher()
-
         let disableRekeyingPublisher = disableRekeyingPublisher
             .dropFirst()
             .removeDuplicates()
@@ -194,8 +178,6 @@ public final class VPNSettings {
             locationChangePublisher,
             environmentChangePublisher,
             showInMenuBarPublisher,
-            vpnFirstEnabledPublisher,
-            networkPathChangePublisher,
             disableRekeyingPublisher).eraseToAnyPublisher()
     }()
 
@@ -242,12 +224,6 @@ public final class VPNSettings {
             self.selectedEnvironment = selectedEnvironment
         case .setShowInMenuBar(let showInMenuBar):
             self.showInMenuBar = showInMenuBar
-        case .setVPNFirstEnabled(let vpnFirstEnabled):
-            self.vpnFirstEnabled = vpnFirstEnabled
-        case .setNetworkPathChange(let newPath):
-            self.networkPathChange = UserDefaults.NetworkPathChange(
-                oldPath: networkPathChange?.newPath ?? "unknown",
-                newPath: newPath ?? "unknown")
         case .setDisableRekeying(let disableRekeying):
             self.disableRekeying = disableRekeying
         }
@@ -439,38 +415,6 @@ public final class VPNSettings {
             case .range(let range, _):
                 return range
             }
-        }
-    }
-
-    // MARK: - First time VPN is enabled
-
-    public var vpnFirstEnabledPublisher: AnyPublisher<Date?, Never> {
-        defaults.vpnFirstEnabledPublisher
-    }
-
-    public var vpnFirstEnabled: Date? {
-        get {
-            defaults.vpnFirstEnabled
-        }
-
-        set {
-            defaults.vpnFirstEnabled = newValue
-        }
-    }
-
-    // MARK: - Network path change info
-
-    public var networkPathChangePublisher: AnyPublisher<UserDefaults.NetworkPathChange?, Never> {
-        defaults.networkPathChangePublisher
-    }
-
-    public var networkPathChange: UserDefaults.NetworkPathChange? {
-        get {
-            defaults.networkPathChange
-        }
-
-        set {
-            defaults.networkPathChange = newValue
         }
     }
 

--- a/Sources/Subscription/Services/AuthService.swift
+++ b/Sources/Subscription/Services/AuthService.swift
@@ -65,12 +65,6 @@ public struct AuthService: APIService {
                 case email, entitlements, externalID = "externalId" // no underscores due to keyDecodingStrategy = .convertFromSnakeCase
             }
         }
-
-        struct Entitlement: Decodable {
-            let id: Int
-            let name: String
-            let product: String
-        }
     }
     // swiftlint:enable nesting
 

--- a/Sources/Subscription/Services/Model/Entitlement.swift
+++ b/Sources/Subscription/Services/Model/Entitlement.swift
@@ -18,7 +18,19 @@
 
 import Foundation
 
-public struct Entitlement: Decodable {
+public struct Entitlement: Codable, Equatable {
+    let id: Int
     let name: String
-    let product: String
+    public let product: ProductName
+
+    public enum ProductName: String, Codable {
+        case networkProtection = "Network Protection"
+        case dataBrokerProtection = "Data Broker Protection"
+        case identityTheftRestoration = "Identity Theft Restoration"
+        case unknown
+
+        public init(from decoder: Decoder) throws {
+            self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+        }
+    }
 }

--- a/Sources/Subscription/UserDefaultsCache.swift
+++ b/Sources/Subscription/UserDefaultsCache.swift
@@ -1,0 +1,62 @@
+//
+//  UserDefaultsCache.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public enum UserDefaultsCacheKey: String {
+    case subscriptionEntitlements
+}
+
+/// A generic UserDefaults cache for storing and retrieving Codable objects.
+public class UserDefaultsCache<ObjectType: Codable> {
+    private var subscriptionAppGroup: String
+    private lazy var userDefaults: UserDefaults? = UserDefaults(suiteName: subscriptionAppGroup)
+    private let key: UserDefaultsCacheKey
+
+    public init(subscriptionAppGroup: String, key: UserDefaultsCacheKey) {
+        self.subscriptionAppGroup = subscriptionAppGroup
+        self.key = key
+    }
+
+    public func set(_ object: ObjectType) {
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(object)
+            userDefaults?.set(data, forKey: key.rawValue)
+        } catch {
+            assertionFailure("Failed to encode object of type \(ObjectType.self): \(error)")
+        }
+    }
+
+    public func get() -> ObjectType? {
+        guard let data = userDefaults?.data(forKey: key.rawValue) else { return nil }
+        let decoder = JSONDecoder()
+        do {
+            let object = try decoder.decode(ObjectType.self, from: data)
+            return object
+        } catch {
+            assertionFailure("Failed to decode object of type \(ObjectType.self): \(error)")
+            return nil
+        }
+    }
+
+    public func reset() {
+        userDefaults?.removeObject(forKey: key.rawValue)
+    }
+
+}


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1206780414627545/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2560
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2351
What kind of version bump will this require?: Major

**Optional**:

Tech Design URL:
CC:

**Description**:

This PR makes `vpnFirstEnabled` and `networkPathChange` accessible via UserDefaults.netP instead of VPNSettings.

**Steps to test this PR**:
1. Green CI

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
