### PR TITLE
VPN startup logging cleanup

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -506,6 +506,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             connectionStatus = .connecting
 
             let startupOptions = StartupOptions(options: options ?? [:])
+            os_log("Starting tunnel with options: %{public}s", log: .networkProtection, startupOptions.description)
 
             resetIssueStateOnTunnelStart(startupOptions)
 

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -505,8 +505,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             connectionStatus = .connecting
 
-            os_log("Will load options\n%{public}@", log: .networkProtection, String(describing: options))
-            let startupOptions = StartupOptions(options: options ?? [:], log: .networkProtection)
+            let startupOptions = StartupOptions(options: options ?? [:])
 
             resetIssueStateOnTunnelStart(startupOptions)
 

--- a/Sources/NetworkProtection/StartupOptions.swift
+++ b/Sources/NetworkProtection/StartupOptions.swift
@@ -72,6 +72,17 @@ struct StartupOptions {
             self = .set(value)
         }
 
+        var description: String {
+            switch self {
+            case .set(let value):
+                return String(describing: value)
+            case .reset:
+                return "reset"
+            case .useExisting:
+                return "useExisting"
+            }
+        }
+
         // MARK: - Equatable
 
         static func == (lhs: StartupOptions.StoredOption<T>, rhs: StartupOptions.StoredOption<T>) -> Bool {
@@ -123,6 +134,22 @@ struct StartupOptions {
         selectedEnvironment = Self.readSelectedEnvironment(from: options, resetIfNil: resetStoredOptionsIfNil)
         selectedServer = Self.readSelectedServer(from: options, resetIfNil: resetStoredOptionsIfNil)
         selectedLocation = Self.readSelectedLocation(from: options, resetIfNil: resetStoredOptionsIfNil)
+    }
+
+    var description: String {
+        return """
+        StartupOptions(
+            startupMethod: \(self.startupMethod.debugDescription),
+            simulateError: \(self.simulateError.description),
+            simulateCrash: \(self.simulateCrash.description),
+            simulateMemoryCrash: \(self.simulateMemoryCrash.description),
+            keyValidity: \(self.keyValidity.description),
+            selectedEnvironment: \(self.selectedEnvironment.description),
+            selectedServer: \(self.selectedServer.description),
+            selectedLocation: \(self.selectedLocation.description),
+            enableTester: \(self.enableTester)
+        )
+        """
     }
 
     // MARK: - Helpers for reading stored options

--- a/Sources/NetworkProtection/StartupOptions.swift
+++ b/Sources/NetworkProtection/StartupOptions.swift
@@ -88,7 +88,6 @@ struct StartupOptions {
         }
     }
 
-    private let log: OSLog
     let startupMethod: StartupMethod
     let simulateError: Bool
     let simulateCrash: Bool
@@ -100,9 +99,7 @@ struct StartupOptions {
     let authToken: StoredOption<String>
     let enableTester: StoredOption<Bool>
 
-    init(options: [String: Any], log: OSLog) {
-        self.log = log
-
+    init(options: [String: Any]) {
         let startupMethod: StartupMethod = {
             if options[NetworkProtectionOptionKey.isOnDemand] as? Bool == true {
                 return .automaticOnDemand
@@ -131,7 +128,6 @@ struct StartupOptions {
     // MARK: - Helpers for reading stored options
 
     private static func readAuthToken(from options: [String: Any], resetIfNil: Bool) -> StoredOption<String> {
-
         StoredOption(resetIfNil: resetIfNil) {
             guard let authToken = options[NetworkProtectionOptionKey.authToken] as? String,
                   !authToken.isEmpty else {
@@ -155,7 +151,6 @@ struct StartupOptions {
     }
 
     private static func readSelectedEnvironment(from options: [String: Any], resetIfNil: Bool) -> StoredOption<VPNSettings.SelectedEnvironment> {
-
         StoredOption(resetIfNil: resetIfNil) {
             guard let environment = options[NetworkProtectionOptionKey.selectedEnvironment] as? String else {
                 return nil
@@ -166,7 +161,6 @@ struct StartupOptions {
     }
 
     private static func readSelectedServer(from options: [String: Any], resetIfNil: Bool) -> StoredOption<VPNSettings.SelectedServer> {
-
         StoredOption(resetIfNil: resetIfNil) {
             guard let serverName = options[NetworkProtectionOptionKey.selectedServer] as? String else {
                 return nil
@@ -190,7 +184,6 @@ struct StartupOptions {
     }
 
     private static func readEnableTester(from options: [String: Any], resetIfNil: Bool) -> StoredOption<Bool> {
-
         StoredOption(resetIfNil: resetIfNil) {
             guard let value = options[NetworkProtectionOptionKey.connectionTesterEnabled] as? Bool else {
                 return nil

--- a/Tests/NetworkProtectionTests/StartupOptionTests.swift
+++ b/Tests/NetworkProtectionTests/StartupOptionTests.swift
@@ -30,7 +30,7 @@ final class StartupOptionsTests: XCTestCase {
     ///
     func testStartupOptionsHaveCorrectDefaultValuesWhenStartedByTheSystem() {
         let rawOptions = [String: Any]()
-        let options = StartupOptions(options: rawOptions, log: .disabled)
+        let options = StartupOptions(options: rawOptions)
 
         XCTAssertEqual(options.authToken, .useExisting)
         XCTAssertEqual(options.enableTester, .useExisting)
@@ -52,7 +52,7 @@ final class StartupOptionsTests: XCTestCase {
             NetworkProtectionOptionKey.activationAttemptId: UUID().uuidString,
             NetworkProtectionOptionKey.isOnDemand: NSNumber(value: false)
         ]
-        let options = StartupOptions(options: rawOptions, log: .disabled)
+        let options = StartupOptions(options: rawOptions)
 
         XCTAssertEqual(options.authToken, .reset)
         XCTAssertEqual(options.enableTester, .reset)
@@ -73,7 +73,7 @@ final class StartupOptionsTests: XCTestCase {
         let rawOptions: [String: Any] = [
             NetworkProtectionOptionKey.isOnDemand: NSNumber(value: true)
         ]
-        let options = StartupOptions(options: rawOptions, log: .disabled)
+        let options = StartupOptions(options: rawOptions)
 
         XCTAssertEqual(options.authToken, .useExisting)
         XCTAssertEqual(options.enableTester, .useExisting)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1206914003023279/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2630
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2491
What kind of version bump will this require?: Minor

**Description**:

This PR updates logging during startup to no longer emit all values in the options directory, as some of these may be sensitive (i.e., auth token values). Instead, `StartupOptions` now defies its own description which omits any options that should be kept secret.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
