### PR TITLE
Update subscription and accounts cache after the confirmation of purchase completes

### DIFF
--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -353,6 +353,21 @@ public class AccountManager: AccountManaging {
 
         return hasEntitlements
     }
+
+    // MARK: - Update cache
+
+    public func updateCache(with entitlements: [Entitlement]) {
+        let cachedEntitlements: [Entitlement] = entitlementsCache.get() ?? []
+
+        if entitlements != cachedEntitlements {
+            if entitlements.isEmpty {
+                entitlementsCache.reset()
+            } else {
+                entitlementsCache.set(entitlements)
+            }
+            NotificationCenter.default.post(name: .entitlementsDidChange, object: self, userInfo: [UserDefaultsCacheKey.subscriptionEntitlements: entitlements])
+        }
+    }
 }
 
 extension Task where Success == Never, Failure == Never {

--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -23,6 +23,7 @@ public extension Notification.Name {
     static let accountDidSignIn = Notification.Name("com.duckduckgo.subscription.AccountDidSignIn")
     static let accountDidSignOut = Notification.Name("com.duckduckgo.subscription.AccountDidSignOut")
     static let entitlementsDidChange = Notification.Name("com.duckduckgo.subscription.EntitlementsDidChange")
+    static let subscriptionDidChange = Notification.Name("com.duckduckgo.subscription.SubscriptionDidChange")
 }
 
 public protocol AccountManagerKeychainAccessDelegate: AnyObject {

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -122,12 +122,15 @@ public final class AppStorePurchaseFlow {
         SubscriptionService.signOut()
 
         os_log(.info, log: .subscription, "[AppStorePurchaseFlow] completeSubscriptionPurchase")
+        let accountManager = AccountManager(subscriptionAppGroup: subscriptionAppGroup)
 
-        guard let accessToken = AccountManager(subscriptionAppGroup: subscriptionAppGroup).accessToken else { return .failure(.missingEntitlements) }
+        guard let accessToken = accountManager.accessToken else { return .failure(.missingEntitlements) }
 
         let result = await callWithRetries(retry: 5, wait: 2.0) {
             switch await SubscriptionService.confirmPurchase(accessToken: accessToken, signature: transactionJWS) {
-            case .success:
+            case .success(let confirmation):
+                SubscriptionService.updateCache(with: confirmation.subscription)
+                accountManager.updateCache(with: confirmation.entitlements)
                 return true
             case .failure:
                 return false

--- a/Sources/Subscription/Services/Model/Subscription.swift
+++ b/Sources/Subscription/Services/Model/Subscription.swift
@@ -18,7 +18,9 @@
 
 import Foundation
 
-public struct Subscription: Codable {
+public typealias DDGSubscription = Subscription // to avoid conflicts when Combine is imported
+
+public struct Subscription: Codable, Equatable {
     public let productId: String
     public let name: String
     public let billingPeriod: BillingPeriod

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -64,9 +64,15 @@ public final class SubscriptionService: APIService {
     }
 
     public static func updateCache(with subscription: Subscription) {
-        let defaultExpiryDate = Date().addingTimeInterval(subscriptionCache.settings.defaultExpirationInterval)
-        let expiryDate = min(defaultExpiryDate, subscription.expiresOrRenewsAt)
-        subscriptionCache.set(subscription, expires: expiryDate)
+        let cachedSubscription: Subscription? = subscriptionCache.get()
+
+        if subscription != cachedSubscription {
+            let defaultExpiryDate = Date().addingTimeInterval(subscriptionCache.settings.defaultExpirationInterval)
+            let expiryDate = min(defaultExpiryDate, subscription.expiresOrRenewsAt)
+
+            subscriptionCache.set(subscription, expires: expiryDate)
+            NotificationCenter.default.post(name: .subscriptionDidChange, object: self, userInfo: [UserDefaultsCacheKey.subscription: subscription])
+        }
     }
 
     public static func getSubscription(accessToken: String, cachePolicy: CachePolicy = .returnCacheDataElseLoad) async -> Result<Subscription, SubscriptionServiceError> {

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -56,13 +56,17 @@ public final class SubscriptionService: APIService {
 
         switch result {
         case .success(let subscriptionResponse):
-            let defaultExpiryDate = Date().addingTimeInterval(subscriptionCache.settings.defaultExpirationInterval)
-            let expiryDate = min(defaultExpiryDate, subscriptionResponse.expiresOrRenewsAt)
-            subscriptionCache.set(subscriptionResponse, expires: expiryDate)
+            updateCache(with: subscriptionResponse)
             return .success(subscriptionResponse)
         case .failure(let error):
             return .failure(.apiError(error))
         }
+    }
+
+    public static func updateCache(with subscription: Subscription) {
+        let defaultExpiryDate = Date().addingTimeInterval(subscriptionCache.settings.defaultExpirationInterval)
+        let expiryDate = min(defaultExpiryDate, subscription.expiresOrRenewsAt)
+        subscriptionCache.set(subscription, expires: expiryDate)
     }
 
     public static func getSubscription(accessToken: String, cachePolicy: CachePolicy = .returnCacheDataElseLoad) async -> Result<Subscription, SubscriptionServiceError> {
@@ -135,13 +139,5 @@ public final class SubscriptionService: APIService {
         public let email: String?
         public let entitlements: [Entitlement]
         public let subscription: Subscription
-    }
-
-    // MARK: - Update cache
-
-    public static func updateCache(with subscription: Subscription) {
-        let defaultExpiryDate = Date().addingTimeInterval(subscriptionCache.settings.defaultExpirationInterval)
-        let expiryDate = min(defaultExpiryDate, subscription.expiresOrRenewsAt)
-        subscriptionCache.set(subscription, expires: expiryDate)
     }
 }

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -136,4 +136,12 @@ public final class SubscriptionService: APIService {
         public let entitlements: [Entitlement]
         public let subscription: Subscription
     }
+
+    // MARK: - Update cache
+
+    public static func updateCache(with subscription: Subscription) {
+        let defaultExpiryDate = Date().addingTimeInterval(subscriptionCache.settings.defaultExpirationInterval)
+        let expiryDate = min(defaultExpiryDate, subscription.expiresOrRenewsAt)
+        subscriptionCache.set(subscription, expires: expiryDate)
+    }
 }


### PR DESCRIPTION

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206918870699971/f
What kind of version bump will this require?: Patch


**Description**:
Update subscription and accounts cache after the confirmation of purchase completes.


**Steps to test this PR**:
1. Make a purchase via App Store.
2. Check if caches are properly updated in the handling for `SubscriptionService.confirmPurchase(accessToken: accessToken, signature: transactionJWS)`


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
