### PR TITLE
Fix VPN rekeying

### DIFF
--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -146,7 +146,11 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
 
         keyStore.updateKeyPair(keyPair)
 
-        if let newExpiration {
+        // We only update the expiration date if it happens before our client-set expiration date.
+        // This way we respect the client-set expiration date, unless the server has set an earlier
+        // expiration for whatever reason (like if the subscription is known to expire).
+        //
+        if let newExpiration, newExpiration < keyPair.expirationDate {
             keyPair = KeyPair(privateKey: keyPair.privateKey, expirationDate: newExpiration)
             keyStore.updateKeyPair(keyPair)
         }
@@ -224,9 +228,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
                 // If we're looking to exclude a server we should have a few other options available.  If we can't find any
                 // then it means theres an inconsistency in the server list that was returned.
                 errorEvents?.fire(NetworkProtectionError.serverListInconsistency)
-
-                let cachedServer = try cachedServer(registeredWith: keyPair)
-                return (cachedServer, nil)
+                throw NetworkProtectionError.serverListInconsistency
             }
 
             selectedServer = registeredServer
@@ -238,9 +240,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             }
 
             handle(clientError: error)
-
-            let cachedServer = try cachedServer(registeredWith: keyPair)
-            return (cachedServer, nil)
+            throw error
         }
     }
 

--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -138,7 +138,16 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
         if regenerateKey {
             keyPair = keyStore.newKeyPair()
         } else {
-            keyPair = keyStore.currentKeyPair() ?? keyStore.newKeyPair()
+            // Temporary code added on 2024-03-12 to fix a previous issue where users had a really long
+            // key expiration date.  We should remove this after a month or so.
+            if let existingKeyPair = keyStore.currentKeyPair(),
+               existingKeyPair.expirationDate > Date().addingTimeInterval(TimeInterval.day) {
+
+                keyPair = keyStore.newKeyPair()
+            } else {
+                // This is the regular code to restore when the above code is removed.
+                keyPair = keyStore.currentKeyPair() ?? keyStore.newKeyPair()
+            }
         }
 
         let (selectedServer, newExpiration) = try await register(keyPair: keyPair, selectionMethod: selectionMethod)

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -595,7 +595,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                                                                                 serverSelectionMethod: currentServerSelectionMethod,
                                                                                 includedRoutes: includedRoutes ?? [],
                                                                                 excludedRoutes: settings.excludedRanges,
-                                                                                regenerateKey: false)
+                                                                                regenerateKey: true)
                 startTunnel(with: tunnelConfiguration, onDemand: onDemand, completionHandler: completionHandler)
                 os_log("🔵 Done generating tunnel config", log: .networkProtection, type: .info)
             } catch {


### PR DESCRIPTION
## Required

Task/Issue URL: 

iOS PR: https://github.com/duckduckgo/iOS/pull/2577
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2369
What kind of version bump will this require?: Patch

## Description

Fixes the following:
- Several users seem to be no longer rekeying in the latest releases.
- Some users seem to have trouble connecting due to these rekeying issues.

## Testing

See the platform-specific instructions for testing.

The pixels should show:

```
23:12:51.370517+0100	584: 0x35f0	com.duckduckgo.mobile.ios.NetworkExtension	default	PacketTunnelProvider	DDG General	Pixel fired m_mac_netp_rekey_attempt_c [:]
23:12:51.370672+0100	584: 0x35f0	com.duckduckgo.mobile.ios.NetworkExtension	default	PacketTunnelProvider	DDG General	Pixel fired m_netp_tunnel_update_attempt_c [:]
23:12:51.883486+0100	584: 0x35f0	com.duckduckgo.mobile.ios.NetworkExtension	default	PacketTunnelProvider	DDG General	Pixel fired m_netp_tunnel_update_success_c [:]
23:12:51.884248+0100	584: 0x35f0	com.duckduckgo.mobile.ios.NetworkExtension	default	PacketTunnelProvider	DDG General	Pixel fired m_netp_rekey_completed_c [:]
```

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
