### PR TITLE
Add function as an alternative to NSLocalizedString

### DIFF
--- a/Sources/Common/Extensions/StringExtension.swift
+++ b/Sources/Common/Extensions/StringExtension.swift
@@ -31,6 +31,12 @@ extension RegEx {
     static let hostName = regex("^(((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)*[A-Za-z0-9-]{2,63})$", .caseInsensitive)
 }
 
+// Use this instead of NSLocalizedString for strings that are not supposed to be translated
+// swiftlint:disable:next identifier_name
+public func NotLocalizedString(_ key: String, tableName: String? = nil, bundle: Bundle = Bundle.main, value: String = "", comment: String) -> String {
+    return value
+}
+
 public extension String {
 
     static let localhost = "localhost"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1206998467134661/f
iOS PR: n/a
macOS PR: n/a 
What kind of version bump will this require?: Patch

**Description**:

Add NonLocalizedString that is supposed to be used in place of NSLocalizedString for strings that are not supposed to be (yet) translated.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
