### PR TITLE
BSK: Bundle-Specfic Autofill Secure Vault Keychain Items

### DIFF
--- a/Sources/BrowserServicesKit/SecureVault/AutofillDatabaseProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/AutofillDatabaseProvider.swift
@@ -809,7 +809,7 @@ extension DefaultAutofillDatabaseProvider {
         }
 
         let cryptoProvider: SecureStorageCryptoProvider = AutofillSecureVaultFactory.makeCryptoProvider()
-        let keyStoreProvider: SecureStorageKeyStoreProvider = AutofillSecureVaultFactory.makeKeyStoreProvider()
+        let keyStoreProvider: SecureStorageKeyStoreProvider = AutofillSecureVaultFactory.makeKeyStoreProvider(nil)
 
         // The initial version of the credit card model stored the credit card number as L1 data. This migration
         // updates it to store the full number as L2 data, and the suffix as L1 data for use with the Autofill
@@ -1014,7 +1014,7 @@ extension DefaultAutofillDatabaseProvider {
     static private func updatePasswordHashes(database: Database) throws {
         let accountRows = try Row.fetchCursor(database, sql: "SELECT * FROM \(SecureVaultModels.WebsiteAccount.databaseTableName)")
         let cryptoProvider: SecureStorageCryptoProvider = AutofillSecureVaultFactory.makeCryptoProvider()
-        let keyStoreProvider: SecureStorageKeyStoreProvider = AutofillSecureVaultFactory.makeKeyStoreProvider()
+        let keyStoreProvider: SecureStorageKeyStoreProvider = AutofillSecureVaultFactory.makeKeyStoreProvider(nil)
         let salt = cryptoProvider.hashingSalt
 
         while let accountRow = try accountRows.next() {

--- a/Sources/BrowserServicesKit/SecureVault/AutofillKeyStoreProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/AutofillKeyStoreProvider.swift
@@ -52,14 +52,16 @@ final class AutofillKeyStoreProvider: SecureStorageKeyStoreProvider {
         }
 
         static func entryName(from keyValue: String) -> EntryName? {
-            if keyValue == EntryName.generatedPassword.keyValue {
+            switch keyValue {
+            case EntryName.generatedPassword.keyValue:
                 return .generatedPassword
-            } else if keyValue == EntryName.l1Key.keyValue {
+            case EntryName.l1Key.keyValue:
                 return .l1Key
-            } else if keyValue == EntryName.l2Key.keyValue {
+            case EntryName.l2Key.keyValue:
                 return .l2Key
+            default:
+                return nil
             }
-            return nil
         }
     }
 

--- a/Sources/BrowserServicesKit/SecureVault/AutofillKeyStoreProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/AutofillKeyStoreProvider.swift
@@ -30,7 +30,7 @@ final class AutofillKeyStoreProvider: SecureStorageKeyStoreProvider {
 
     // DO NOT CHANGE except if you want to deliberately invalidate all users's vaults.
     // The keys have a uid to deter casual hacker from easily seeing which keychain entry is related to what.
-    private enum EntryName: String {
+    enum EntryName: String, CaseIterable {
 
         case generatedPassword = "32A8C8DF-04AF-4C9D-A4C7-83096737A9C0"
         case l1Key = "79963A16-4E3A-464C-B01A-9774B3F695F1"
@@ -52,14 +52,14 @@ final class AutofillKeyStoreProvider: SecureStorageKeyStoreProvider {
             }
         }
 
-        static func entryName(from keyValue: String) -> EntryName? {
+        init?(_ keyValue: String) {
             switch keyValue {
             case EntryName.generatedPassword.keychainIdentifier:
-                return .generatedPassword
+                self = .generatedPassword
             case EntryName.l1Key.keychainIdentifier:
-                return .l1Key
+                self = .l1Key
             case EntryName.l2Key.keychainIdentifier:
-                return .l2Key
+                self = .l2Key
             default:
                 return nil
             }
@@ -111,7 +111,7 @@ final class AutofillKeyStoreProvider: SecureStorageKeyStoreProvider {
             os_log("Autofill Keystore data retrieved", log: .autofill, type: .debug)
             return data
         } else {
-            guard let entryName = EntryName.entryName(from: name) else { return nil }
+            guard let entryName = EntryName(name) else { return nil }
 
             reporter?.secureVaultKeyStoreEvent(entryName.keyStoreMigrationEvent)
 

--- a/Sources/BrowserServicesKit/SecureVault/AutofillKeyStoreProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/AutofillKeyStoreProvider.swift
@@ -36,6 +36,12 @@ final class AutofillKeyStoreProvider: SecureStorageKeyStoreProvider {
 
     }
 
+    let keychainService: KeychainService
+
+    init(keychainService: KeychainService = DefaultKeychainService()) {
+        self.keychainService = keychainService
+    }
+
     var keychainServiceName: String {
         return Constants.defaultServiceName
     }
@@ -59,7 +65,7 @@ final class AutofillKeyStoreProvider: SecureStorageKeyStoreProvider {
 
         var item: CFTypeRef?
 
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        let status = keychainService.itemMatching(query, &item)
         switch status {
         case errSecSuccess:
             if serviceName == Constants.defaultServiceName {

--- a/Sources/BrowserServicesKit/SecureVault/AutofillKeyStoreProvider.swift
+++ b/Sources/BrowserServicesKit/SecureVault/AutofillKeyStoreProvider.swift
@@ -40,6 +40,17 @@ final class AutofillKeyStoreProvider: SecureStorageKeyStoreProvider {
             (Bundle.main.bundleIdentifier ?? "com.duckduckgo") + rawValue
         }
 
+        var keyStoreMigrationEvent: SecureStorageKeyStoreEvent {
+            switch self {
+            case .l1Key:
+                return .l1KeyMigration
+            case .l2Key:
+                return .l2KeyMigration
+            case .generatedPassword:
+                return .l2KeyPasswordMigration
+            }
+        }
+
         static func entryName(from keyValue: String) -> EntryName? {
             if keyValue == EntryName.generatedPassword.keyValue {
                 return .generatedPassword
@@ -57,10 +68,14 @@ final class AutofillKeyStoreProvider: SecureStorageKeyStoreProvider {
     private var log: OSLog {
         getLog()
     }
+    private var reporter: SecureVaultReporting?
 
-    init(keychainService: KeychainService = DefaultKeychainService(), log: @escaping @autoclosure () -> OSLog = .disabled) {
+    init(keychainService: KeychainService = DefaultKeychainService(),
+         log: @escaping @autoclosure () -> OSLog = .disabled,
+         reporter: SecureVaultReporting? = nil) {
         self.keychainService = keychainService
         self.getLog = log
+        self.reporter = reporter
     }
 
     var keychainServiceName: String {
@@ -94,6 +109,8 @@ final class AutofillKeyStoreProvider: SecureStorageKeyStoreProvider {
             return data
         } else {
             guard let entryName = EntryName.entryName(from: name) else { return nil }
+
+            reporter?.secureVaultKeyStoreEvent(entryName.keyStoreMigrationEvent)
 
             // Look for items based on older EntryName attributes (pre-bundle-specifc Keychain storage)
             if let data = try migrateEntry(entryName: entryName, serviceName: keychainServiceName) {

--- a/Sources/BrowserServicesKit/SecureVault/AutofillSecureVault.swift
+++ b/Sources/BrowserServicesKit/SecureVault/AutofillSecureVault.swift
@@ -27,8 +27,8 @@ public typealias AutofillVaultFactory = SecureVaultFactory<DefaultAutofillSecure
 public let AutofillSecureVaultFactory: AutofillVaultFactory = SecureVaultFactory<DefaultAutofillSecureVault>(
     makeCryptoProvider: {
         return AutofillCryptoProvider()
-    }, makeKeyStoreProvider: {
-        return AutofillKeyStoreProvider()
+    }, makeKeyStoreProvider: { reporter in
+        return AutofillKeyStoreProvider(reporter: reporter)
     }, makeDatabaseProvider: { key in
         return try DefaultAutofillDatabaseProvider(key: key)
     }

--- a/Sources/BrowserServicesKit/SecureVault/CredentialsDatabaseCleaner.swift
+++ b/Sources/BrowserServicesKit/SecureVault/CredentialsDatabaseCleaner.swift
@@ -99,7 +99,7 @@ public final class CredentialsDatabaseCleaner {
         var saveAttemptsLeft = Const.maxContextSaveRetries
 
         do {
-            let secureVault = try secureVaultFactory.makeVault(errorReporter: secureVaultErrorReporter)
+            let secureVault = try secureVaultFactory.makeVault(reporter: secureVaultErrorReporter)
 
             while true {
                 do {

--- a/Sources/BrowserServicesKit/SecureVault/CredentialsDatabaseCleaner.swift
+++ b/Sources/BrowserServicesKit/SecureVault/CredentialsDatabaseCleaner.swift
@@ -36,7 +36,7 @@ public final class CredentialsDatabaseCleaner {
 
     public convenience init(
         secureVaultFactory: AutofillVaultFactory,
-        secureVaultErrorReporter: SecureVaultErrorReporting,
+        secureVaultErrorReporter: SecureVaultReporting,
         errorEvents: EventMapping<CredentialsCleanupError>?,
         log: @escaping @autoclosure () -> OSLog = .disabled
     ) {
@@ -51,7 +51,7 @@ public final class CredentialsDatabaseCleaner {
 
     init(
         secureVaultFactory: AutofillVaultFactory,
-        secureVaultErrorReporter: SecureVaultErrorReporting,
+        secureVaultErrorReporter: SecureVaultReporting,
         errorEvents: EventMapping<CredentialsCleanupError>?,
         log: @escaping @autoclosure () -> OSLog = .disabled,
         removeSyncMetadataPendingDeletion: @escaping ((Database) throws -> Int)
@@ -153,7 +153,7 @@ public final class CredentialsDatabaseCleaner {
 
     private let errorEvents: EventMapping<CredentialsCleanupError>?
     private let secureVaultFactory: AutofillVaultFactory
-    private let secureVaultErrorReporter: SecureVaultErrorReporting
+    private let secureVaultErrorReporter: SecureVaultReporting
     private let externalTriggerSubject = PassthroughSubject<Void, Never>()
     private let scheduledTriggerSubject = PassthroughSubject<Void, Never>()
     private let workQueue = DispatchQueue(label: "CredentialsDatabaseCleaner queue", qos: .userInitiated)

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -154,7 +154,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                 completionHandler([], [], [], credentialsProvider)
                 return
             }
-            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
 
             var identities: [SecureVaultModels.Identity] = []
             if delegate.secureVaultManagerIsEnabledStatus(self, forType: .identity) {
@@ -213,7 +213,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
             }
 
             var autofilldata = data
-            let vault = try? self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+            let vault = try? self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
             var autoSavedCredentials: SecureVaultModels.WebsiteCredentials?
 
             // If the user navigated away from current domain, remove autosave data
@@ -318,7 +318,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                                                                  SecureVaultModels.CredentialsProvider) -> Void) {
 
         do {
-            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
             getAccounts(for: domain, from: vault,
                         or: passwordManager,
                         withPartialMatches: includePartialAccountMatches) { [weak self] accounts, error in
@@ -346,7 +346,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                                                                  SecureVaultModels.CredentialsProvider,
                                                                  RequestVaultCredentialsAction) -> Void) {
         do {
-            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
 
             getAccounts(for: domain,
                         from: vault,
@@ -411,7 +411,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                                                                  SecureVaultModels.CredentialsProvider) -> Void) {
 
         do {
-            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
 
             updateLastUsedDate(for: accountId, vault: vault)
 
@@ -443,7 +443,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                                    didRequestCreditCardWithId creditCardId: Int64,
                                    completionHandler: @escaping (SecureVaultModels.CreditCard?) -> Void) {
         do {
-            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
             let card = try vault.creditCardFor(id: creditCardId)
 
             delegate?.secureVaultManager(self, didRequestAuthenticationWithCompletionHandler: { authenticated in
@@ -465,7 +465,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                                    didRequestIdentityWithId identityId: Int64,
                                    completionHandler: @escaping (SecureVaultModels.Identity?) -> Void) {
         do {
-            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
             completionHandler(try vault.identityFor(id: identityId))
 
             delegate?.secureVaultManager(self, didAutofill: .identity, withObjectId: String(identityId))
@@ -490,7 +490,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
                         completionHandler([], [], [], self.credentialsProvider)
                     } else {
                         do {
-                            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+                            let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
                             let identities = try vault.identities()
                             let cards = try vault.creditCards()
                             completionHandler(credentials, identities, cards, self.credentialsProvider)
@@ -559,7 +559,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
         let user: String = credentials.username ??  ""
         let pass: String = credentials.password ?? ""
 
-        let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+        let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
         let accounts = try vault.accountsFor(domain: domain)
         var currentAccount: SecureVaultModels.WebsiteAccount
 
@@ -612,7 +612,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
     }
 
     private func createAccount(username: String, password: Data, domain: String) -> SecureVaultModels.WebsiteAccount {
-        let vault = try? self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+        let vault = try? self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
         var account = SecureVaultModels.WebsiteAccount(username: username, domain: domain, lastUsed: Date())
         let credentials = try? vault?.storeWebsiteCredentials(SecureVaultModels.WebsiteCredentials(account: account, password: password))
         account.id = String(credentials ?? -1)
@@ -632,7 +632,7 @@ extension SecureVaultManager: AutofillSecureVaultDelegate {
     func existingEntries(for domain: String,
                          autofillData: AutofillUserScript.DetectedAutofillData
     ) throws -> AutofillData {
-        let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(errorReporter: self.delegate)
+        let vault = try self.vault ?? AutofillSecureVaultFactory.makeVault(reporter: self.delegate)
 
         let proposedIdentity = try existingIdentity(with: autofillData, vault: vault)
         let proposedCredentials: SecureVaultModels.WebsiteCredentials?

--- a/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
+++ b/Sources/BrowserServicesKit/SecureVault/SecureVaultManager.swift
@@ -34,7 +34,7 @@ public struct AutofillData {
     public var automaticallySavedCredentials: Bool
 }
 
-public protocol SecureVaultManagerDelegate: AnyObject, SecureVaultErrorReporting {
+public protocol SecureVaultManagerDelegate: AnyObject, SecureVaultReporting {
 
     func secureVaultManagerIsEnabledStatus(_ manager: SecureVaultManager, forType type: AutofillType?) -> Bool
 

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -47,7 +47,7 @@ extension OSLog {
 #if DEBUG
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     // To activate Logging Categories for DEBUG add categories here:
-    static var debugCategories: Set<Categories> = [ .autofill ]
+    static var debugCategories: Set<Categories> = [ /*.autofill*/ ]
 #endif
 
     @OSLogWrapper(.userScripts)     public static var userScripts

--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -41,12 +41,13 @@ extension OSLog {
         case remoteMessaging = "Remote Messaging"
         case subscription = "Subscription"
         case history = "History"
+        case autofill = "Autofill"
     }
 
 #if DEBUG
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     // To activate Logging Categories for DEBUG add categories here:
-    static var debugCategories: Set<Categories> = [ /* .userScripts, */ ]
+    static var debugCategories: Set<Categories> = [ .autofill ]
 #endif
 
     @OSLogWrapper(.userScripts)     public static var userScripts
@@ -54,6 +55,7 @@ extension OSLog {
     @OSLogWrapper(.remoteMessaging) public static var remoteMessaging
     @OSLogWrapper(.subscription)    public static var subscription
     @OSLogWrapper(.history)         public static var history
+    @OSLogWrapper(.autofill)        public static var autofill
 
     public static var enabledLoggingCategories = Set<String>()
 

--- a/Sources/SecureStorage/SecureStorageKeyStoreProvider.swift
+++ b/Sources/SecureStorage/SecureStorageKeyStoreProvider.swift
@@ -43,6 +43,12 @@ public struct DefaultKeychainService: KeychainService {
     public init() {}
 }
 
+public enum SecureStorageKeyStoreEvent {
+    case l1KeyMigration
+    case l2KeyMigration
+    case l2KeyPasswordMigration
+}
+
 public protocol SecureStorageKeyStoreProvider {
 
     var keychainService: KeychainService { get }

--- a/Sources/SecureStorage/SecureStorageKeyStoreProvider.swift
+++ b/Sources/SecureStorage/SecureStorageKeyStoreProvider.swift
@@ -19,29 +19,29 @@
 import Foundation
 
 /// Conforming types provide methods which interact with the system Keychain. Mainly used to enable testing.
- public protocol KeychainService {
-     func itemMatching(_ query: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
-     func add(_ attributes: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
-     func delete(_ query: [String: Any]) -> OSStatus
- }
+public protocol KeychainService {
+    func itemMatching(_ query: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+    func add(_ attributes: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+    func delete(_ query: [String: Any]) -> OSStatus
+}
 
- public extension KeychainService {
-     func itemMatching(_ query: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
-         SecItemCopyMatching(query as CFDictionary, result)
-     }
+public extension KeychainService {
+    func itemMatching(_ query: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        SecItemCopyMatching(query as CFDictionary, result)
+    }
 
-     func add(_ query: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
-         SecItemAdd(query as CFDictionary, nil)
-     }
+    func add(_ query: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        SecItemAdd(query as CFDictionary, nil)
+    }
 
-     func delete(_ query: [String: Any]) -> OSStatus {
-         SecItemDelete(query as CFDictionary)
-     }
- }
+    func delete(_ query: [String: Any]) -> OSStatus {
+        SecItemDelete(query as CFDictionary)
+    }
+}
 
- public struct DefaultKeychainService: KeychainService {
-     public init() {}
- }
+public struct DefaultKeychainService: KeychainService {
+    public init() {}
+}
 
 public protocol SecureStorageKeyStoreProvider {
 

--- a/Sources/SecureStorage/SecureStorageKeyStoreProvider.swift
+++ b/Sources/SecureStorage/SecureStorageKeyStoreProvider.swift
@@ -18,8 +18,34 @@
 
 import Foundation
 
+/// Conforming types provide methods which interact with the system Keychain. Mainly used to enable testing.
+ public protocol KeychainService {
+     func itemMatching(_ query: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+     func add(_ attributes: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+     func delete(_ query: [String: Any]) -> OSStatus
+ }
+
+ public extension KeychainService {
+     func itemMatching(_ query: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+         SecItemCopyMatching(query as CFDictionary, result)
+     }
+
+     func add(_ query: [String: Any], _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+         SecItemAdd(query as CFDictionary, nil)
+     }
+
+     func delete(_ query: [String: Any]) -> OSStatus {
+         SecItemDelete(query as CFDictionary)
+     }
+ }
+
+ public struct DefaultKeychainService: KeychainService {
+     public init() {}
+ }
+
 public protocol SecureStorageKeyStoreProvider {
 
+    var keychainService: KeychainService { get }
     var generatedPasswordEntryName: String { get }
     var l1KeyEntryName: String { get }
     var l2KeyEntryName: String { get }
@@ -42,6 +68,10 @@ public protocol SecureStorageKeyStoreProvider {
 }
 
 public extension SecureStorageKeyStoreProvider {
+
+    var keychainService: KeychainService {
+        DefaultKeychainService()
+    }
 
     func generatedPassword() throws -> Data? {
         return try readData(named: generatedPasswordEntryName, serviceName: keychainServiceName)
@@ -81,7 +111,7 @@ public extension SecureStorageKeyStoreProvider {
 
         var item: CFTypeRef?
 
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        let status = keychainService.itemMatching(query, &item)
         switch status {
         case errSecSuccess:
             guard let itemData = item as? Data,
@@ -111,7 +141,7 @@ public extension SecureStorageKeyStoreProvider {
         query[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
         query[kSecValueData as String] = base64Data
 
-        let status = SecItemAdd(query as CFDictionary, nil)
+        let status = keychainService.add(query, nil)
 
         guard status == errSecSuccess else {
             throw SecureStorageError.keystoreError(status: status)
@@ -123,7 +153,7 @@ public extension SecureStorageKeyStoreProvider {
     private func deleteEntry(named name: String) throws {
         let query = attributesForEntry(named: name, serviceName: keychainServiceName)
 
-        let status = SecItemDelete(query as CFDictionary)
+        let status = keychainService.delete(query)
         switch status {
         case errSecItemNotFound, errSecSuccess: break
         default:

--- a/Sources/SecureStorage/SecureVaultFactory.swift
+++ b/Sources/SecureStorage/SecureVaultFactory.swift
@@ -18,15 +18,22 @@
 
 import Foundation
 
-public protocol SecureVaultErrorReporting: AnyObject {
-    func secureVaultInitFailed(_ error: SecureStorageError)
+public protocol SecureVaultReporting: AnyObject {
+    func secureVaultError(_ error: SecureStorageError)
+    func secureVaultKeyStoreEvent(_ event: SecureStorageKeyStoreEvent)
+}
+
+public extension SecureVaultReporting {
+    func secureVaultKeyStoreEvent(_ event: SecureStorageKeyStoreEvent) {
+        // no-op by default
+    }
 }
 
 /// Can make a SecureVault instance with given specification.  May return previously created instance if specification is unchanged.
 public class SecureVaultFactory<Vault: SecureVault> {
 
     public typealias CryptoProviderInitialization = () -> SecureStorageCryptoProvider
-    public typealias KeyStoreProviderInitialization = () -> SecureStorageKeyStoreProvider
+    public typealias KeyStoreProviderInitialization = (_ reporter: SecureVaultReporting?) -> SecureStorageKeyStoreProvider
     public typealias DatabaseProviderInitialization = (_ key: Data) throws -> Vault.DatabaseProvider
 
     private var lock = NSLock()
@@ -52,7 +59,7 @@ public class SecureVaultFactory<Vault: SecureVault> {
     /// * Generates a secret key for L2 encryption
     /// * Generates a user password to encrypt the L2 key with
     /// * Stores encrypted L2 key in Keychain
-    public func makeVault(errorReporter: SecureVaultErrorReporting?) throws -> Vault {
+    public func makeVault(errorReporter: SecureVaultReporting?) throws -> Vault {
         if let vault = self.vault {
             return vault
         } else {
@@ -62,7 +69,7 @@ public class SecureVaultFactory<Vault: SecureVault> {
             }
 
             do {
-                let providers = try makeSecureStorageProviders()
+                let providers = try makeSecureStorageProviders(reporter: errorReporter)
                 let vault = Vault(providers: providers)
 
                 self.vault = vault
@@ -70,19 +77,19 @@ public class SecureVaultFactory<Vault: SecureVault> {
                 return vault
 
             } catch let error as SecureStorageError {
-                errorReporter?.secureVaultInitFailed(error)
+                errorReporter?.secureVaultError(error)
                 throw error
             } catch {
-                errorReporter?.secureVaultInitFailed(SecureStorageError.initFailed(cause: error))
+                errorReporter?.secureVaultError(SecureStorageError.initFailed(cause: error))
                 throw SecureStorageError.initFailed(cause: error)
             }
         }
     }
 
-    public func makeSecureStorageProviders() throws -> SecureStorageProviders<Vault.DatabaseProvider> {
+    public func makeSecureStorageProviders(reporter: SecureVaultReporting?) throws -> SecureStorageProviders<Vault.DatabaseProvider> {
         let (cryptoProvider, keystoreProvider): (SecureStorageCryptoProvider, SecureStorageKeyStoreProvider)
         do {
-            (cryptoProvider, keystoreProvider) = try createAndInitializeEncryptionProviders()
+            (cryptoProvider, keystoreProvider) = try createAndInitializeEncryptionProviders(reporter: reporter)
         } catch {
             throw SecureStorageError.initFailed(cause: error)
         }
@@ -96,9 +103,9 @@ public class SecureVaultFactory<Vault: SecureVault> {
         }
     }
 
-    public func createAndInitializeEncryptionProviders() throws -> (SecureStorageCryptoProvider, SecureStorageKeyStoreProvider) {
+    public func createAndInitializeEncryptionProviders(reporter: SecureVaultReporting? = nil) throws -> (SecureStorageCryptoProvider, SecureStorageKeyStoreProvider) {
         let cryptoProvider = makeCryptoProvider()
-        let keystoreProvider = makeKeyStoreProvider()
+        let keystoreProvider = makeKeyStoreProvider(reporter)
 
         if try keystoreProvider.l1Key() != nil {
             return (cryptoProvider, keystoreProvider)

--- a/Sources/SecureStorage/SecureVaultFactory.swift
+++ b/Sources/SecureStorage/SecureVaultFactory.swift
@@ -59,7 +59,7 @@ public class SecureVaultFactory<Vault: SecureVault> {
     /// * Generates a secret key for L2 encryption
     /// * Generates a user password to encrypt the L2 key with
     /// * Stores encrypted L2 key in Keychain
-    public func makeVault(errorReporter: SecureVaultReporting?) throws -> Vault {
+    public func makeVault(reporter: SecureVaultReporting?) throws -> Vault {
         if let vault = self.vault {
             return vault
         } else {
@@ -69,7 +69,7 @@ public class SecureVaultFactory<Vault: SecureVault> {
             }
 
             do {
-                let providers = try makeSecureStorageProviders(reporter: errorReporter)
+                let providers = try makeSecureStorageProviders(reporter: reporter)
                 let vault = Vault(providers: providers)
 
                 self.vault = vault
@@ -77,10 +77,10 @@ public class SecureVaultFactory<Vault: SecureVault> {
                 return vault
 
             } catch let error as SecureStorageError {
-                errorReporter?.secureVaultError(error)
+                reporter?.secureVaultError(error)
                 throw error
             } catch {
-                errorReporter?.secureVaultError(SecureStorageError.initFailed(cause: error))
+                reporter?.secureVaultError(SecureStorageError.initFailed(cause: error))
                 throw SecureStorageError.initFailed(cause: error)
             }
         }

--- a/Sources/SecureStorageTestsUtils/MockKeystoreProvider.swift
+++ b/Sources/SecureStorageTestsUtils/MockKeystoreProvider.swift
@@ -23,8 +23,8 @@ public final class MockKeychainService: KeychainService {
 
     public enum Mode {
         case nothingFound
-        case bundleSpecificFound
-        case nonBundleSpecificFound
+        case v3Found
+        case v2Found
         case v1Found
     }
 
@@ -55,10 +55,10 @@ public final class MockKeychainService: KeychainService {
         switch mode {
         case .nothingFound:
             return errSecItemNotFound
-        case .bundleSpecificFound:
+        case .v3Found:
             setResult()
             return errSecSuccess
-        case .nonBundleSpecificFound:
+        case .v2Found:
             if itemMatchingCallCount == 2 {
                 setResult()
                 return errSecSuccess

--- a/Sources/SecureStorageTestsUtils/MockKeystoreProvider.swift
+++ b/Sources/SecureStorageTestsUtils/MockKeystoreProvider.swift
@@ -42,19 +42,33 @@ public final class MockKeychainService: KeychainService {
         itemMatchingCallCount += 1
         latestItemMatchingQuery = query
 
+        func setResult() {
+            let originalString = "Mock Keychain data!"
+            let data = originalString.data(using: .utf8)!
+            let encodedString = data.base64EncodedString()
+            let mockResult = encodedString.data(using: .utf8)! as CFData
+            
+            if let result = result {
+                result.pointee = mockResult
+            }
+        }
+        
         switch mode {
         case .nothingFound:
             return errSecItemNotFound
         case .bundleSpecificFound:
+            setResult()
             return errSecSuccess
         case .nonBundleSpecificFound:
             if itemMatchingCallCount == 2 {
+                setResult()
                 return errSecSuccess
             } else {
                 return errSecItemNotFound
             }
         case .v1Found:
             if itemMatchingCallCount == 3 {
+                setResult()
                 return errSecSuccess
             } else {
                 return errSecItemNotFound

--- a/Sources/SecureStorageTestsUtils/MockKeystoreProvider.swift
+++ b/Sources/SecureStorageTestsUtils/MockKeystoreProvider.swift
@@ -19,7 +19,6 @@
 import Foundation
 import SecureStorage
 
-
 public final class MockKeychainService: KeychainService {
 
     public enum Mode {
@@ -47,12 +46,12 @@ public final class MockKeychainService: KeychainService {
             let data = originalString.data(using: .utf8)!
             let encodedString = data.base64EncodedString()
             let mockResult = encodedString.data(using: .utf8)! as CFData
-            
+
             if let result = result {
                 result.pointee = mockResult
             }
         }
-        
+
         switch mode {
         case .nothingFound:
             return errSecItemNotFound

--- a/Sources/SyncDataProviders/Credentials/CredentialsProvider.swift
+++ b/Sources/SyncDataProviders/Credentials/CredentialsProvider.swift
@@ -43,7 +43,7 @@ public final class CredentialsProvider: DataProvider {
     // MARK: - DataProviding
 
     public override func prepareForFirstSync() throws {
-        let secureVault = try secureVaultFactory.makeVault(errorReporter: secureVaultErrorReporter)
+        let secureVault = try secureVaultFactory.makeVault(reporter: secureVaultErrorReporter)
         try secureVault.inDatabaseTransaction { database in
 
             let accountIds = try Row.fetchAll(
@@ -84,12 +84,12 @@ public final class CredentialsProvider: DataProvider {
             return []
         }
 
-        let secureVault = try secureVaultFactory.makeVault(errorReporter: secureVaultErrorReporter)
+        let secureVault = try secureVaultFactory.makeVault(reporter: secureVaultErrorReporter)
         return try secureVault.accountTitlesForSyncableCredentials(modifiedBefore: lastSyncLocalTimestamp)
     }
 
     public override func fetchChangedObjects(encryptedUsing crypter: Crypting) async throws -> [Syncable] {
-        let secureVault = try secureVaultFactory.makeVault(errorReporter: secureVaultErrorReporter)
+        let secureVault = try secureVaultFactory.makeVault(reporter: secureVaultErrorReporter)
         let syncableCredentials = try secureVault.modifiedSyncableCredentials()
         let encryptionKey = try crypter.fetchSecretKey()
         return try syncableCredentials.compactMap { credentials in
@@ -147,7 +147,7 @@ public final class CredentialsProvider: DataProvider {
                             crypter: Crypting) async throws {
         var saveError: Error?
 
-        let secureVault = try secureVaultFactory.makeVault(errorReporter: secureVaultErrorReporter)
+        let secureVault = try secureVaultFactory.makeVault(reporter: secureVaultErrorReporter)
         let clientTimestampMilliseconds = clientTimestamp.withMillisecondPrecision
         var saveAttemptsLeft = Const.maxContextSaveRetries
 

--- a/Sources/SyncDataProviders/Credentials/CredentialsProvider.swift
+++ b/Sources/SyncDataProviders/Credentials/CredentialsProvider.swift
@@ -28,7 +28,7 @@ public final class CredentialsProvider: DataProvider {
 
     public init(
         secureVaultFactory: AutofillVaultFactory = AutofillSecureVaultFactory,
-        secureVaultErrorReporter: SecureVaultErrorReporting,
+        secureVaultErrorReporter: SecureVaultReporting,
         metadataStore: SyncMetadataStore,
         metricsEvents: EventMapping<MetricsEvent>? = nil,
         log: @escaping @autoclosure () -> OSLog = .disabled,
@@ -257,7 +257,7 @@ public final class CredentialsProvider: DataProvider {
     // MARK: - Private
 
     private let secureVaultFactory: AutofillVaultFactory
-    private let secureVaultErrorReporter: SecureVaultErrorReporting
+    private let secureVaultErrorReporter: SecureVaultReporting
     private let metricsEvents: EventMapping<MetricsEvent>?
 
     enum Const {

--- a/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
@@ -23,26 +23,9 @@ import SecureStorageTestsUtils
 
 final class AutofillKeyStoreProviderTests: XCTestCase {
 
-    private enum Constants {
-        static let v1ServiceName = "DuckDuckGo Secure Vault"
-        static let v2ServiceName = "DuckDuckGo Secure Vault v2"
-        static let v3ServiceName = "DuckDuckGo Secure Vault v3"
-    }
-
-    private enum EntryName: String, CaseIterable {
-
-        case generatedPassword = "32A8C8DF-04AF-4C9D-A4C7-83096737A9C0"
-        case l1Key = "79963A16-4E3A-464C-B01A-9774B3F695F1"
-        case l2Key = "A5711F4D-7AA5-4F0C-9E4F-BE553F1EA299"
-
-        var keychainIdentifier: String {
-            (Bundle.main.bundleIdentifier ?? "com.duckduckgo") + rawValue
-        }
-    }
-
     func testWhenReadData_AndValueIsFound_NoFallbackSearchIsPerformed() throws {
 
-        try EntryName.allCases.forEach { entry in
+        try AutofillKeyStoreProvider.EntryName.allCases.forEach { entry in
             // Given
             let keychainService = MockKeychainService()
             keychainService.mode = .v3Found
@@ -57,9 +40,9 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
         }
     }
 
-    func testWhenReadData_AndValueNotFound_AllFallbackSearchesArePerformed() throws {
+    func testWhenReadData_AndNoValuesFound_AllFallbackSearchesArePerformed() throws {
 
-        try EntryName.allCases.forEach { entry in
+        try AutofillKeyStoreProvider.EntryName.allCases.forEach { entry in
             // Given
             let keychainService = MockKeychainService()
             let sut = AutofillKeyStoreProvider(keychainService: keychainService)
@@ -72,9 +55,9 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
         }
     }
 
-    func testWhenReadData_AndValueNotFound_V2SearchIsPerformed() throws {
+    func testWhenReadData_AndV3ValueNotFound_V2SearchIsPerformed() throws {
 
-        try EntryName.allCases.forEach { entry in
+        try AutofillKeyStoreProvider.EntryName.allCases.forEach { entry in
             // Given
             let keychainService = MockKeychainService()
             keychainService.mode = .v2Found
@@ -86,14 +69,14 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             // Then
             XCTAssertEqual(keychainService.itemMatchingCallCount, 2)
             XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrAccount as String] as! String, entry.rawValue)
-            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, Constants.v2ServiceName)
+            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, AutofillKeyStoreProvider.Constants.v2ServiceName)
             XCTAssertEqual(String(decoding: result!, as: UTF8.self), "Mock Keychain data!")
         }
     }
 
-    func testWhenReadData_AndValueNotFound_V1SearchIsPerformed() throws {
+    func testWhenReadData_AndV3OrV2ValueNotFound_V1SearchIsPerformed() throws {
 
-        try EntryName.allCases.forEach { entry in
+        try AutofillKeyStoreProvider.EntryName.allCases.forEach { entry in
             // Given
             let keychainService = MockKeychainService()
             keychainService.mode = .v1Found
@@ -105,13 +88,13 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             // Then
             XCTAssertEqual(keychainService.itemMatchingCallCount, 3)
             XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrAccount as String] as! String, entry.rawValue)
-            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, Constants.v1ServiceName)
+            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, AutofillKeyStoreProvider.Constants.v1ServiceName)
         }
     }
 
     func testWhenReadData_AndV2ValueFound_ThenWritesValueToNewStorageWithCorrectAttributes() throws {
 
-        try EntryName.allCases.forEach { entry in
+        try AutofillKeyStoreProvider.EntryName.allCases.forEach { entry in
             // Given
             let keychainService = MockKeychainService()
             keychainService.mode = .v2Found
@@ -123,14 +106,14 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             // Then
             XCTAssertEqual(keychainService.addCallCount, 1)
             XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keychainIdentifier)
-            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.v3ServiceName)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, AutofillKeyStoreProvider.Constants.v3ServiceName)
             XCTAssertEqual(String(decoding: result!, as: UTF8.self), "Mock Keychain data!")
         }
     }
 
     func testWhenReadData_AndV1ValueFound_ThenWritesValueToNewStorageWithCorrectAttributes() throws {
 
-        try EntryName.allCases.forEach { entry in
+        try AutofillKeyStoreProvider.EntryName.allCases.forEach { entry in
             // Given
             let keychainService = MockKeychainService()
             keychainService.mode = .v1Found
@@ -142,7 +125,7 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             // Then
             XCTAssertEqual(keychainService.addCallCount, 1)
             XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keychainIdentifier)
-            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.v3ServiceName)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, AutofillKeyStoreProvider.Constants.v3ServiceName)
         }
     }
 }

--- a/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
@@ -24,8 +24,9 @@ import SecureStorageTestsUtils
 final class AutofillKeyStoreProviderTests: XCTestCase {
 
     private enum Constants {
-        static let legacyServiceName = "DuckDuckGo Secure Vault"
-        static let defaultServiceName = "DuckDuckGo Secure Vault v2"
+        static let v1ServiceName = "DuckDuckGo Secure Vault"
+        static let v2ServiceName = "DuckDuckGo Secure Vault v2"
+        static let v3ServiceName = "DuckDuckGo Secure Vault v3"
     }
 
     private enum EntryName: String, CaseIterable {
@@ -84,7 +85,7 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             // Then
             XCTAssertEqual(keychainService.itemMatchingCallCount, 2)
             XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrAccount as String] as! String, entry.rawValue)
-            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, Constants.defaultServiceName)
+            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, Constants.v2ServiceName)
         }
     }
 
@@ -102,7 +103,7 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             // Then
             XCTAssertEqual(keychainService.itemMatchingCallCount, 3)
             XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrAccount as String] as! String, entry.rawValue)
-            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, Constants.legacyServiceName)
+            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, Constants.v1ServiceName)
         }
     }
 
@@ -120,7 +121,7 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             // Then
             XCTAssertEqual(keychainService.addCallCount, 1)
             XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keyValue)
-            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.defaultServiceName)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.v3ServiceName)
         }
     }
 
@@ -138,7 +139,7 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             // Then
             XCTAssertEqual(keychainService.addCallCount, 1)
             XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keyValue)
-            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.defaultServiceName)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.v3ServiceName)
         }
     }
 }

--- a/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
@@ -119,6 +119,7 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
 
             // Then
             XCTAssertEqual(keychainService.addCallCount, 1)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keyValue)
             XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.defaultServiceName)
         }
     }
@@ -136,6 +137,7 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
 
             // Then
             XCTAssertEqual(keychainService.addCallCount, 1)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keyValue)
             XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.defaultServiceName)
         }
     }

--- a/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
@@ -35,7 +35,7 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
         case l1Key = "79963A16-4E3A-464C-B01A-9774B3F695F1"
         case l2Key = "A5711F4D-7AA5-4F0C-9E4F-BE553F1EA299"
 
-        var keyValue: String {
+        var keychainIdentifier: String {
             (Bundle.main.bundleIdentifier ?? "com.duckduckgo") + rawValue
         }
     }
@@ -45,14 +45,15 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
         try EntryName.allCases.forEach { entry in
             // Given
             let keychainService = MockKeychainService()
-            keychainService.mode = .bundleSpecificFound
+            keychainService.mode = .v3Found
             let sut = AutofillKeyStoreProvider(keychainService: keychainService)
 
             // When
-            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+            let result = try sut.readData(named: entry.keychainIdentifier, serviceName: sut.keychainServiceName)
 
             // Then
             XCTAssertEqual(keychainService.itemMatchingCallCount, 1)
+            XCTAssertEqual(String(decoding: result!, as: UTF8.self), "Mock Keychain data!")
         }
     }
 
@@ -64,28 +65,29 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             let sut = AutofillKeyStoreProvider(keychainService: keychainService)
 
             // When
-            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+            _ = try sut.readData(named: entry.keychainIdentifier, serviceName: sut.keychainServiceName)
 
             // Then
             XCTAssertEqual(keychainService.itemMatchingCallCount, 3)
         }
     }
 
-    func testWhenReadData_AndValueNotFound_NonBundleSpecificSearchIsPerformed() throws {
+    func testWhenReadData_AndValueNotFound_V2SearchIsPerformed() throws {
 
         try EntryName.allCases.forEach { entry in
             // Given
             let keychainService = MockKeychainService()
-            keychainService.mode = .nonBundleSpecificFound
+            keychainService.mode = .v2Found
             let sut = AutofillKeyStoreProvider(keychainService: keychainService)
 
             // When
-            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+            let result = try sut.readData(named: entry.keychainIdentifier, serviceName: sut.keychainServiceName)
 
             // Then
             XCTAssertEqual(keychainService.itemMatchingCallCount, 2)
             XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrAccount as String] as! String, entry.rawValue)
             XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, Constants.v2ServiceName)
+            XCTAssertEqual(String(decoding: result!, as: UTF8.self), "Mock Keychain data!")
         }
     }
 
@@ -98,7 +100,7 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             let sut = AutofillKeyStoreProvider(keychainService: keychainService)
 
             // When
-            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+            _ = try sut.readData(named: entry.keychainIdentifier, serviceName: sut.keychainServiceName)
 
             // Then
             XCTAssertEqual(keychainService.itemMatchingCallCount, 3)
@@ -107,21 +109,22 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
         }
     }
 
-    func testWhenReadData_AndNonBundleSpecificValueFound_ThenWritesValueToNewStorageWithCorrectAttributes() throws {
+    func testWhenReadData_AndV2ValueFound_ThenWritesValueToNewStorageWithCorrectAttributes() throws {
 
         try EntryName.allCases.forEach { entry in
             // Given
             let keychainService = MockKeychainService()
-            keychainService.mode = .nonBundleSpecificFound
+            keychainService.mode = .v2Found
             let sut = AutofillKeyStoreProvider(keychainService: keychainService)
 
             // When
-            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+            let result = try sut.readData(named: entry.keychainIdentifier, serviceName: sut.keychainServiceName)
 
             // Then
             XCTAssertEqual(keychainService.addCallCount, 1)
-            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keyValue)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keychainIdentifier)
             XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.v3ServiceName)
+            XCTAssertEqual(String(decoding: result!, as: UTF8.self), "Mock Keychain data!")
         }
     }
 
@@ -134,11 +137,11 @@ final class AutofillKeyStoreProviderTests: XCTestCase {
             let sut = AutofillKeyStoreProvider(keychainService: keychainService)
 
             // When
-            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+            _ = try sut.readData(named: entry.keychainIdentifier, serviceName: sut.keychainServiceName)
 
             // Then
             XCTAssertEqual(keychainService.addCallCount, 1)
-            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keyValue)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrAccount as String] as! String, entry.keychainIdentifier)
             XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.v3ServiceName)
         }
     }

--- a/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/AutofillKeyStoreProviderTests.swift
@@ -1,0 +1,142 @@
+//
+//  AutofillKeyStoreProviderTests.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import SecureStorage
+import SecureStorageTestsUtils
+@testable import BrowserServicesKit
+
+final class AutofillKeyStoreProviderTests: XCTestCase {
+
+    private enum Constants {
+        static let legacyServiceName = "DuckDuckGo Secure Vault"
+        static let defaultServiceName = "DuckDuckGo Secure Vault v2"
+    }
+
+    private enum EntryName: String, CaseIterable {
+
+        case generatedPassword = "32A8C8DF-04AF-4C9D-A4C7-83096737A9C0"
+        case l1Key = "79963A16-4E3A-464C-B01A-9774B3F695F1"
+        case l2Key = "A5711F4D-7AA5-4F0C-9E4F-BE553F1EA299"
+
+        var keyValue: String {
+            (Bundle.main.bundleIdentifier ?? "com.duckduckgo") + rawValue
+        }
+    }
+
+    func testWhenReadData_AndValueIsFound_NoFallbackSearchIsPerformed() throws {
+
+        try EntryName.allCases.forEach { entry in
+            // Given
+            let keychainService = MockKeychainService()
+            keychainService.mode = .bundleSpecificFound
+            let sut = AutofillKeyStoreProvider(keychainService: keychainService)
+
+            // When
+            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+
+            // Then
+            XCTAssertEqual(keychainService.itemMatchingCallCount, 1)
+        }
+    }
+
+    func testWhenReadData_AndValueNotFound_AllFallbackSearchesArePerformed() throws {
+
+        try EntryName.allCases.forEach { entry in
+            // Given
+            let keychainService = MockKeychainService()
+            let sut = AutofillKeyStoreProvider(keychainService: keychainService)
+
+            // When
+            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+
+            // Then
+            XCTAssertEqual(keychainService.itemMatchingCallCount, 3)
+        }
+    }
+
+    func testWhenReadData_AndValueNotFound_NonBundleSpecificSearchIsPerformed() throws {
+
+        try EntryName.allCases.forEach { entry in
+            // Given
+            let keychainService = MockKeychainService()
+            keychainService.mode = .nonBundleSpecificFound
+            let sut = AutofillKeyStoreProvider(keychainService: keychainService)
+
+            // When
+            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+
+            // Then
+            XCTAssertEqual(keychainService.itemMatchingCallCount, 2)
+            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrAccount as String] as! String, entry.rawValue)
+            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, Constants.defaultServiceName)
+        }
+    }
+
+    func testWhenReadData_AndValueNotFound_V1SearchIsPerformed() throws {
+
+        try EntryName.allCases.forEach { entry in
+            // Given
+            let keychainService = MockKeychainService()
+            keychainService.mode = .v1Found
+            let sut = AutofillKeyStoreProvider(keychainService: keychainService)
+
+            // When
+            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+
+            // Then
+            XCTAssertEqual(keychainService.itemMatchingCallCount, 3)
+            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrAccount as String] as! String, entry.rawValue)
+            XCTAssertEqual(keychainService.latestItemMatchingQuery[kSecAttrService as String] as! String, Constants.legacyServiceName)
+        }
+    }
+
+    func testWhenReadData_AndNonBundleSpecificValueFound_ThenWritesValueToNewStorageWithCorrectAttributes() throws {
+
+        try EntryName.allCases.forEach { entry in
+            // Given
+            let keychainService = MockKeychainService()
+            keychainService.mode = .nonBundleSpecificFound
+            let sut = AutofillKeyStoreProvider(keychainService: keychainService)
+
+            // When
+            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+
+            // Then
+            XCTAssertEqual(keychainService.addCallCount, 1)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.defaultServiceName)
+        }
+    }
+
+    func testWhenReadData_AndV1ValueFound_ThenWritesValueToNewStorageWithCorrectAttributes() throws {
+
+        try EntryName.allCases.forEach { entry in
+            // Given
+            let keychainService = MockKeychainService()
+            keychainService.mode = .v1Found
+            let sut = AutofillKeyStoreProvider(keychainService: keychainService)
+
+            // When
+            _ = try sut.readData(named: entry.keyValue, serviceName: sut.keychainServiceName)
+
+            // Then
+            XCTAssertEqual(keychainService.addCallCount, 1)
+            XCTAssertEqual(keychainService.latestAddQuery[kSecAttrService as String] as! String, Constants.defaultServiceName)
+        }
+    }
+}

--- a/Tests/BrowserServicesKitTests/SecureVault/CredentialsDatabaseCleanerTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/CredentialsDatabaseCleanerTests.swift
@@ -77,7 +77,7 @@ final class CredentialsDatabaseCleanerTests: XCTestCase {
         databaseLocation = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".db")
         databaseProvider = try DefaultAutofillDatabaseProvider(file: databaseLocation, key: simpleL1Key)
         secureVaultFactory = AutofillVaultFactory.testFactory(databaseProvider: databaseProvider)
-        secureVault = try secureVaultFactory.makeVault(errorReporter: nil)
+        secureVault = try secureVaultFactory.makeVault(reporter: nil)
         _ = try secureVault.authWith(password: "abcd".data(using: .utf8)!)
 
         eventMapper = MockEventMapper()

--- a/Tests/BrowserServicesKitTests/SecureVault/CredentialsDatabaseCleanerTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/CredentialsDatabaseCleanerTests.swift
@@ -37,9 +37,9 @@ final class MockEventMapper: EventMapping<CredentialsCleanupError> {
     }
 }
 
-final class MockSecureVaultErrorReporter: SecureVaultErrorReporting {
+final class MockSecureVaultErrorReporter: SecureVaultReporting {
     var _secureVaultInitFailed: (SecureStorageError) -> Void = { _ in }
-    func secureVaultInitFailed(_ error: SecureStorageError) {
+    func secureVaultError(_ error: SecureStorageError) {
         _secureVaultInitFailed(error)
     }
 }
@@ -48,7 +48,7 @@ extension AutofillVaultFactory {
     static func testFactory(databaseProvider: DefaultAutofillDatabaseProvider) -> AutofillVaultFactory {
         AutofillVaultFactory(makeCryptoProvider: {
             NoOpCryptoProvider()
-        }, makeKeyStoreProvider: {
+        }, makeKeyStoreProvider: { _ in
             let provider = MockKeystoreProvider()
             provider._l1Key = "l1".data(using: .utf8)
             provider._encryptedL2Key = "encrypted".data(using: .utf8)

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
@@ -918,7 +918,7 @@ private class MockSecureVaultManagerDelegate: SecureVaultManagerDelegate {
 
     func secureVaultManager(_: SecureVaultManager, didRequestAuthenticationWithCompletionHandler: @escaping (Bool) -> Void) {}
 
-    func secureVaultInitFailed(_ error: SecureStorageError) {}
+    func secureVaultError(_ error: SecureStorageError) {}
 
     func secureVaultManagerShouldSaveData(_: BrowserServicesKit.SecureVaultManager) -> Bool {
         true

--- a/Tests/SecureStorageTests/SecureVaultFactoryTests.swift
+++ b/Tests/SecureStorageTests/SecureVaultFactoryTests.swift
@@ -25,7 +25,7 @@ import SecureStorageTestsUtils
 let MockSecureVaultFactory = SecureVaultFactory<ConcreteMockSecureVault>(
     makeCryptoProvider: {
         return MockCryptoProvider()
-    }, makeKeyStoreProvider: {
+    }, makeKeyStoreProvider: { _ in
         let provider = MockKeystoreProvider()
         provider._l1Key = "key".data(using: .utf8)
         return provider

--- a/Tests/SecureStorageTests/SecureVaultFactoryTests.swift
+++ b/Tests/SecureStorageTests/SecureVaultFactoryTests.swift
@@ -39,7 +39,7 @@ let MockSecureVaultFactory = SecureVaultFactory<ConcreteMockSecureVault>(
 final class MockVaultTests: XCTestCase {
 
     func testCreatingMockVaultWithSecureVaultFactory() throws {
-        let vault = try MockSecureVaultFactory.makeVault(errorReporter: nil)
+        let vault = try MockSecureVaultFactory.makeVault(reporter: nil)
         let storedString = "hello, world!"
 
         try vault.storeSomeData(string: storedString)

--- a/Tests/SyncDataProvidersTests/Credentials/CredentialsProviderTests.swift
+++ b/Tests/SyncDataProvidersTests/Credentials/CredentialsProviderTests.swift
@@ -232,7 +232,7 @@ final class CredentialsProviderTests: CredentialsProviderTestsBase {
 
         let localDatabaseProvider = try DefaultAutofillDatabaseProvider(file: databaseLocation, key: simpleL1Key)
         let localSecureVaultFactory = AutofillVaultFactory.testFactory(databaseProvider: localDatabaseProvider)
-        let localSecureVault = try localSecureVaultFactory.makeVault(errorReporter: nil)
+        let localSecureVault = try localSecureVaultFactory.makeVault(reporter: nil)
         _ = try localSecureVault.authWith(password: "abcd".data(using: .utf8)!)
 
         let received: [Syncable] = [
@@ -368,7 +368,7 @@ final class CredentialsProviderTests: CredentialsProviderTestsBase {
 
         let localDatabaseProvider = try DefaultAutofillDatabaseProvider(file: databaseLocation, key: simpleL1Key)
         let localSecureVaultFactory = AutofillVaultFactory.testFactory(databaseProvider: localDatabaseProvider)
-        let localSecureVault = try localSecureVaultFactory.makeVault(errorReporter: nil)
+        let localSecureVault = try localSecureVaultFactory.makeVault(reporter: nil)
         _ = try localSecureVault.authWith(password: "abcd".data(using: .utf8)!)
 
         try secureVault.inDatabaseTransaction { database in

--- a/Tests/SyncDataProvidersTests/Credentials/helpers/CredentialsProviderTestsBase.swift
+++ b/Tests/SyncDataProvidersTests/Credentials/helpers/CredentialsProviderTestsBase.swift
@@ -107,7 +107,7 @@ internal class CredentialsProviderTestsBase: XCTestCase {
     // MARK: - Helpers
 
     func makeSecureVault() throws {
-        secureVault = try secureVaultFactory.makeVault(errorReporter: nil)
+        secureVault = try secureVaultFactory.makeVault(reporter: nil)
         _ = try secureVault.authWith(password: "abcd".data(using: .utf8)!)
     }
 

--- a/Tests/SyncDataProvidersTests/Credentials/helpers/CredentialsProviderTestsBase.swift
+++ b/Tests/SyncDataProvidersTests/Credentials/helpers/CredentialsProviderTestsBase.swift
@@ -26,9 +26,9 @@ import SecureStorage
 @testable import BrowserServicesKit
 @testable import SyncDataProviders
 
-final class MockSecureVaultErrorReporter: SecureVaultErrorReporting {
+final class MockSecureVaultErrorReporter: SecureVaultReporting {
     var _secureVaultInitFailed: (SecureStorageError) -> Void = { _ in }
-    func secureVaultInitFailed(_ error: SecureStorageError) {
+    func secureVaultError(_ error: SecureStorageError) {
         _secureVaultInitFailed(error)
     }
 }

--- a/Tests/SyncDataProvidersTests/Credentials/helpers/TestAutofillSecureVaultFactory.swift
+++ b/Tests/SyncDataProvidersTests/Credentials/helpers/TestAutofillSecureVaultFactory.swift
@@ -25,7 +25,7 @@ extension AutofillVaultFactory {
     static func testFactory(databaseProvider: DefaultAutofillDatabaseProvider) -> AutofillVaultFactory {
         AutofillVaultFactory(makeCryptoProvider: {
             NoOpCryptoProvider()
-        }, makeKeyStoreProvider: {
+        }, makeKeyStoreProvider: { _ in
             let provider = MockKeystoreProvider()
             provider._l1Key = "l1".data(using: .utf8)
             provider._encryptedL2Key = "encrypted".data(using: .utf8)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/72649045549333/1206924205159008/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2759
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2652
What kind of version bump will this require?: Major

**Optional**:
Tech Design URL: https://app.asana.com/0/481882893211075/1206942775357851/f

**Description**:
Our two public app variants  - App Store and DMG -  share some of key pieces of Autofill-related data which are used to access their Autofill storage (Actually all variants share this data, but only public variants impact users). Specifically, the following items are shared between our App Store and DMG app variants:

* L1 Key
* L2 Ley
* L2 Key Password

This results in the following problematic scenario:

* User directly downloads and installs from our site
* On first launch of the DMG version, Autofill-related encryption data (L1 key, L2 key, password) is generated
* At this point, the user may or may not utilize our browser for Autofill data storage. Either choice does not avoid the problem
* User downloads our app from the Mac App Store
* On first launch of the App Store version, Autofill-related encryption data (L1 key, L2 key, password) is not generated, as they already exist.
* Instead the user is prompted multiple times for their password to allow the app to access the L1 key which was generated and stored as part of the initial DMG launch
* Additionally, when the app requires access to the L2 key and L2 key password (e.g launching with Sync enabled, or with Autofill data saved), they are again prompted for their password to access these Keychain items.

This scenario will also occur if the user first downloads the App Store version and then switches to the DMG. 

To address this scenario, this work implements bundle-specific Keychain storage for our L1 keys, L2 keys and L2 encryption passwords. 

We solve two specific problems:

1. Separation of Shared Keychain Data into Bundle-Specific Keychain Data
2. Migration of Existing Shared Keychain Data to Bundle-Specific Keychain Data

**Steps to test this PR**:
1. Complete all macOS tests described [here](https://github.com/duckduckgo/macos-browser/pull/2652)
2. Complete all iOS tests described [here](https://github.com/duckduckgo/iOS/pull/2759)

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
