### PR TITLE
Fix VPN bug: Nearest city breaks register requests

### DIFF
--- a/Sources/NetworkProtection/Settings/Extensions/UserDefaults+selectedLocation.swift
+++ b/Sources/NetworkProtection/Settings/Extensions/UserDefaults+selectedLocation.swift
@@ -56,6 +56,10 @@ extension UserDefaults {
         guard let storageValue else {
             return .nearest
         }
+
+        // To handle a bug where a UI element's title was set for nearest cities rather than nil
+        let city = storageValue.city == "Nearest" ? nil : storageValue.city
+
         let selectedLocation = NetworkProtectionSelectedLocation(country: storageValue.country, city: storageValue.city)
 
         return .location(selectedLocation)

--- a/Sources/NetworkProtection/Settings/Extensions/UserDefaults+selectedLocation.swift
+++ b/Sources/NetworkProtection/Settings/Extensions/UserDefaults+selectedLocation.swift
@@ -60,7 +60,7 @@ extension UserDefaults {
         // To handle a bug where a UI element's title was set for nearest cities rather than nil
         let city = storageValue.city == "Nearest" ? nil : storageValue.city
 
-        let selectedLocation = NetworkProtectionSelectedLocation(country: storageValue.country, city: storageValue.city)
+        let selectedLocation = NetworkProtectionSelectedLocation(country: storageValue.country, city: city)
 
         return .location(selectedLocation)
     }


### PR DESCRIPTION
⚠️ I am open to suggestion that this PR is not even necessary because the bug is recoverable if the user just changes location once. The bug would be fixed with just the macOS change and it’s undefined how long we would need to keep this workaround for. ⚠️

**Required**:

Task/Issue URL: 
iOS PR: https://github.com/duckduckgo/iOS/pull/2706
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2589
What kind of version bump will this require?: Patch

**Description**:
Due to a bug in the VPNLocationViewModel, we were using the string “Nearest” as a city ID which ended up making it to the register request. This only happens when we explicitly select Nearest rather than just selecting the country (which has the same effect).

This PR is to handle the case that they already selected a Nearest city 

**Steps to test this PR**:
See macOS PR

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
