### PR TITLE
make history entry weak to avoid retain cycle

### DIFF
--- a/Sources/History/Visit.swift
+++ b/Sources/History/Visit.swift
@@ -37,7 +37,7 @@ final public class Visit {
 
     public let date: Date
     public var identifier: ID?
-    public var historyEntry: HistoryEntry?
+    public weak var historyEntry: HistoryEntry?
 
 }
 


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1206840485929811/f
iOS PR: n/a
macOS PR: n/a
What kind of version bump will this require?: Major/Minor/Patch

**Description**:
Fix retain cycle added when moving this code to BSK

**Steps to test this PR**:
1. Drop into iOS app and macOS app and launch
1. On macOS smoke test history and check that the Visit/HistoryItems are not retained after the fire button
