### PR TITLE
Only stale PRs, not issues

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -12,8 +12,8 @@ jobs:
         uses: actions/stale@v9
         with:
           stale-pr-message: 'This PR has been inactive for more than 7 days and will be automatically closed 7 days from now.'
-          days-before-stale: 7
+          days-before-pr-stale: 7
           close-pr-message: 'This PR has been closed after 14 days of inactivity. Feel free to reopen it if you plan to continue working on it or have further discussions.'
-          days-before-close: 7
+          days-before-pr-close: 7
           stale-pr-label: stale
           exempt-draft-pr: true


### PR DESCRIPTION
Limit PR stale marking actions to be PRs only. (Avoid marking issues)