### PR TITLE
Update autofill to 10.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "6493e296934bf09277c03df45f11f4619711cb24",
-        "version" : "10.2.0"
+        "revision" : "3d293c541266e290b83d11b6e1e960f0edfbed4b",
+        "version" : "10.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .library(name: "Suggestions", targets: ["Suggestions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "10.2.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "10.3.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.3.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "1.2.2"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207023130848414/1207023130848414
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.3.0


## Description
Updates Autofill to version [10.3.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.3.0).

### Autofill 10.3.0 release notes
## What's Changed
* update CSS selectors by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/546


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.2.0...10.3.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).