### PR TITLE
Bump Content Scope Scripts to 5.7.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "edd96481d49b094c260f9a79e078abdbdd3a83fb",
-        "version" : "5.6.0"
+        "revision" : "2f44185cca2edefbae7557393a61a23c282abbf8",
+        "version" : "5.7.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "3.3.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "5.6.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "5.7.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/wireguard-apple", exact: "1.1.3"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1206903263956340/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2627
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2485
What kind of version bump will this require?: Patch

**Description**:
Added new changes C-S-S changes needed for PIR PP release.