### PR TITLE
Fix Navigation same-document build flags

### DIFF
--- a/Sources/Navigation/NavigationType.swift
+++ b/Sources/Navigation/NavigationType.swift
@@ -56,7 +56,11 @@ public enum NavigationType: Equatable {
         switch navigationAction.navigationType {
         case .linkActivated where navigationAction.isSameDocumentNavigation,
              .other where navigationAction.isSameDocumentNavigation:
+#if PRIVATE_NAVIGATION_DID_FINISH_CALLBACKS_ENABLED
             self = .sameDocumentNavigation(.anchorNavigation)
+#else
+            self = .sameDocumentNavigation
+#endif
 
         case .linkActivated:
 #if os(macOS)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

What kind of version bump will this require?: not affecting current macOS/iOS builds

**Optional**:

**Description**:
- fix BSK.Navigation compilation without build flags

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate the framework builds in iOS env
1. Validate the framework builds without changes to macOS project

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
