### PR TITLE
Entitlements cache fixes

### DIFF
--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -242,8 +242,13 @@ public class AccountManager: AccountManaging {
         switch await AuthService.validateToken(accessToken: accessToken) {
         case .success(let response):
             let entitlements = response.account.entitlements
+
             if entitlements != cachedEntitlements {
-                entitlementsCache.set(entitlements)
+                if entitlements.isEmpty {
+                    entitlementsCache.reset()
+                } else {
+                    entitlementsCache.set(entitlements)
+                }
                 NotificationCenter.default.post(name: .entitlementsDidChange, object: self, userInfo: [UserDefaultsCacheKey.subscriptionEntitlements: entitlements])
             }
             return .success(entitlements)

--- a/Sources/Subscription/UserDefaultsCache.swift
+++ b/Sources/Subscription/UserDefaultsCache.swift
@@ -24,7 +24,7 @@ public struct UserDefaultsCacheSettings {
     // Default expiration interval set to 24 hours
     public let defaultExpirationInterval: TimeInterval
 
-    public init(defaultExpirationInterval: TimeInterval = 24 * 60 * 60) {
+    public init(defaultExpirationInterval: TimeInterval = 1 * 60 * 60) {
         self.defaultExpirationInterval = defaultExpirationInterval
     }
 }


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/1199230911884351/1206892721639727/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2620
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2465
What kind of version bump will this require?: Patch

**Description**:
Update the default cache validity time from 1 day to 1 hour.
Change the entitlements cache behaviour to not to store the empty entitlement array but instead clear the cache as this will force refetching updated ones via API.

**Steps to test this PR**:
Complete the purchase check the confirmation response it should contain the full entitlement set which should be then reflected in the UI in more menu and settings.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
