### PR TITLE
Remove timezone offset from the VPN server object

### DIFF
--- a/Sources/NetworkProtection/Models/NetworkProtectionServerInfo.swift
+++ b/Sources/NetworkProtection/Models/NetworkProtectionServerInfo.swift
@@ -29,13 +29,11 @@ public struct NetworkProtectionServerInfo: Codable, Equatable, Sendable {
         public let city: String
         public let country: String
         public let state: String
-        public let timezoneOffset: Int
 
         enum CodingKeys: String, CodingKey {
             case city
             case country
             case state
-            case timezoneOffset = "tzOffset"
         }
     }
 

--- a/Tests/NetworkProtectionTests/Mocks/NetworkProtectionServerMocks.swift
+++ b/Tests/NetworkProtectionTests/Mocks/NetworkProtectionServerMocks.swift
@@ -35,7 +35,7 @@ extension NetworkProtectionServerInfo {
                                                   ips: ["192.168.1.1"],
                                                   internalIP: "10.11.12.1",
                                                   port: 443,
-                                                  attributes: .init(city: "City", country: "Country", state: "State", timezoneOffset: 0))
+                                                  attributes: .init(city: "City", country: "Country", state: "State"))
 
     static let hostNameOnly = NetworkProtectionServerInfo(name: "Mock Server",
                                                           publicKey: "ovn9RpzUuvQ4XLQt6B3RKuEXGIxa5QpTnehjduZlcSE=",
@@ -43,7 +43,7 @@ extension NetworkProtectionServerInfo {
                                                           ips: [],
                                                           internalIP: "10.11.12.1",
                                                           port: 443,
-                                                          attributes: .init(city: "City", country: "Country", state: "State", timezoneOffset: 0))
+                                                          attributes: .init(city: "City", country: "Country", state: "State"))
 
     static let ipAddressOnly = NetworkProtectionServerInfo(name: "Mock Server",
                                                            publicKey: "ovn9RpzUuvQ4XLQt6B3RKuEXGIxa5QpTnehjduZlcSE=",
@@ -51,7 +51,7 @@ extension NetworkProtectionServerInfo {
                                                            ips: ["192.168.1.1"],
                                                            internalIP: "10.11.12.1",
                                                            port: 443,
-                                                           attributes: .init(city: "City", country: "Country", state: "State", timezoneOffset: 0))
+                                                           attributes: .init(city: "City", country: "Country", state: "State"))
 
     static func make(named name: String, withPublicKey publicKey: String = "") -> Self {
         NetworkProtectionServerInfo(name: name,
@@ -60,7 +60,7 @@ extension NetworkProtectionServerInfo {
                                     ips: ["192.168.1.1"],
                                     internalIP: "10.11.12.1",
                                     port: 443,
-                                    attributes: .init(city: "City", country: "Country", state: "State", timezoneOffset: 0))
+                                    attributes: .init(city: "City", country: "Country", state: "State"))
     }
 
 }

--- a/Tests/NetworkProtectionTests/NetworkProtectionServerInfoTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionServerInfoTests.swift
@@ -29,7 +29,7 @@ final class NetworkProtectionServerInfoTests: XCTestCase {
                                                      ips: [],
                                                      internalIP: "10.11.12.1",
                                                      port: 42,
-                                                     attributes: .init(city: "Amsterdam", country: "nl", state: "na", timezoneOffset: 3600))
+                                                     attributes: .init(city: "Amsterdam", country: "nl", state: "na"))
 
         XCTAssertEqual(serverInfo.serverLocation, "Amsterdam, NL")
     }
@@ -41,7 +41,7 @@ final class NetworkProtectionServerInfoTests: XCTestCase {
                                                      ips: [],
                                                      internalIP: "10.11.12.1",
                                                      port: 42,
-                                                     attributes: .init(city: "New York", country: "us", state: "ny", timezoneOffset: 3600))
+                                                     attributes: .init(city: "New York", country: "us", state: "ny"))
 
         XCTAssertEqual(serverInfo.serverLocation, "New York, NY")
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1207032029127388/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2701
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2580
What kind of version bump will this require?: Major

**Optional**:

Tech Design URL:
CC:

**Description**:

This PR removes `tzOffset` from the server object. It wasn't being used and is in the process of being removed.

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
