### PR TITLE
Send correct platform value for App Store purchase options

### DIFF
--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -51,7 +51,15 @@ public final class AppStorePurchaseFlow {
 
         let features = SubscriptionFeatureName.allCases.map { SubscriptionFeature(name: $0.rawValue) }
 
-        return .success(SubscriptionOptions(platform: SubscriptionPlatformName.macos.rawValue,
+        let platform: SubscriptionPlatformName
+
+#if os(iOS)
+        platform = .ios
+#else
+        platform = .macos
+#endif
+
+        return .success(SubscriptionOptions(platform: platform.rawValue,
                                             options: options,
                                             features: features))
     }

--- a/Sources/Subscription/Flows/PurchaseFlow.swift
+++ b/Sources/Subscription/Flows/PurchaseFlow.swift
@@ -55,6 +55,7 @@ public enum SubscriptionFeatureName: String, CaseIterable {
 }
 
 public enum SubscriptionPlatformName: String {
+    case ios
     case macos
     case stripe
 }

--- a/Sources/Subscription/Flows/PurchaseFlow.swift
+++ b/Sources/Subscription/Flows/PurchaseFlow.swift
@@ -24,7 +24,13 @@ public struct SubscriptionOptions: Encodable {
     let features: [SubscriptionFeature]
     public static var empty: SubscriptionOptions {
         let features = SubscriptionFeatureName.allCases.map { SubscriptionFeature(name: $0.rawValue) }
-        return SubscriptionOptions(platform: "macos", options: [], features: features)
+        let platform: SubscriptionPlatformName
+#if os(iOS)
+        platform = .ios
+#else
+        platform = .macos
+#endif
+        return SubscriptionOptions(platform: platform.rawValue, options: [], features: features)
     }
 }
 


### PR DESCRIPTION
**Required**:

Task/Issue URL: 
iOS PR:  https://github.com/duckduckgo/iOS/pull/2633
macOS PR:  https://github.com/duckduckgo/macos-browser/pull/2493
What kind of version bump will this require?: Patch

**Description**:
Send correct platform value for App Store purchase options.

**Steps to test this PR**:
See platform PRs


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
