### PR TITLE
fix crash in DistributedNavigationDelegate

### DIFF
--- a/Sources/Common/SecurityOrigin.swift
+++ b/Sources/Common/SecurityOrigin.swift
@@ -32,7 +32,7 @@ public struct SecurityOrigin: Hashable {
 
     public static let empty = SecurityOrigin(protocol: "", host: "", port: 0)
 
-    var isEmpty: Bool {
+    public var isEmpty: Bool {
         self == .empty
     }
 

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -559,11 +559,10 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
 
             let finishedNavigationAction: NavigationAction? = {
                 guard let navigation = wkNavigation?.navigation else { return nil }
-                if navigation.state == .finished, navigation.navigationActions.isEmpty == false {
+                if navigation.state == .finished || navigation.state.isFailed, navigation.navigationActions.isEmpty == false {
                     // about: scheme navigation for `<a target='_blank'>` duplicates didStart/didCommit/didFinish events with the same WKNavigation
                     return navigation.navigationAction
                 } else {
-                    assert(webView.url?.isEmpty ?? true, "please report which steps you took to reach this state")
                     // we‘ll get here when allowing to open a new window with an empty URL (`window.open()`) from a permission context menu
                     return nil
                 }

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -539,32 +539,52 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
 
     @MainActor
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation wkNavigation: WKNavigation?) {
-        let navigation: Navigation
-        if let expectedNavigation = navigationExpectedToStart,
-           wkNavigation != nil
-            || expectedNavigation.navigationAction.navigationType == .sessionRestoration
-            || expectedNavigation.navigationAction.url.scheme.map(URL.NavigationalScheme.init) == .about {
+        var navigation: Navigation
+        if let approvedNavigation = wkNavigation?.navigation,
+           approvedNavigation.state == .approved, approvedNavigation.navigationActions.isEmpty == false {
+            // rely on the associated Navigation that is in the correct state
+            navigation = approvedNavigation
+
+        } else if let expectedNavigation = navigationExpectedToStart,
+                  wkNavigation != nil
+                    || expectedNavigation.navigationAction.navigationType == .sessionRestoration
+                    || expectedNavigation.navigationAction.url.scheme.map(URL.NavigationalScheme.init) == .about {
 
             // regular flow: start .expected navigation
             navigation = expectedNavigation
-        } else if webView.url?.isEmpty == false {
+
+        } else {
+            // make a new Navigation object for unexpected navigations (that didn‘t receive corresponding `decidePolicyForNavigationAction`)
             navigation = Navigation(identity: NavigationIdentity(wkNavigation), responders: responders, state: .expected(nil), isCurrent: true)
-            if let finishedNavigation = wkNavigation?.navigation {
-                assert(finishedNavigation.state == .finished)
-                // about: scheme navigation for new window sometimes duplicates didStart/didCommit/didFinish events with the same WKNavigation
-                let navigationAction = NavigationAction(request: finishedNavigation.request, navigationType: finishedNavigation.navigationAction.navigationType, currentHistoryItemIdentity: nil, redirectHistory: nil, isUserInitiated: false, sourceFrame: finishedNavigation.navigationAction.sourceFrame, targetFrame: finishedNavigation.navigationAction.targetFrame, shouldDownload: false, mainFrameNavigation: navigation)
-                navigation.navigationActionReceived(navigationAction)
-            } else {
-                navigation.navigationActionReceived(.alternateHtmlLoadNavigation(webView: webView, mainFrameNavigation: navigation))
-            }
-            navigation.willStart()
-        } else if let wkNavigation {
-            navigation = Navigation(identity: NavigationIdentity(wkNavigation), responders: responders, state: .expected(nil), isCurrent: true)
-            let navigationAction = NavigationAction(request: URLRequest(url: .empty), navigationType: .other, currentHistoryItemIdentity: nil, redirectHistory: nil, isUserInitiated: false, sourceFrame: .mainFrame(for: webView), targetFrame: .mainFrame(for: webView), shouldDownload: false, mainFrameNavigation: navigation)
+
+            let finishedNavigationAction: NavigationAction? = {
+                guard let navigation = wkNavigation?.navigation else { return nil }
+                if navigation.state == .finished, navigation.navigationActions.isEmpty == false  {
+                    // about: scheme navigation for `<a target='_blank'>` duplicates didStart/didCommit/didFinish events with the same WKNavigation
+                    return navigation.navigationAction
+                } else {
+                    assert(webView.url?.isEmpty ?? true, "please report which steps you took to reach this state")
+                    // we‘ll get here when allowing to open a new window with an empty URL (`window.open()`) from a permission context menu
+                    return nil
+                }
+            }()
+            let navigationAction: NavigationAction = {
+                if wkNavigation == nil, webView.url?.isEmpty == false {
+                    // loading error page
+                    return .alternateHtmlLoadNavigation(webView: webView, mainFrameNavigation: navigation)
+                }
+                return NavigationAction(request: URLRequest(url: webView.url ?? .empty),
+                                        navigationType: finishedNavigationAction?.navigationType ?? .other,
+                                        currentHistoryItemIdentity: nil,
+                                        redirectHistory: nil,
+                                        isUserInitiated: false,
+                                        sourceFrame: finishedNavigationAction?.sourceFrame ?? .mainFrame(for: webView),
+                                        targetFrame: finishedNavigationAction?.targetFrame ?? .mainFrame(for: webView),
+                                        shouldDownload: false,
+                                        mainFrameNavigation: navigation)
+            }()            
             navigation.navigationActionReceived(navigationAction)
             navigation.willStart()
-        } else {
-            return
         }
 
         navigation.started(wkNavigation)
@@ -867,7 +887,6 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
                 true
             }
 
-            assert(wkNavigation != nil)
             navigation = Navigation(identity: NavigationIdentity(wkNavigation), responders: responders, state: .expected(nil), isCurrent: isCurrent)
             let request = wkNavigation?.request ?? URLRequest(url: webView.url ?? .empty)
             let navigationAction = NavigationAction(request: request, navigationType: .sameDocumentNavigation(navigationType), currentHistoryItemIdentity: currentHistoryItemIdentity, redirectHistory: nil, isUserInitiated: wkNavigation?.isUserInitiated ?? false, sourceFrame: .mainFrame(for: webView), targetFrame: .mainFrame(for: webView), shouldDownload: false, mainFrameNavigation: navigation)

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -559,7 +559,7 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
 
             let finishedNavigationAction: NavigationAction? = {
                 guard let navigation = wkNavigation?.navigation else { return nil }
-                if navigation.state == .finished, navigation.navigationActions.isEmpty == false  {
+                if navigation.state == .finished, navigation.navigationActions.isEmpty == false {
                     // about: scheme navigation for `<a target='_blank'>` duplicates didStart/didCommit/didFinish events with the same WKNavigation
                     return navigation.navigationAction
                 } else {
@@ -582,7 +582,7 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
                                         targetFrame: finishedNavigationAction?.targetFrame ?? .mainFrame(for: webView),
                                         shouldDownload: false,
                                         mainFrameNavigation: navigation)
-            }()            
+            }()
             navigation.navigationActionReceived(navigationAction)
             navigation.willStart()
         }

--- a/Sources/Navigation/Navigation.swift
+++ b/Sources/Navigation/Navigation.swift
@@ -81,7 +81,7 @@ public final class Navigation {
 
     /// is Finished or Failed
     public var isCompleted: Bool {
-        return state.isFinished || state.isFailed
+        return state.isCompleted
     }
 
     internal var hasReceivedNavigationAction: Bool {

--- a/Sources/Navigation/Navigation.swift
+++ b/Sources/Navigation/Navigation.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import Common
 import Foundation
 import WebKit
@@ -31,7 +32,7 @@ public final class Navigation {
     /// Is the navigation currently loaded in the WebView
     private(set) public var isCurrent: Bool
 
-    public fileprivate(set) var state: NavigationState
+    @Published public fileprivate(set) var state: NavigationState
     public private(set) var isCommitted: Bool = false
     public private(set) var didReceiveAuthenticationChallenge: Bool = false
 

--- a/Sources/Navigation/Navigation.swift
+++ b/Sources/Navigation/Navigation.swift
@@ -83,6 +83,10 @@ public final class Navigation {
         return state.isFinished || state.isFailed
     }
 
+    internal var hasReceivedNavigationAction: Bool {
+        navigationActions.isEmpty == false
+    }
+
 }
 
 public protocol NavigationProtocol: AnyObject {

--- a/Sources/Navigation/NavigationState.swift
+++ b/Sources/Navigation/NavigationState.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WebKit
 
-public enum NavigationState: Equatable {
+public enum NavigationState: Equatable, Comparable {
 
     case expected(NavigationType?)
     case navigationActionReceived
@@ -72,6 +72,24 @@ public enum NavigationState: Equatable {
         case .failed(let error1): if case .failed(let error2) = rhs { return error1.code == error2.code }
         }
         return false
+    }
+
+    private var rawValue: UInt {
+        switch self {
+        case .expected: 0
+        case .navigationActionReceived: 1
+        case .approved: 2
+        case .started: 3
+        case .willPerformClientRedirect: 4
+        case .redirected: 5
+        case .responseReceived: 6
+        case .finished: 7
+        case .failed: 8
+        }
+    }
+
+    public static func < (lhs: NavigationState, rhs: NavigationState) -> Bool {
+        lhs.rawValue < rhs.rawValue
     }
 
 }

--- a/Sources/Navigation/NavigationState.swift
+++ b/Sources/Navigation/NavigationState.swift
@@ -58,6 +58,10 @@ public enum NavigationState: Equatable, Comparable {
         return false
     }
 
+    public var isCompleted: Bool {
+        isFinished || isFailed
+    }
+
     // swiftlint:disable:next cyclomatic_complexity
     public static func == (lhs: NavigationState, rhs: NavigationState) -> Bool {
         switch lhs {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL:  https://app.asana.com/0/1177771139624306/1206920871805921/f
iOS PR: not affected
macOS PR: 
What kind of version bump will this require?: Patch

**Description**:
- https://errors.duckduckgo.com/organizations/ddg/issues/17228/?query=is%3Aunresolved&referrer=issue-stream&stream_index=3
- I could not reproduce the crash but refactored the place where it happened
- fixed the wrong Navigation object chosen for quick consequent navigations (like multiple downloads)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. the navigations handled by the modified method can be triggered by opening a `<a target="_blank" href="about:blank">link</a>`, running `window.open()` from js console and allowing the popup. Try different navigations opening a new window.
2. click "download" many times on some website, confirm no assertion is fired and correct Navigation object is used

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->
