### PR TITLE
Avoid caching a PrivacyConfig instance in FeatureFlagger

### DIFF
--- a/Sources/BrowserServicesKit/FeatureFlagger/FeatureFlagger.swift
+++ b/Sources/BrowserServicesKit/FeatureFlagger/FeatureFlagger.swift
@@ -29,11 +29,11 @@ public protocol FeatureFlagger {
 
 public class DefaultFeatureFlagger: FeatureFlagger {
     private let internalUserDecider: InternalUserDecider
-    private let privacyConfig: PrivacyConfiguration
+    private let privacyConfigManager: PrivacyConfigurationManaging
 
-    public init(internalUserDecider: InternalUserDecider, privacyConfig: PrivacyConfiguration) {
+    public init(internalUserDecider: InternalUserDecider, privacyConfigManager: PrivacyConfigurationManaging) {
         self.internalUserDecider = internalUserDecider
-        self.privacyConfig = privacyConfig
+        self.privacyConfigManager = privacyConfigManager
     }
 
     public func isFeatureOn<F: FeatureFlagSourceProviding>(forProvider provider: F) -> Bool {
@@ -55,9 +55,9 @@ public class DefaultFeatureFlagger: FeatureFlagger {
     private func isEnabled(_ featureType: PrivacyConfigFeatureLevel) -> Bool {
         switch featureType {
         case .feature(let feature):
-            return privacyConfig.isEnabled(featureKey: feature)
+            return privacyConfigManager.privacyConfig.isEnabled(featureKey: feature)
         case .subfeature(let subfeature):
-            return privacyConfig.isSubfeatureEnabled(subfeature)
+            return privacyConfigManager.privacyConfig.isSubfeatureEnabled(subfeature)
         }
     }
 }

--- a/Tests/BrowserServicesKitTests/FeatureFlagging/DefaultFeatureFlaggerTests.swift
+++ b/Tests/BrowserServicesKitTests/FeatureFlagging/DefaultFeatureFlaggerTests.swift
@@ -117,7 +117,7 @@ final class DefaultFeatureFlaggerTests: XCTestCase {
                                                   localProtection: MockDomainsProtectionStore(),
                                                  internalUserDecider: DefaultInternalUserDecider())
         let internalUserDecider = DefaultInternalUserDecider(store: internalUserDeciderStore)
-        return DefaultFeatureFlagger(internalUserDecider: internalUserDecider, privacyConfig: manager.privacyConfig)
+        return DefaultFeatureFlagger(internalUserDecider: internalUserDecider, privacyConfigManager: manager)
     }
 
     private static func embeddedConfig(autofillState: String = "enabled",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1206053496104935/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2692
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2561
What kind of version bump will this require?: Major

**Description**:

This PR updates FeatureFlagger to no longer cache an instance of the PrivacyConfig.

This caching was leading to a situation where the FeatureFlagger has a different feature flag state to the rest of the app.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
