### PR TITLE
Renames "Network Protection" to "VPN" in all user-facing text

### DIFF
--- a/Sources/NetworkProtection/Controllers/TunnelController.swift
+++ b/Sources/NetworkProtection/Controllers/TunnelController.swift
@@ -25,11 +25,11 @@ public protocol TunnelController {
 
     // MARK: - Starting & Stopping the VPN
 
-    /// Starts the VPN connection used for Network Protection
+    /// Starts the VPN connection
     ///
     func start() async
 
-    /// Stops the VPN connection used for Network Protection
+    /// Stops the VPN connection
     ///
     func stop() async
 

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionConnectionTester.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionConnectionTester.swift
@@ -21,7 +21,7 @@ import Network
 import NetworkExtension
 import Common
 
-/// This class takes care of testing whether the Network Protection connection is working or not.  Results are handled by
+/// This class takes care of testing whether the VPN connection is working or not.  Results are handled by
 /// an injected object that implements ``NetworkProtectionConnectionTestResultsHandler``.
 ///
 /// In order to test that the connection is working, this class test creating a TCP connection to "www.duckduckgo.com" using

--- a/Sources/NetworkProtection/FeatureActivation/NetworkProtectionCodeRedemptionCoordinator.swift
+++ b/Sources/NetworkProtection/FeatureActivation/NetworkProtectionCodeRedemptionCoordinator.swift
@@ -21,7 +21,7 @@ import Common
 
 public protocol NetworkProtectionCodeRedeeming {
 
-    /// Redeems an invite code with the Network Protection backend and stores the resulting auth token
+    /// Redeems an invite code with the VPN backend and stores the resulting auth token
     func redeem(_ code: String) async throws
 
     /// Exchanges an access token for an auth token, and stores the resulting auth token

--- a/Sources/NetworkProtection/KeyManagement/NetworkProtectionKeyStore.swift
+++ b/Sources/NetworkProtection/KeyManagement/NetworkProtectionKeyStore.swift
@@ -42,7 +42,7 @@ public protocol NetworkProtectionKeyStore {
     func resetCurrentKeyPair()
 }
 
-/// Generates and stores instances of a PrivateKey on behalf of the user. This key is used to derive a PublicKey which is then used for registration with the Network Protection backend servers.
+/// Generates and stores instances of a PrivateKey on behalf of the user. This key is used to derive a PublicKey which is then used for registration with the VPN backend servers.
 /// The key is reused between servers (that is, each user currently gets a single key), though this will change in the future to periodically refresh the key.
 public final class NetworkProtectionKeychainKeyStore: NetworkProtectionKeyStore {
     private let keychainStore: NetworkProtectionKeychainStore
@@ -225,7 +225,7 @@ public final class NetworkProtectionKeychainKeyStore: NetworkProtectionKeyStore 
 
     private func handle(_ error: Error) {
         guard let error = error as? NetworkProtectionKeychainStoreError else {
-            assertionFailure("Failed to cast Network Protection Keychain store error")
+            assertionFailure("Failed to cast VPN Keychain store error")
             errorEvents?.fire(NetworkProtectionError.unhandledError(function: #function, line: #line, error: error))
             return
         }

--- a/Sources/NetworkProtection/KeyManagement/NetworkProtectionTokenStore.swift
+++ b/Sources/NetworkProtection/KeyManagement/NetworkProtectionTokenStore.swift
@@ -44,7 +44,7 @@ public protocol NetworkProtectionTokenStore {
     static func isSubscriptionAccessToken(_ token: String) -> Bool
 }
 
-/// Store an auth token for NetworkProtection on behalf of the user. This key is then used to authenticate requests for registration and server fetches from the Network Protection backend servers.
+/// Store an auth token for NetworkProtection on behalf of the user. This key is then used to authenticate requests for registration and server fetches from the VPN backend servers.
 /// Writing a new auth token will replace the old one.
 public final class NetworkProtectionKeychainTokenStore: NetworkProtectionTokenStore {
     private let keychainStore: NetworkProtectionKeychainStore
@@ -108,7 +108,7 @@ public final class NetworkProtectionKeychainTokenStore: NetworkProtectionTokenSt
 
     private func handle(_ error: Error) {
         guard let error = error as? NetworkProtectionKeychainStoreError else {
-            assertionFailure("Failed to cast Network Protection Token store error")
+            assertionFailure("Failed to cast VPN Token store error")
             errorEvents?.fire(NetworkProtectionError.unhandledError(function: #function, line: #line, error: error))
             return
         }

--- a/Sources/NetworkProtection/Logging/Logging.swift
+++ b/Sources/NetworkProtection/Logging/Logging.swift
@@ -79,41 +79,41 @@ struct Logging {
     static let subsystem = "com.duckduckgo.macos.browser.network-protection"
 
     fileprivate static let networkProtectionLoggingEnabled = true
-    fileprivate static let networkProtection: OSLog = OSLog(subsystem: subsystem, category: "Network Protection")
+    fileprivate static let networkProtection: OSLog = OSLog(subsystem: subsystem, category: "VPN")
 
     fileprivate static let networkProtectionBandwidthAnalysisLoggingEnabled = true
-    fileprivate static let networkProtectionBandwidthAnalysis: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Bandwidth Analysis")
+    fileprivate static let networkProtectionBandwidthAnalysis: OSLog = OSLog(subsystem: subsystem, category: "VPN: Bandwidth Analysis")
 
     fileprivate static let networkProtectionLatencyMonitorLoggingEnabled = true
-    fileprivate static let networkProtectionLatencyMonitor: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Latency Monitor")
+    fileprivate static let networkProtectionLatencyMonitor: OSLog = OSLog(subsystem: subsystem, category: "VPN: Latency Monitor")
 
     fileprivate static let networkProtectionTunnelFailureMonitorLoggingEnabled = true
-    fileprivate static let networkProtectionTunnelFailureMonitor: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Tunnel Failure Monitor")
+    fileprivate static let networkProtectionTunnelFailureMonitor: OSLog = OSLog(subsystem: subsystem, category: "VPN: Tunnel Failure Monitor")
 
     fileprivate static let networkProtectionConnectionTesterLoggingEnabled = true
-    fileprivate static let networkProtectionConnectionTesterLog: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Connection Tester")
+    fileprivate static let networkProtectionConnectionTesterLog: OSLog = OSLog(subsystem: subsystem, category: "VPN: Connection Tester")
 
     fileprivate static let networkProtectionDistributedNotificationsLoggingEnabled = true
-    fileprivate static let networkProtectionDistributedNotificationsLog: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Distributed Notifications")
+    fileprivate static let networkProtectionDistributedNotificationsLog: OSLog = OSLog(subsystem: subsystem, category: "VPN: Distributed Notifications")
 
     fileprivate static let networkProtectionIPCLoggingEnabled = true
-    fileprivate static let networkProtectionIPCLog: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: IPC")
+    fileprivate static let networkProtectionIPCLog: OSLog = OSLog(subsystem: subsystem, category: "VPN: IPC")
 
     fileprivate static let networkProtectionKeyManagementLoggingEnabled = true
-    fileprivate static let networkProtectionKeyManagement: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Key Management")
+    fileprivate static let networkProtectionKeyManagement: OSLog = OSLog(subsystem: subsystem, category: "VPN: Key Management")
 
     fileprivate static let networkProtectionMemoryLoggingEnabled = true
-    fileprivate static let networkProtectionMemoryLog: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Memory")
+    fileprivate static let networkProtectionMemoryLog: OSLog = OSLog(subsystem: subsystem, category: "VPN: Memory")
 
     fileprivate static let networkProtectionPixelLoggingEnabled = true
-    fileprivate static let networkProtectionPixel: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Pixel")
+    fileprivate static let networkProtectionPixel: OSLog = OSLog(subsystem: subsystem, category: "VPN: Pixel")
 
     fileprivate static let networkProtectionStatusReporterLoggingEnabled = true
-    fileprivate static let networkProtectionStatusReporterLog: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Status Reporter")
+    fileprivate static let networkProtectionStatusReporterLog: OSLog = OSLog(subsystem: subsystem, category: "VPN: Status Reporter")
 
     fileprivate static let networkProtectionSleepLoggingEnabled = true
-    fileprivate static let networkProtectionSleepLog: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Sleep and Wake")
+    fileprivate static let networkProtectionSleepLog: OSLog = OSLog(subsystem: subsystem, category: "VPN: Sleep and Wake")
 
     fileprivate static let networkProtectionEntitlementLoggingEnabled = true
-    fileprivate static let networkProtectionEntitlementLog: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Entitlement Monitor")
+    fileprivate static let networkProtectionEntitlementLog: OSLog = OSLog(subsystem: subsystem, category: "VPN: Entitlement Monitor")
 }

--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -121,7 +121,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
         return completeServerList
     }
 
-    /// Registers the device with the Network Protection backend.
+    /// Registers the device with the VPN backend.
     ///
     /// The flow for registration is as follows:
     /// 1. Look for an existing private key, and if one does not exist then generate it and store it in the Keychain
@@ -310,7 +310,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
                                                dns: [DNSServer(address: server.serverInfo.internalIP)],
                                                isKillSwitchEnabled: isKillSwitchEnabled)
 
-        return TunnelConfiguration(name: "Network Protection", interface: interface, peers: [peerConfiguration])
+        return TunnelConfiguration(name: "DuckDuckGo VPN", interface: interface, peers: [peerConfiguration])
     }
 
     func peerConfiguration(serverPublicKey: PublicKey, serverEndpoint: Endpoint) -> PeerConfiguration {

--- a/Sources/NetworkProtection/Notifications/DistributedNotificationObjectCoders.swift
+++ b/Sources/NetworkProtection/Notifications/DistributedNotificationObjectCoders.swift
@@ -53,7 +53,7 @@ public struct DistributedNotificationObjectDecoder<T: Decodable> {
 
     public init() {}
 
-    /// Decodes the object from a Network Protection distributed notification.
+    /// Decodes the object from a VPN distributed notification.
     ///
     public func decodeObject(from notification: Notification) throws -> T {
         guard let string = notification.object as? String else {
@@ -63,7 +63,7 @@ public struct DistributedNotificationObjectDecoder<T: Decodable> {
         return try decode(string)
     }
 
-    /// Decodes the object from a Network Protection distributed notification.
+    /// Decodes the object from a VPN distributed notification.
     ///
     public func decode(_ payload: String) throws -> T {
         let jsonData = payload.data(using: defaultJSONEncoding)!

--- a/Sources/NetworkProtection/Storage/NetworkProtectionServerListStore.swift
+++ b/Sources/NetworkProtection/Storage/NetworkProtectionServerListStore.swift
@@ -21,13 +21,13 @@ import Foundation
 
 public protocol NetworkProtectionServerListStore {
 
-    /// Replace the existing stored Network Protection server list, if one exists. If any servers exist on disk but not in this array, then the ones on disk will be removed.
+    /// Replace the existing stored VPN server list, if one exists. If any servers exist on disk but not in this array, then the ones on disk will be removed.
     func store(serverList: [NetworkProtectionServer]) throws
 
     /// Update the existing server cache with a list of registered servers. This will update existing servers if they are found, or will add them into the list otherwise.
     func updateServerListCache(with registeredServers: [NetworkProtectionServer]) throws
 
-    /// Returns the list of stored Network Protection servers.
+    /// Returns the list of stored VPN servers.
     ///
     /// - Note: This list is sorted by server name alphabetically.
     func storedNetworkProtectionServerList() throws -> [NetworkProtectionServer]
@@ -54,7 +54,7 @@ public enum NetworkProtectionServerListStoreError: Error, NetworkProtectionError
     }
 }
 
-/// Stores the most recent Network Protection server list.
+/// Stores the most recent VPN server list.
 ///
 /// This list is used to present a list of servers to the user. Because this list is cached, it may not represent the true list of servers and should be periodically refreshed.
 /// This list also remembers which servers have been registered with, and can be used to check whether registration is needed before connecting.

--- a/Sources/Subscription/Services/Model/Entitlement.swift
+++ b/Sources/Subscription/Services/Model/Entitlement.swift
@@ -23,7 +23,7 @@ public struct Entitlement: Codable, Equatable {
     public let product: ProductName
 
     public enum ProductName: String, Codable {
-        case networkProtection = "Network Protection"
+        case networkProtection = "VPN"
         case dataBrokerProtection = "Data Broker Protection"
         case identityTheftRestoration = "Identity Theft Restoration"
         case unknown

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Matchers/UserAttributeMatcherTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Matchers/UserAttributeMatcherTests.swift
@@ -205,7 +205,7 @@ class UserAttributeMatcherTests: XCTestCase {
                        .fail)
     }
 
-    // MARK: - Network Protection Waitlist
+    // MARK: - VPN Waitlist
 
     func testWhenIsNetPWaitlistUserMatchesThenReturnMatch() throws {
         XCTAssertEqual(userAttributeMatcher.evaluate(matchingAttribute: IsNetPWaitlistUserMatchingAttribute(value: true, fallback: nil)),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206800069675133/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2576
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2392
What kind of version bump will this require?: Patch

## Description

Updates the copy from "Network Protection" to "VPN" or "DuckDuckGo VPN"

## Testing

See platform specific PRs for validation steps.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
