### PR TITLE
Improve subscription library sync failure error reporting

### DIFF
--- a/Sources/Subscription/PurchaseManager.swift
+++ b/Sources/Subscription/PurchaseManager.swift
@@ -85,7 +85,7 @@ public final class PurchaseManager: ObservableObject {
 
             return .success(())
         } catch {
-            os_log(.error, log: .subscription, "[PurchaseManager] Error: %{public}s", String(reflecting: error))
+            os_log(.error, log: .subscription, "[PurchaseManager] Error: %{public}s", error.localizedDescription)
             return .failure(error)
         }
     }

--- a/Sources/Subscription/PurchaseManager.swift
+++ b/Sources/Subscription/PurchaseManager.swift
@@ -85,7 +85,7 @@ public final class PurchaseManager: ObservableObject {
 
             return .success(())
         } catch {
-            os_log(.error, log: .subscription, "[PurchaseManager] Error: %{public}s", error.localizedDescription)
+            os_log(.error, log: .subscription, "[PurchaseManager] Error: %{public}s (%{public}s)", String(reflecting: error), error.localizedDescription)
             return .failure(error)
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1206946506094035/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2658
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2520
What kind of version bump will this require?: Patch

**Description**:

This PR updates the subscription library to log the real error message when an Apple ID sync failures. Currently there is no way to tell why something failed when the Restore Purchase feature failed.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
