### PR TITLE
Improve matching App Store subscription by billing period

### DIFF
--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -38,8 +38,8 @@ public final class AppStorePurchaseFlow {
 
         let products = PurchaseManager.shared.availableProducts
 
-        let monthly = products.first(where: { $0.id.contains("1month") })
-        let yearly = products.first(where: { $0.id.contains("1year") })
+        let monthly = products.first(where: { $0.subscription?.subscriptionPeriod.unit == .month && $0.subscription?.subscriptionPeriod.value == 1 })
+        let yearly = products.first(where: { $0.subscription?.subscriptionPeriod.unit == .year && $0.subscription?.subscriptionPeriod.value == 1 })
 
         guard let monthly, let yearly else {
             os_log(.error, log: .subscription, "[AppStorePurchaseFlow] Error: noProductsFound")


### PR DESCRIPTION

**Required**:

Task/Issue URL:  https://app.asana.com/0/0/1206935438989341/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2644
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2508
What kind of version bump will this require?: Patch

**Description**:
Improve matching App Store subscription by billing period. Instead of matching by id pattern we should leverage the enums provided in StoreKit subscription object.

**Steps to test this PR**:
Smoke test opening the purchase page on macOS App Store and iOS. Opening purchase page is enough as we fetch the available subscription and prepare structs to be shown in the purchase page footer.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
