### PR TITLE
RMF update adding build number to app version check

### DIFF
--- a/Sources/RemoteMessaging/Matchers/AppAttributeMatcher.swift
+++ b/Sources/RemoteMessaging/Matchers/AppAttributeMatcher.swift
@@ -33,7 +33,7 @@ public struct AppAttributeMatcher: AttributeMatcher {
             assertionFailure("BundleIdentifier should not be empty")
         }
         self.init(bundleId: AppVersion.shared.identifier,
-                  appVersion: AppVersion.shared.versionNumber,
+                  appVersion: AppVersion.shared.versionAndBuildNumber,
                   isInternalUser: isInternalUser,
                   statisticsStore: statisticsStore,
                   variantManager: variantManager)

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Matchers/AppAttributeMatcherTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Matchers/AppAttributeMatcherTests.swift
@@ -66,7 +66,7 @@ class AppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionEqualOrLowerThanMaxThenReturnMatch() throws {
-        let appVersionComponents = AppVersion.shared.versionNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
         let appMajorVersion = appVersionComponents[0]
         let appMinorVersion = appVersionComponents.suffix(from: 1).joined(separator: ".")
 
@@ -82,7 +82,7 @@ class AppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionGreaterThanMaxThenReturnFail() throws {
-        let appVersionComponents = AppVersion.shared.versionNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
         let appMajorVersion = appVersionComponents[0]
         let lessThanMax = String(Int(appMajorVersion)! - 1)
 
@@ -91,12 +91,12 @@ class AppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionEqualOrGreaterThanMinThenReturnMatch() throws {
-        XCTAssertEqual(matcher.evaluate(matchingAttribute: AppVersionMatchingAttribute(min: AppVersion.shared.versionNumber, fallback: nil)),
+        XCTAssertEqual(matcher.evaluate(matchingAttribute: AppVersionMatchingAttribute(min: AppVersion.shared.versionAndBuildNumber, fallback: nil)),
                        .match)
     }
 
     func testWhenAppVersionLowerThanMinThenReturnFail() throws {
-        let appVersionComponents = AppVersion.shared.versionNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
         let appMajorVersion = appVersionComponents[0]
         let greaterThanMax = String(Int(appMajorVersion)! + 1)
         let greaterThanMinorVersion = Float(appVersionComponents.suffix(from: 1).joined(separator: "."))! + 0.1
@@ -107,7 +107,7 @@ class AppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionInRangeThenReturnMatch() throws {
-        let appVersionComponents = AppVersion.shared.versionNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
         let appMajorVersion = appVersionComponents[0]
         let greaterThanMax = String(Int(appMajorVersion)! + 1)
         let lessThanMinorVersion = Float(appVersionComponents.suffix(from: 1).joined(separator: "."))! - 0.1
@@ -117,8 +117,8 @@ class AppAttributeMatcherTests: XCTestCase {
                        .match)
     }
 
-    func testWhenAppVersionNotInRangeThenReturnMatch() throws {
-        let appVersionComponents = AppVersion.shared.versionNumber.components(separatedBy: ".").map { $0 }
+    func testWhenAppVersionNotInRangeThenReturnFail() throws {
+        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
         let appMajorVersion = appVersionComponents[0]
         let greaterThanMax = String(Int(appMajorVersion)! + 1)
 
@@ -127,12 +127,12 @@ class AppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionSameAsDeviceThenReturnMatch() throws {
-        XCTAssertEqual(matcher.evaluate(matchingAttribute: AppVersionMatchingAttribute(min: AppVersion.shared.versionNumber, max: AppVersion.shared.versionNumber, fallback: nil)),
+        XCTAssertEqual(matcher.evaluate(matchingAttribute: AppVersionMatchingAttribute(min: AppVersion.shared.versionAndBuildNumber, max: AppVersion.shared.versionAndBuildNumber, fallback: nil)),
                        .match)
     }
 
     func testWhenAppVersionDifferentToDeviceThenReturnFail() throws {
-        let appVersionComponents = AppVersion.shared.versionNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
         let appMajorVersion = appVersionComponents[0]
         let lessThanMinorVersion = Float(appVersionComponents.suffix(from: 1).joined(separator: "."))! - 0.1
         let minBumped = "\(appMajorVersion).\(lessThanMinorVersion)"

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Model/RangeStringMatchingAttributeTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Model/RangeStringMatchingAttributeTests.swift
@@ -37,6 +37,10 @@ class RangeStringMatchingAttributeTests: XCTestCase {
         XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "0", max: "2").matches(value: "1.44"), .match)
         XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "0", max: "2").matches(value: "1.88"), .match)
         XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "0", max: "2").matches(value: "1.44.88"), .match)
+        XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "1.44.88", max: "2").matches(value: "1.44.88.0"), .match)
+        XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "1.44.88", max: "2").matches(value: "1.44.88.1"), .match)
+        XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "1.44.88.0", max: "2").matches(value: "1.44.88.0"), .match)
+        XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "1.44.88.0", max: "2").matches(value: "1.44.88.1"), .match)
     }
 
     func testWhenVersionOutsideMinMaxShouldFail() throws {
@@ -44,5 +48,9 @@ class RangeStringMatchingAttributeTests: XCTestCase {
         XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "2.88", max: "8.88").matches(value: "88.88"), .fail)
         XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "44.44", max: "88.88").matches(value: "0.1"), .fail)
         XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "44.44", max: "88.88").matches(value: "22.22"), .fail)
+        XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "1.44.89", max: "2").matches(value: "1.44.88.1"), .fail)
+        XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "1.44.88.1", max: "2").matches(value: "1.44.88"), .fail)
+        XCTAssertEqual(RangeStringNumericMatchingAttribute(min: "1.44.88.1", max: "2").matches(value: "1.44.88.0"), .fail)
+
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1206415339617270/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2564
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2362
What kind of version bump will this require?: Patch

**Description**:
Updates RMF to include the build number when performing an app version comparison

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
