### PR TITLE
Rework the caching logic for subscription and entitlements 

### DIFF
--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -56,7 +56,9 @@ public class AccountManager: AccountManaging {
     public convenience init(subscriptionAppGroup: String) {
         let accessTokenStorage = SubscriptionTokenKeychainStorage(keychainType: .dataProtection(.named(subscriptionAppGroup)))
         self.init(accessTokenStorage: accessTokenStorage,
-                  entitlementsCache: UserDefaultsCache<[Entitlement]>(subscriptionAppGroup: subscriptionAppGroup, key: UserDefaultsCacheKey.subscriptionEntitlements))
+                  entitlementsCache: UserDefaultsCache<[Entitlement]>(subscriptionAppGroup: subscriptionAppGroup, 
+                                                                      key: UserDefaultsCacheKey.subscriptionEntitlements,
+                                                                      settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20))))
     }
 
     public init(storage: AccountStorage = AccountKeychainStorage(),

--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -53,6 +53,12 @@ public class AccountManager: AccountManaging {
         return accessToken != nil
     }
 
+    public convenience init(accessTokenStorage: SubscriptionTokenStorage) {
+        self.init(accessTokenStorage: accessTokenStorage,
+                  entitlementsCache: UserDefaultsCache<[Entitlement]>(key: UserDefaultsCacheKey.subscriptionEntitlements,
+                                                                      settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20))))
+    }
+
     public convenience init(subscriptionAppGroup: String) {
         let accessTokenStorage = SubscriptionTokenKeychainStorage(keychainType: .dataProtection(.named(subscriptionAppGroup)))
         self.init(accessTokenStorage: accessTokenStorage,

--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -62,7 +62,7 @@ public class AccountManager: AccountManaging {
     public convenience init(subscriptionAppGroup: String) {
         let accessTokenStorage = SubscriptionTokenKeychainStorage(keychainType: .dataProtection(.named(subscriptionAppGroup)))
         self.init(accessTokenStorage: accessTokenStorage,
-                  entitlementsCache: UserDefaultsCache<[Entitlement]>(subscriptionAppGroup: subscriptionAppGroup, 
+                  entitlementsCache: UserDefaultsCache<[Entitlement]>(subscriptionAppGroup: subscriptionAppGroup,
                                                                       key: UserDefaultsCacheKey.subscriptionEntitlements,
                                                                       settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20))))
     }

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -35,7 +35,8 @@ public final class SubscriptionService: APIService {
         }
     }
 
-    private static let subscriptionCache = UserDefaultsCache<Subscription>(key: UserDefaultsCacheKey.subscription)
+    private static let subscriptionCache = UserDefaultsCache<Subscription>(key: UserDefaultsCacheKey.subscription,
+                                                                           settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20)))
 
     public enum CachePolicy {
         case reloadIgnoringLocalCacheData

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -56,7 +56,9 @@ public final class SubscriptionService: APIService {
 
         switch result {
         case .success(let subscriptionResponse):
-            subscriptionCache.set(subscriptionResponse)
+            let defaultExpiryDate = Date().addingTimeInterval(subscriptionCache.settings.defaultExpirationInterval)
+            let expiryDate = min(defaultExpiryDate, subscriptionResponse.expiresOrRenewsAt)
+            subscriptionCache.set(subscriptionResponse, expires: expiryDate)
             return .success(subscriptionResponse)
         case .failure(let error):
             return .failure(.apiError(error))

--- a/Sources/Subscription/UserDefaultsCache.swift
+++ b/Sources/Subscription/UserDefaultsCache.swift
@@ -20,13 +20,7 @@ import Foundation
 import Common
 
 public struct UserDefaultsCacheSettings {
-
-    // Default expiration interval set to 24 hours
     public let defaultExpirationInterval: TimeInterval
-
-    public init(defaultExpirationInterval: TimeInterval = 1 * 60 * 60) {
-        self.defaultExpirationInterval = defaultExpirationInterval
-    }
 }
 
 public enum UserDefaultsCacheKey: String {
@@ -43,7 +37,7 @@ public class UserDefaultsCache<ObjectType: Codable> {
     }
 
     private var subscriptionAppGroup: String?
-    private var settings: UserDefaultsCacheSettings
+    public private(set) var settings: UserDefaultsCacheSettings
     private lazy var userDefaults: UserDefaults? = {
         if let appGroup = subscriptionAppGroup {
             return UserDefaults(suiteName: appGroup)
@@ -55,14 +49,15 @@ public class UserDefaultsCache<ObjectType: Codable> {
     private let key: UserDefaultsCacheKey
 
     public init(subscriptionAppGroup: String? = nil, key: UserDefaultsCacheKey,
-                settings: UserDefaultsCacheSettings = UserDefaultsCacheSettings()) {
+                settings: UserDefaultsCacheSettings) {
         self.subscriptionAppGroup = subscriptionAppGroup
         self.key = key
         self.settings = settings
     }
 
-    public func set(_ object: ObjectType, expires: Date = Date().addingTimeInterval(UserDefaultsCacheSettings().defaultExpirationInterval)) {
-        let cacheObject = CacheObject(expires: expires, object: object)
+    public func set(_ object: ObjectType, expires: Date? = nil) {
+        let expiryDate = expires ?? Date().addingTimeInterval(self.settings.defaultExpirationInterval)
+        let cacheObject = CacheObject(expires: expiryDate, object: object)
         let encoder = JSONEncoder()
         do {
             let data = try encoder.encode(cacheObject)


### PR DESCRIPTION

**Required**:

Task/Issue URL: 
iOS PR: https://github.com/duckduckgo/macos-browser/pull/2485
macOS PR: https://github.com/duckduckgo/iOS/pull/2627
What kind of version bump will this require?: Patch

**Description**:
Change default staleness time interval for subscription and entitlement cache to 20min
When storing subscription in the cache use the date based on default interval or its date of renewalOrExpiry - whatever is earlier
Make the VPN code use cache and its logic for doing fetch if data is stale
On applicationDidBecomeActive refresh subscription details and entitlements
In the app rely on subscription details and entitlements based on cache logic (cached if still valid else fetch)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
