### PR TITLE
Remove URLs from suggestion search terms

### DIFF
--- a/Sources/Suggestions/Suggestion.swift
+++ b/Sources/Suggestions/Suggestion.swift
@@ -48,6 +48,15 @@ public enum Suggestion: Equatable {
         }
     }
 
+    var phrase: String? {
+        switch self {
+        case .phrase(let phrase):
+            return phrase
+        case .website, .bookmark, .historyEntry, .unknown:
+            return nil
+        }
+    }
+
     public var allowedInTopHits: Bool {
         switch self {
         case .website:

--- a/Sources/Suggestions/URLExtensions.swift
+++ b/Sources/Suggestions/URLExtensions.swift
@@ -1,0 +1,38 @@
+//
+//  URLExtensions.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public extension URL {
+    
+    /// Creates a URL from a suggestion phrase.
+    /// - Parameter phrase: The suggestion phrase to create the URL from.
+    /// - Returns: A URL object if the suggestion phrase can be converted to a valid URL with a supported navigational scheme; otherwise, nil.
+    static func makeURL(fromSuggestionPhrase phrase: String) -> URL? {
+        guard let url = URL(trimmedAddressBarString: phrase),
+              let scheme = url.scheme.map(NavigationalScheme.init),
+              NavigationalScheme.hypertextSchemes.contains(scheme),
+              url.isValid else {
+            return nil
+        }
+
+        return url
+    }
+    
+}

--- a/Sources/Suggestions/URLExtensions.swift
+++ b/Sources/Suggestions/URLExtensions.swift
@@ -1,6 +1,5 @@
 //
 //  URLExtensions.swift
-//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //
@@ -20,7 +19,7 @@
 import Foundation
 
 public extension URL {
-    
+
     /// Creates a URL from a suggestion phrase.
     /// - Parameter phrase: The suggestion phrase to create the URL from.
     /// - Returns: A URL object if the suggestion phrase can be converted to a valid URL with a supported navigational scheme; otherwise, nil.
@@ -34,5 +33,5 @@ public extension URL {
 
         return url
     }
-    
+
 }

--- a/Tests/SuggestionsTests/SuggestionProcessingTests.swift
+++ b/Tests/SuggestionsTests/SuggestionProcessingTests.swift
@@ -74,12 +74,9 @@ extension HistoryEntryMock {
 extension BookmarkMock {
 
     static var someBookmarks: [Bookmark] {
-        [
-            BookmarkMock(url: "http://duckduckgo.com", title: "DuckDuckGo", isFavorite: true),
-            BookmarkMock(url: "spreadprivacy.com", title: "Test 2", isFavorite: true),
-            BookmarkMock(url: "wikipedia.org", title: "Wikipedia", isFavorite: false),
-            BookmarkMock(url: "www.facebook.com", title: "Facebook", isFavorite: true),
-        ]
+        [ BookmarkMock(url: "http://duckduckgo.com", title: "DuckDuckGo", isFavorite: true),
+          BookmarkMock(url: "spreadprivacy.com", title: "Test 2", isFavorite: true),
+          BookmarkMock(url: "wikipedia.org", title: "Wikipedia", isFavorite: false) ]
     }
 
 }

--- a/Tests/SuggestionsTests/SuggestionProcessingTests.swift
+++ b/Tests/SuggestionsTests/SuggestionProcessingTests.swift
@@ -35,6 +35,25 @@ final class SuggestionProcessingTests: XCTestCase {
         XCTAssertEqual(result!.topHits.first!.title, "DuckDuckGo")
     }
 
+    func testWhenDuckDuckGoSuggestionContainsURLThenDoNotShowAsSearchTerm() throws {
+        // GIVEN
+        let processing = SuggestionProcessing(urlFactory: URL.makeURL(fromSuggestionPhrase:))
+        let facebookURLSearchTermSuggestion = Suggestion(key: Suggestion.phraseKey, value: "www.acer.com/ac/en/US/content/home")
+
+        // WHEN
+        let result = processing.result(
+            for: "ace",
+            from: [],
+            bookmarks: [],
+            apiResult: .aceAPIResult
+        )
+
+        // THEN
+        let duckduckGoSuggestions = try XCTUnwrap(result?.duckduckgoSuggestions)
+        XCTAssertEqual(duckduckGoSuggestions.count, 4)
+        XCTAssertFalse(duckduckGoSuggestions.contains(facebookURLSearchTermSuggestion))
+    }
+
 }
 
 extension HistoryEntryMock {
@@ -55,9 +74,12 @@ extension HistoryEntryMock {
 extension BookmarkMock {
 
     static var someBookmarks: [Bookmark] {
-        [ BookmarkMock(url: "http://duckduckgo.com", title: "DuckDuckGo", isFavorite: true),
-          BookmarkMock(url: "spreadprivacy.com", title: "Test 2", isFavorite: true),
-          BookmarkMock(url: "wikipedia.org", title: "Wikipedia", isFavorite: false) ]
+        [
+            BookmarkMock(url: "http://duckduckgo.com", title: "DuckDuckGo", isFavorite: true),
+            BookmarkMock(url: "spreadprivacy.com", title: "Test 2", isFavorite: true),
+            BookmarkMock(url: "wikipedia.org", title: "Wikipedia", isFavorite: false),
+            BookmarkMock(url: "www.facebook.com", title: "Facebook", isFavorite: true),
+        ]
     }
 
 }
@@ -73,5 +95,17 @@ extension APIResult {
         ]
         return result
     }
+
+    static let aceAPIResult: APIResult = {
+        var result = APIResult()
+        result.items = [
+            [ "phrase": "acecqa" ],
+            [ "phrase": "acer" ],
+            [ "phrase": "www.acer.com/ac/en/US/content/home" ],
+            [ "phrase": "ace hotel sydney" ],
+            [ "phrase": "acer drivers" ],
+        ]
+        return result
+    }()
 
 }

--- a/Tests/SuggestionsTests/URLExtensionsTests.swift
+++ b/Tests/SuggestionsTests/URLExtensionsTests.swift
@@ -1,6 +1,5 @@
 //
 //  URLExtensionsTests.swift
-//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //

--- a/Tests/SuggestionsTests/URLExtensionsTests.swift
+++ b/Tests/SuggestionsTests/URLExtensionsTests.swift
@@ -1,0 +1,40 @@
+//
+//  URLExtensionsTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+final class URLExtensionsTests: XCTestCase {
+
+    func testWhenMakingUrlFromSuggestionPhaseContainingColon_ThenVerifyHypertextScheme() {
+        let validUrl = URL.makeURL(fromSuggestionPhrase: "http://duckduckgo.com")
+        XCTAssert(validUrl != nil)
+        XCTAssertEqual(validUrl?.scheme, "http")
+
+        let anotherValidUrl = URL.makeURL(fromSuggestionPhrase: "duckduckgo.com")
+        XCTAssert(anotherValidUrl != nil)
+        XCTAssertNotNil(validUrl?.scheme)
+
+        let notURL = URL.makeURL(fromSuggestionPhrase: "type:pdf")
+        XCTAssertNil(notURL)
+
+        let anotherInvalidURL = URL.makeURL(fromSuggestionPhrase: "Test")
+        XCTAssertNil(anotherInvalidURL)
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1206836396714144/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2683
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2551
What kind of version bump will this require?: Minor

**Description**:

Removes URLs suggestions from the search term when typing on the address bar. 

**Steps to test this PR**:
1. Type “face”, “ama” or “ace" on the address bar.
**Expected Result:** The search term suggestions should not include “www.facebook.com”, “www.amazon.com”, “www.acer.com/"  

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [x] iOS 17 (simulator)
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12
* [x] macOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
