### PR TITLE
Support Autofill Domains with Port Number Suffixes

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
@@ -138,8 +138,6 @@ public class WebsiteAutofillUserScript: AutofillUserScript {
                                                       configType: selectedDetailsData.configType)
         }
 
-        
-
         if let json = try? JSONEncoder().encode(response),
            let jsonString = String(data: json, encoding: .utf8) {
             replyHandler(jsonString)

--- a/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
@@ -138,6 +138,8 @@ public class WebsiteAutofillUserScript: AutofillUserScript {
                                                       configType: selectedDetailsData.configType)
         }
 
+        
+
         if let json = try? JSONEncoder().encode(response),
            let jsonString = String(data: json, encoding: .utf8) {
             replyHandler(jsonString)

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -77,12 +77,6 @@ public protocol SecureVaultManagerDelegate: AnyObject, SecureVaultErrorReporting
 
 }
 
-extension SecureVaultManagerDelegate {
-    func secureVaultManagerIsEnabledStatus(_ manager: SecureVaultManager, forType type: AutofillType? = nil) -> Bool {
-        return secureVaultManagerIsEnabledStatus(manager, forType: type)
-    }
-}
-
 public protocol PasswordManager: AnyObject {
 
     var isEnabled: Bool { get }
@@ -156,7 +150,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                                                                  SecureVaultModels.CredentialsProvider) -> Void) {
 
         do {
-            guard let delegate = delegate, delegate.secureVaultManagerIsEnabledStatus(self) else {
+            guard let delegate = delegate, delegate.secureVaultManagerIsEnabledStatus(self, forType: nil) else {
                 completionHandler([], [], [], credentialsProvider)
                 return
             }

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -759,7 +759,13 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                         completion([], nil)
                         return
                     }
-                    let accounts = try vault.accountsWithPartialMatchesFor(eTLDplus1: eTLDplus1)
+
+                    var eTLDplus1WithPort = eTLDplus1
+                    if let port = currentUrlComponents.port {
+                        eTLDplus1WithPort += ":\(port)"
+                    }
+
+                    let accounts = try vault.accountsWithPartialMatchesFor(eTLDplus1: eTLDplus1WithPort)
                     completion(accounts, nil)
                 } else {
                     let accounts = try vault.accountsFor(domain: domain)

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -570,7 +570,6 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
     }
 
     private func extractTLD(domain: String, tld: TLD, urlMatcher: AutofillDomainNameUrlMatcher) -> String? {
-//        guard let urlComponents = removePort(domain: domain, urlMatcher: urlMatcher) else { return nil }
         var urlComponents = URLComponents()
         urlComponents.host = removePort(domain: domain, urlMatcher: urlMatcher)
         return urlComponents.eTLDplus1(tld: tld)

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -571,6 +571,7 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
 
     private func extractTLD(domain: String, tld: TLD, urlMatcher: AutofillDomainNameUrlMatcher) -> String? {
         guard var urlComponents = urlMatcher.normalizeSchemeForAutofill(domain) else { return nil }
+        guard urlComponents.host != .localhost else { return domain }
         return urlComponents.eTLDplus1WithPort(tld: tld)
 
     }

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultModels.swift
@@ -570,21 +570,9 @@ extension Array where Element == SecureVaultModels.WebsiteAccount {
     }
 
     private func extractTLD(domain: String, tld: TLD, urlMatcher: AutofillDomainNameUrlMatcher) -> String? {
-        var urlComponents = URLComponents()
-        // We need to remove the port for the eTLDplus1 construction, and then re-add it
-        let (domain, port) = removePort(domain: domain, urlMatcher: urlMatcher)
-        urlComponents.host = domain
-        guard let tld = urlComponents.eTLDplus1(tld: tld) else { return nil }
-        guard let port = port else { return tld }
-        return  "\(tld):\(port)"
-    }
+        guard var urlComponents = urlMatcher.normalizeSchemeForAutofill(domain) else { return nil }
+        return urlComponents.eTLDplus1WithPort(tld: tld)
 
-    private func removePort(domain: String, urlMatcher: AutofillDomainNameUrlMatcher) -> (domain: String?, port: String?) {
-        let urlComponents = urlMatcher.normalizeSchemeForAutofill(domain)
-        if let port = urlComponents?.port {
-            return (domain.dropping(suffix: ":\(port)"), "\(port)")
-        }
-        return (domain, nil)
     }
 
     // Last Used > Last Updated > Alphabetical Domain > Alphabetical Username > Empty Usernames

--- a/Sources/Common/Extensions/URLComponentsExtension.swift
+++ b/Sources/Common/Extensions/URLComponentsExtension.swift
@@ -28,4 +28,15 @@ extension URLComponents {
         return tld.extractSubdomain(from: self.host?.lowercased())
     }
 
+    mutating public func eTLDplus1WithPort(tld: TLD) -> String? {
+        guard let port = self.port else {
+            return tld.eTLDplus1(self.host?.lowercased())
+        }
+
+        self.port = nil
+        guard let etldPlus1 = tld.eTLDplus1(self.host?.lowercased()) else { return nil }
+
+        return "\(etldPlus1):\(port)"
+    }
+
 }

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import XCTest
 import UserScript
 import SecureStorage
@@ -190,6 +191,130 @@ class SecureVaultManagerTests: XCTestCase {
             XCTAssertEqual(action, .fill)
             XCTAssertEqual(credentials!.password, "password".data(using: .utf8)!)
             XCTAssertEqual(credentials!.account.username, "dax2")
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testWhenRequestingCredentialsWithDomainAndPort_ThenFillActionIsReturned() throws {
+
+        // Given
+        class SecureVaultDelegate: MockSecureVaultManagerDelegate {
+            override func secureVaultManager(_ manager: SecureVaultManager,
+                                             promptUserToAutofillCredentialsForDomain domain: String,
+                                             withAccounts accounts: [SecureVaultModels.WebsiteAccount],
+                                             withTrigger trigger: AutofillUserScript.GetTriggerType,
+                                             onAccountSelected account: @escaping (SecureVaultModels.WebsiteAccount?) -> Void,
+                                             completionHandler: @escaping (SecureVaultModels.WebsiteAccount?) -> Void) {
+                XCTAssertEqual(accounts.count, 1, "One account should have been returned")
+                completionHandler(accounts[0])
+            }
+        }
+
+        self.manager = SecureVaultManager(vault: self.testVault, includePartialAccountMatches: true, tld: TLD())
+        self.secureVaultManagerDelegate = SecureVaultDelegate()
+        self.manager.delegate = self.secureVaultManagerDelegate
+
+        let triggerType = AutofillUserScript.GetTriggerType.userInitiated
+
+        let domain = "domain.com:1234"
+        let username = "dax"
+        let account = SecureVaultModels.WebsiteAccount(id: "1", title: nil, username: username, domain: domain, created: Date(), lastUpdated: Date())
+        self.mockDatabaseProvider._accounts = [account]
+
+        // credential for the account
+        let credentials = SecureVaultModels.WebsiteCredentials(account: account, password: "password".data(using: .utf8)!)
+        try self.testVault.storeWebsiteCredentials(credentials)
+
+        let subType = AutofillUserScript.GetAutofillDataSubType.username
+        let expect = expectation(description: #function)
+
+        // When
+        manager.autofillUserScript(mockAutofillUserScript, didRequestCredentialsForDomain: domain, subType: subType, trigger: triggerType) { credentials, _, action in
+            
+            // Then
+            XCTAssertEqual(action, .fill)
+            XCTAssertEqual(credentials!.password, "password".data(using: .utf8)!)
+            XCTAssertEqual(credentials!.account.username, "dax")
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testWhenRequestingAutofillInitDataWithDomainAndPort_ThenDataIsReturned() throws {
+
+        // Given
+        class SecureVaultDelegate: MockSecureVaultManagerDelegate {
+            override func secureVaultManager(_ manager: SecureVaultManager,
+                                             promptUserToAutofillCredentialsForDomain domain: String,
+                                             withAccounts accounts: [SecureVaultModels.WebsiteAccount],
+                                             withTrigger trigger: AutofillUserScript.GetTriggerType,
+                                             onAccountSelected account: @escaping (SecureVaultModels.WebsiteAccount?) -> Void,
+                                             completionHandler: @escaping (SecureVaultModels.WebsiteAccount?) -> Void) {
+                XCTAssertEqual(accounts.count, 1, "One account should have been returned")
+                completionHandler(accounts[0])
+            }
+        }
+
+        self.manager = SecureVaultManager(vault: self.testVault, includePartialAccountMatches: true, tld: TLD())
+        self.secureVaultManagerDelegate = SecureVaultDelegate()
+        self.manager.delegate = self.secureVaultManagerDelegate
+
+        let domain = "domain.com:1234"
+        let username = "dax"
+        let account = SecureVaultModels.WebsiteAccount(id: "1", title: nil, username: username, domain: domain, created: Date(), lastUpdated: Date())
+        self.mockDatabaseProvider._accounts = [account]
+
+        let credentials = SecureVaultModels.WebsiteCredentials(account: account, password: "password".data(using: .utf8)!)
+        try self.testVault.storeWebsiteCredentials(credentials)
+
+        let expect = expectation(description: #function)
+
+        // When
+        manager.autofillUserScript(mockAutofillUserScript, didRequestAutoFillInitDataForDomain: domain) { accounts, _, _, _ in
+
+            // Then
+            XCTAssertTrue(accounts.count == 1)
+            XCTAssertEqual(accounts.first!, account)
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testWhenRequestingAccountsWithDomainAndPort_ThenDataIsReturned() throws {
+
+        // Given
+        class SecureVaultDelegate: MockSecureVaultManagerDelegate {
+            override func secureVaultManager(_ manager: SecureVaultManager,
+                                             promptUserToAutofillCredentialsForDomain domain: String,
+                                             withAccounts accounts: [SecureVaultModels.WebsiteAccount],
+                                             withTrigger trigger: AutofillUserScript.GetTriggerType,
+                                             onAccountSelected account: @escaping (SecureVaultModels.WebsiteAccount?) -> Void,
+                                             completionHandler: @escaping (SecureVaultModels.WebsiteAccount?) -> Void) {
+                XCTAssertEqual(accounts.count, 1, "One account should have been returned")
+                completionHandler(accounts[0])
+            }
+        }
+
+        self.manager = SecureVaultManager(vault: self.testVault, includePartialAccountMatches: true, tld: TLD())
+        self.secureVaultManagerDelegate = SecureVaultDelegate()
+        self.manager.delegate = self.secureVaultManagerDelegate
+
+        let domain = "domain.com:1234"
+        let username = "dax"
+        let account = SecureVaultModels.WebsiteAccount(id: "1", title: nil, username: username, domain: domain, created: Date(), lastUpdated: Date())
+        self.mockDatabaseProvider._accounts = [account]
+
+        let credentials = SecureVaultModels.WebsiteCredentials(account: account, password: "password".data(using: .utf8)!)
+        try self.testVault.storeWebsiteCredentials(credentials)
+
+        let expect = expectation(description: #function)
+
+        // When
+        manager.autofillUserScript(mockAutofillUserScript, didRequestAccountsForDomain: domain) { accounts, _ in
+            // Then
+            XCTAssertTrue(accounts.count == 1)
+            XCTAssertEqual(accounts.first!, account)
             expect.fulfill()
         }
         waitForExpectations(timeout: 0.1)
@@ -723,7 +848,7 @@ private class MockSecureVaultManagerDelegate: SecureVaultManagerDelegate {
 
     private(set) var promptedAutofillData: AutofillData?
 
-    func secureVaultManagerIsEnabledStatus(_: SecureVaultManager) -> Bool {
+    func secureVaultManagerIsEnabledStatus(_ manager: SecureVaultManager, forType type: AutofillType?) -> Bool {
         return true
     }
 

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
@@ -240,6 +240,34 @@ class SecureVaultModelTests: XCTestCase {
         testAccount("pheobe", "amazon.com", "4488", 10 * days, 2 * days)
     ]
 
+    lazy var sortTestAccountsWithPorts = [
+        testAccount("", "appliances.amazon.com:1234", "5678", 0),
+        testAccount("mary", "garden.amazon.com:1234", "12345", 50 * days),
+        testAccount("daniel", "www.amazon.com:1234", "23456", 0),
+        testAccount("lisa", "books.amazon.com:1234", "5678", 50  * days),
+        testAccount("peter", "primevideo.amazon.com:1234", "4567", 85 * days),
+        testAccount("jane", "amazon.com:1234", "7890", 0),
+        testAccount("", "", "7890", 0),
+        testAccount("", "amazon.com:1234", "3456", 0),
+        testAccount("william", "fashion.amazon.com:1234", "1234", 50 * days),
+        testAccount("olivia", "toys.amazon.com:1234", "4567", 50 * days),
+        testAccount("", "movies.amazon.com:1234", "2345", 0),
+        testAccount("jacob", "office.amazon.com:1234", "12345", 0),
+        testAccount("rachel", "amazon.com:1234", "7890", 0),
+        testAccount("james", "", "7890", 0),
+        testAccount("", "grocery.amazon.com:1234", "4567", 0),
+        testAccount("frank", "sports.amazon.com:1234", "23456", 0),
+        testAccount("quinn", "www.amazon.com:1234", "2345", 0),
+        testAccount("oscar", "amazon.com:1234", "7890", 0),
+        testAccount("chris", "baby.amazon.com:1234", "3456", 0),
+        testAccount("anna", "amazon.com:1234", "1234", 50 * days),
+        testAccount("paul", "amazon.com:1234", "3456", 0),
+        testAccount("john", "www.amazon.com:1234", "4567", 0),
+        testAccount("ringo", "www.amazon.com:1234", "1233", 0, 1 * days),
+        testAccount("george", "www.amazon.com:1234", "4488", 0, 0 * days),
+        testAccount("pheobe", "amazon.com:1234", "4488", 10 * days, 2 * days)
+    ]
+
     func testExactMatchAccountsAreShownFirst() {
         let sortedAccounts = sortTestAccounts.sortedForDomain("www.amazon.com", tld: tld)
 
@@ -273,6 +301,39 @@ class SecureVaultModelTests: XCTestCase {
         }
     }
 
+    func testExactMatchAccountsWithPortAreShownFirst() {
+        let sortedAccounts = sortTestAccountsWithPorts.sortedForDomain("www.amazon.com:1234", tld: tld)
+
+        let controlAccounts = [
+            testAccount("ringo", "www.amazon.com:1234", "1233", 0, 1 * days),
+            testAccount("george", "www.amazon.com:1234", "4488", 0, 0 * days),
+            testAccount("daniel", "www.amazon.com:1234", "23456", 0),
+            testAccount("john", "www.amazon.com:1234", "4567", 0),
+            testAccount("quinn", "www.amazon.com:1234", "2345", 0),
+            testAccount("pheobe", "amazon.com:1234", "4488", 10 * days, 2 * days),
+            testAccount("anna", "amazon.com:1234", "1234", 50 * days),
+            testAccount("jane", "amazon.com:1234", "7890", 0),
+            testAccount("oscar", "amazon.com:1234", "7890", 0),
+            testAccount("paul", "amazon.com:1234", "3456", 0),
+            testAccount("rachel", "amazon.com:1234", "7890", 0),
+            testAccount("", "amazon.com:1234", "3456", 0),
+            testAccount("peter", "primevideo.amazon.com:1234", "4567", 85 * days),
+            testAccount("lisa", "books.amazon.com:1234", "5678", 50 * days),
+            testAccount("william", "fashion.amazon.com:1234", "1234", 50 * days),
+            testAccount("mary", "garden.amazon.com:1234", "12345", 50 * days),
+            testAccount("olivia", "toys.amazon.com:1234", "4567", 50 * days),
+            testAccount("chris", "baby.amazon.com:1234", "3456", 0),
+            testAccount("jacob", "office.amazon.com:1234", "12345", 0),
+            testAccount("frank", "sports.amazon.com:1234", "23456", 0),
+            testAccount("", "appliances.amazon.com:1234", "5678", 0),
+            testAccount("", "grocery.amazon.com:1234", "4567", 0),
+            testAccount("", "movies.amazon.com:1234", "2345", 0)
+        ]
+        for i in 0...controlAccounts.count - 1 {
+            XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
+        }
+    }
+
     func testWWWAccountsAreConsideredTopLevel() {
 
         let sortedAccounts = sortTestAccounts.sortedForDomain("amazon.com", tld: tld)
@@ -289,6 +350,28 @@ class SecureVaultModelTests: XCTestCase {
             testAccount("daniel", "www.amazon.com", "23456", 0),
             testAccount("john", "www.amazon.com", "4567", 0),
             testAccount("quinn", "www.amazon.com", "2345", 0),
+        ]
+        for i in 0...controlAccounts.count - 1 {
+            XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
+        }
+    }
+
+    func testWWWAccountsWithPortAreConsideredTopLevel() {
+
+        let sortedAccounts = sortTestAccountsWithPorts.sortedForDomain("amazon.com:1234", tld: tld)
+        let controlAccounts = [
+            testAccount("pheobe", "amazon.com:1234", "4488", 10 * days, 2 * days),
+            testAccount("anna", "amazon.com:1234", "1234", 50 * days),
+            testAccount("jane", "amazon.com:1234", "7890", 0),
+            testAccount("oscar", "amazon.com:1234", "7890", 0),
+            testAccount("paul", "amazon.com:1234", "3456", 0),
+            testAccount("rachel", "amazon.com:1234", "7890", 0),
+            testAccount("", "amazon.com:1234", "3456", 0),
+            testAccount("ringo", "www.amazon.com:1234", "1233", 0, 1 * days),
+            testAccount("george", "www.amazon.com:1234", "4488", 0, 0 * days),
+            testAccount("daniel", "www.amazon.com:1234", "23456", 0),
+            testAccount("john", "www.amazon.com:1234", "4567", 0),
+            testAccount("quinn", "www.amazon.com:1234", "2345", 0),
         ]
         for i in 0...controlAccounts.count - 1 {
             XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
@@ -329,6 +412,40 @@ class SecureVaultModelTests: XCTestCase {
         }
     }
 
+    func testExactSubdomainMatchWithPortIsFirstFollowedByTLDAndWWW() {
+
+        let sortedAccounts  = sortTestAccountsWithPorts.sortedForDomain("toys.amazon.com:1234", tld: tld)
+        let controlAccounts  = [
+            testAccount("olivia", "toys.amazon.com:1234", "4567", 50 * days),
+            testAccount("pheobe", "amazon.com:1234", "4488", 10 * days, 2 * days),
+            testAccount("ringo", "www.amazon.com:1234", "1233", 0, 1 * days),
+            testAccount("george", "www.amazon.com:1234", "4488", 0, 0 * days),
+            testAccount("anna", "amazon.com:1234", "1234", 50 * days),
+            testAccount("jane", "amazon.com:1234", "7890", 0),
+            testAccount("oscar", "amazon.com:1234", "7890", 0),
+            testAccount("paul", "amazon.com:1234", "3456", 0),
+            testAccount("rachel", "amazon.com:1234", "7890", 0),
+            testAccount("daniel", "www.amazon.com:1234", "23456", 0),
+            testAccount("john", "www.amazon.com:1234", "4567", 0),
+            testAccount("quinn", "www.amazon.com:1234", "2345", 0),
+            testAccount("", "amazon.com:1234", "3456", 0),
+            testAccount("peter", "primevideo.amazon.com:1234", "4567", 85 * days),
+            testAccount("lisa", "books.amazon.com:1234", "5678", 50 * days),
+            testAccount("william", "fashion.amazon.com:1234", "1234", 50 * days),
+            testAccount("mary", "garden.amazon.com:1234", "12345", 50 * days),
+            testAccount("chris", "baby.amazon.com:1234", "3456", 0),
+            testAccount("jacob", "office.amazon.com:1234", "12345", 0),
+            testAccount("frank", "sports.amazon.com:1234", "23456", 0),
+            testAccount("", "appliances.amazon.com:1234", "5678", 0),
+            testAccount("", "grocery.amazon.com:1234", "4567", 0),
+            testAccount("", "movies.amazon.com:1234", "2345", 0)
+        ]
+        XCTAssertTrue(sortedAccounts.count == controlAccounts.count)
+        for i in 0...controlAccounts.count - 1 {
+            XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
+        }
+    }
+
     func testDuplicatesAreProperlyRemoved() {
         // (Note Duplicates are removed exclusively based on signature -- Ignoring usernames/domains)
         let sortedAccounts  = sortTestAccounts.sortedForDomain("toys.amazon.com", tld: tld, removeDuplicates: true)
@@ -344,6 +461,28 @@ class SecureVaultModelTests: XCTestCase {
             testAccount("lisa", "books.amazon.com", "5678", 50 * days),
             testAccount("mary", "garden.amazon.com", "12345", 50 * days),
         ]
+
+        for i in 0...controlAccounts.count - 1 {
+            XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
+        }
+    }
+
+    func testDomainWithPortIsSorted() {
+        // (Note Duplicates are removed exclusively based on signature -- Ignoring usernames/domains)
+        let sortedAccounts  = sortTestAccountsWithPorts.sortedForDomain("toys.amazon.com:1234", tld: tld, removeDuplicates: true)
+        let controlAccounts  = [
+            testAccount("olivia", "toys.amazon.com:1234", "4567", 50 * days),
+            testAccount("pheobe", "amazon.com:1234", "4488", 10 * days, 2 * days),
+            testAccount("ringo", "www.amazon.com:1234", "1233", 0, 1 * days),
+            testAccount("anna", "amazon.com:1234", "1234", 50 * days),
+            testAccount("jane", "amazon.com:1234", "7890", 0),
+            testAccount("paul", "amazon.com:1234", "3456", 0),
+            testAccount("daniel", "www.amazon.com:1234", "23456", 0),
+            testAccount("quinn", "www.amazon.com:1234", "2345", 0),
+            testAccount("lisa", "books.amazon.com:1234", "5678", 50 * days),
+            testAccount("mary", "garden.amazon.com:1234", "12345", 50 * days),
+        ]
+
         for i in 0...controlAccounts.count - 1 {
             XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
         }

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultModelTests.swift
@@ -268,6 +268,15 @@ class SecureVaultModelTests: XCTestCase {
         testAccount("pheobe", "amazon.com:1234", "4488", 10 * days, 2 * days)
     ]
 
+    lazy var localHostWithPorts = [
+        testAccount("ringo", "subdomain.localhost:1234", "5678", 0),
+        testAccount("mary", "localhost:1234", "5678", 0),
+        testAccount("daniel", "localhost:1234", "23456", 0),
+        testAccount("lisa", "localhost:1234", "5678", 50  * days),
+        testAccount("", "subdomain.localhost:1234", "4567", 85 * days),
+        testAccount("jane", "subdomain.localhost:1234", "7890", 0),
+    ]
+
     func testExactMatchAccountsAreShownFirst() {
         let sortedAccounts = sortTestAccounts.sortedForDomain("www.amazon.com", tld: tld)
 
@@ -481,6 +490,36 @@ class SecureVaultModelTests: XCTestCase {
             testAccount("quinn", "www.amazon.com:1234", "2345", 0),
             testAccount("lisa", "books.amazon.com:1234", "5678", 50 * days),
             testAccount("mary", "garden.amazon.com:1234", "12345", 50 * days),
+        ]
+
+        for i in 0...controlAccounts.count - 1 {
+            XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
+        }
+    }
+
+    func testReturnsLocalhostWithPortSorted() {
+        let sortedAccounts  = localHostWithPorts.sortedForDomain("localhost:1234", tld: tld, removeDuplicates: false)
+        let controlAccounts  = [
+            testAccount("lisa", "localhost:1234", "5678", 50  * days),
+            testAccount("daniel", "localhost:1234", "23456", 0),
+            testAccount("mary", "localhost:1234", "5678", 0),
+            testAccount("jane", "subdomain.localhost:1234", "7890", 0),
+            testAccount("ringo", "subdomain.localhost:1234", "5678", 0),
+            testAccount("", "subdomain.localhost:1234", "4567", 85 * days)
+        ]
+
+        for i in 0...controlAccounts.count - 1 {
+            XCTAssertEqual(sortedAccounts[i], controlAccounts[i])
+        }
+    }
+
+    func testReturnsLocalhostWithPortSortedAndDuplicatedRemoved() {
+        let sortedAccounts  = localHostWithPorts.sortedForDomain("localhost:1234", tld: tld, removeDuplicates: true)
+        let controlAccounts  = [
+            testAccount("lisa", "localhost:1234", "5678", 50  * days),
+            testAccount("daniel", "localhost:1234", "23456", 0),
+            testAccount("jane", "subdomain.localhost:1234", "7890", 0),
+            testAccount("", "subdomain.localhost:1234", "4567", 85 * days)
         ]
 
         for i in 0...controlAccounts.count - 1 {

--- a/Tests/CommonTests/Extensions/URLComponentsExtensionTests.swift
+++ b/Tests/CommonTests/Extensions/URLComponentsExtensionTests.swift
@@ -1,0 +1,51 @@
+//
+//  URLComponentsExtensionTests.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import XCTest
+
+final class URLComponentsExtensionTests: XCTestCase {
+
+    private let portSuffix = ":1234"
+    private let domain = "https://www.duckduckgo.com"
+    private let etldPlus1 = "duckduckgo.com"
+
+    func testWhenGetETLDplus1WithPort_ThenPortIsReturnedWithResult() throws {
+        // Given
+        let domainAndPort = domain + portSuffix
+        var sut = URLComponents(string: domainAndPort)
+
+        // When
+        let result = sut?.eTLDplus1WithPort(tld: TLD())
+
+        // Then
+        XCTAssertTrue(result!.hasSuffix(portSuffix))
+    }
+
+    func testWhenGetETLDplus1WithOutPort_ThenETLDPlus1IsReturned() throws {
+        // Given
+        var sut = URLComponents(string: domain)
+
+        // When
+        let result = sut?.eTLDplus1WithPort(tld: TLD())
+
+        // Then
+        XCTAssertEqual(result!, etldPlus1)
+    }
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200930669568058/1206023722645078/f
iOS PR: TBD
macOS PR: TBD
What kind of version bump will this require?: Minor

**Description**:
This PR includes the following changes:
* Updates `SecureVaultModels` to return sorted Accounts when the target domain has a port suffix
* Updates `SecureVaultManager` `getAccounts` method to handle domains with ports, and `localhost`
* Removes `SecureVaultManagerDelegate` default extension implementation, which had the ability to cause an infinite loop
* Add `URLComponentsExtenions` method to return `eTLDPlus1` with a port suffix
* Add tests for all of the above

**Steps to test this PR**:
See related client PRs for test steps

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
