### PR TITLE
Fix VPN bug: Nearest city breaks register requests (#770)

### DIFF
--- a/Sources/NetworkProtection/Settings/Extensions/UserDefaults+selectedLocation.swift
+++ b/Sources/NetworkProtection/Settings/Extensions/UserDefaults+selectedLocation.swift
@@ -56,7 +56,11 @@ extension UserDefaults {
         guard let storageValue else {
             return .nearest
         }
-        let selectedLocation = NetworkProtectionSelectedLocation(country: storageValue.country, city: storageValue.city)
+
+        // To handle a bug where a UI element's title was set for nearest cities rather than nil
+        let city = storageValue.city == "Nearest" ? nil : storageValue.city
+
+        let selectedLocation = NetworkProtectionSelectedLocation(country: storageValue.country, city: city)
 
         return .location(selectedLocation)
     }


### PR DESCRIPTION
* Handle stored Nearest city values

* Actually use the amended city value

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: 
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
