### PR TITLE
macOS: Display error messaging for cancelled subscriptions 

### DIFF
--- a/Sources/NetworkProtection/AppLaunching.swift
+++ b/Sources/NetworkProtection/AppLaunching.swift
@@ -31,6 +31,7 @@ public enum AppLaunchCommand: Codable {
     case stopVPN
     case enableOnDemand
     case moveAppToApplications
+    case showPrivacyPro
 }
 
 public protocol AppLaunching {

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionEntitlementMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionEntitlementMonitor.swift
@@ -40,7 +40,7 @@ public actor NetworkProtectionEntitlementMonitor {
 
     // MARK: - Init & deinit
 
-    init() {
+    public init() {
         os_log("[+] %{public}@", log: .networkProtectionMemoryLog, type: .debug, String(describing: self))
     }
 

--- a/Sources/NetworkProtection/Notifications/NetworkProtectionNotification.swift
+++ b/Sources/NetworkProtection/Notifications/NetworkProtectionNotification.swift
@@ -107,6 +107,7 @@ public enum NetworkProtectionNotification: String {
     case showConnectedNotification
     case showIssuesNotResolvedNotification
     case showVPNSupersededNotification
+    case showExpiredEntitlementNotification
     case showTestNotification
 
     // Server Selection


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/72649045549333/1205438842252963/f
iOS PR: TODO
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2394
What kind of version bump will this require?: Major

**Optional**:

**Description**:
See macOS PR

**Steps to test this PR**:
See macOS PR. iOS should just compile.

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
