### PR TITLE
Avoid posting unnecessary `entitlementsDidChange` notifications

### DIFF
--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -245,7 +245,7 @@ public class AccountManager: AccountManaging {
             return .failure(EntitlementsError.noAccessToken)
         }
 
-        let cachedEntitlements: [Entitlement]? = entitlementsCache.get()
+        let cachedEntitlements: [Entitlement] = entitlementsCache.get() ?? []
 
         switch await AuthService.validateToken(accessToken: accessToken) {
         case .success(let response):


### PR DESCRIPTION

**Required**:

Task/Issue URL: https://app.asana.com/0/1142021229838617/1206911655298919/f
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Patch

**Description**:
Avoid posting unnecessary `entitlementsDidChange` notifications.

**Steps to test this PR**:
Try purchasing subscription on iOS. The `entitlementsDidChange` notification should only by fired when the entitlements change (are granted or revoked). When the cache is empty (nil is stored) and the remote entitlement fetch returns empty array it should not trigger the notification.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
