### PR TITLE
Allows nil subs app groups again

### DIFF
--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -54,7 +54,7 @@ public class AccountManager: AccountManaging {
         return accessToken != nil
     }
 
-    public convenience init(subscriptionAppGroup: String, accessTokenStorage: SubscriptionTokenStorage) {
+    public convenience init(subscriptionAppGroup: String?, accessTokenStorage: SubscriptionTokenStorage) {
         self.init(accessTokenStorage: accessTokenStorage,
                   entitlementsCache: UserDefaultsCache<[Entitlement]>(subscriptionAppGroup: subscriptionAppGroup,
                                                                       key: UserDefaultsCacheKey.subscriptionEntitlements,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206948122428068/f
iOS PR: None needed
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2524
What kind of version bump will this require?: Patch

## Description

Allows nil subs app groups again

## Testing

Refer to macOS PR.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
