### PR TITLE
Allow Repurchase of a 3rd party subscription

### DIFF
--- a/Sources/Common/Logging.swift
+++ b/Sources/Common/Logging.swift
@@ -41,6 +41,7 @@ extension OSLog {
         case remoteMessaging = "Remote Messaging"
         case subscription = "Subscription"
         case history = "History"
+        case general = "General"
     }
 
 #if DEBUG
@@ -54,6 +55,7 @@ extension OSLog {
     @OSLogWrapper(.remoteMessaging) public static var remoteMessaging
     @OSLogWrapper(.subscription)    public static var subscription
     @OSLogWrapper(.history)         public static var history
+    @OSLogWrapper(.general)         public static var general
 
     public static var enabledLoggingCategories = Set<String>()
 

--- a/Sources/Common/UserDefaultsCache.swift
+++ b/Sources/Common/UserDefaultsCache.swift
@@ -17,10 +17,13 @@
 //
 
 import Foundation
-import Common
 
 public struct UserDefaultsCacheSettings {
     public let defaultExpirationInterval: TimeInterval
+    
+    public init(defaultExpirationInterval: TimeInterval) {
+        self.defaultExpirationInterval = defaultExpirationInterval
+    }
 }
 
 public protocol UserDefaultsCacheKeyStore {
@@ -39,24 +42,18 @@ public class UserDefaultsCache<ObjectType: Codable> {
         let expires: Date
         let object: ObjectType
     }
-
-    private var subscriptionAppGroup: String?
+    
+    private var userDefaults: UserDefaults
     public private(set) var settings: UserDefaultsCacheSettings
-    private lazy var userDefaults: UserDefaults? = {
-        if let appGroup = subscriptionAppGroup {
-            return UserDefaults(suiteName: appGroup)
-        } else {
-            return UserDefaults.standard
-        }
-    }()
 
     private let key: UserDefaultsCacheKeyStore
 
-    public init(subscriptionAppGroup: String?, key: UserDefaultsCacheKeyStore,
+    public init(userDefaults: UserDefaults = UserDefaults.standard,
+                key: UserDefaultsCacheKeyStore,
                 settings: UserDefaultsCacheSettings) {
-        self.subscriptionAppGroup = subscriptionAppGroup
         self.key = key
         self.settings = settings
+        self.userDefaults = userDefaults
     }
 
     public func set(_ object: ObjectType, expires: Date? = nil) {
@@ -65,23 +62,23 @@ public class UserDefaultsCache<ObjectType: Codable> {
         let encoder = JSONEncoder()
         do {
             let data = try encoder.encode(cacheObject)
-            userDefaults?.set(data, forKey: key.rawValue)
-            os_log(.debug, log: .subscription, "Cache Set: \(cacheObject)")
+            userDefaults.set(data, forKey: key.rawValue)
+            os_log(.debug, log: .general, "Cache Set: \(cacheObject)")
         } catch {
             assertionFailure("Failed to encode CacheObject: \(error)")
         }
     }
 
     public func get() -> ObjectType? {
-        guard let data = userDefaults?.data(forKey: key.rawValue) else { return nil }
+        guard let data = userDefaults.data(forKey: key.rawValue) else { return nil }
         let decoder = JSONDecoder()
         do {
             let cacheObject = try decoder.decode(CacheObject.self, from: data)
             if cacheObject.expires > Date() {
-                os_log(.debug, log: .subscription, "Cache Hit: \(ObjectType.self)")
+                os_log(.debug, log: .general, "Cache Hit: \(ObjectType.self)")
                 return cacheObject.object
             } else {
-                os_log(.debug, log: .subscription, "Cache Miss: \(ObjectType.self)")
+                os_log(.debug, log: .general, "Cache Miss: \(ObjectType.self)")
                 reset()  // Clear expired data
                 return nil
             }
@@ -91,7 +88,7 @@ public class UserDefaultsCache<ObjectType: Codable> {
     }
 
     public func reset() {
-        os_log(.debug, log: .subscription, "Cache Clean: \(ObjectType.self)")
-        userDefaults?.removeObject(forKey: key.rawValue)
+        os_log(.debug, log: .general, "Cache Clean: \(ObjectType.self)")
+        userDefaults.removeObject(forKey: key.rawValue)
     }
 }

--- a/Sources/Common/UserDefaultsCache.swift
+++ b/Sources/Common/UserDefaultsCache.swift
@@ -82,7 +82,8 @@ public class UserDefaultsCache<ObjectType: Codable> {
                 reset()  // Clear expired data
                 return nil
             }
-        } catch {
+        } catch(let error) {
+            os_log(.error, log: .general, "Cache Decode Error: \(error)")
             return nil
         }
     }

--- a/Sources/Common/UserDefaultsCache.swift
+++ b/Sources/Common/UserDefaultsCache.swift
@@ -20,7 +20,7 @@ import Foundation
 
 public struct UserDefaultsCacheSettings {
     public let defaultExpirationInterval: TimeInterval
-    
+
     public init(defaultExpirationInterval: TimeInterval) {
         self.defaultExpirationInterval = defaultExpirationInterval
     }
@@ -42,7 +42,7 @@ public class UserDefaultsCache<ObjectType: Codable> {
         let expires: Date
         let object: ObjectType
     }
-    
+
     private var userDefaults: UserDefaults
     public private(set) var settings: UserDefaultsCacheSettings
 
@@ -82,7 +82,7 @@ public class UserDefaultsCache<ObjectType: Codable> {
                 reset()  // Clear expired data
                 return nil
             }
-        } catch(let error) {
+        } catch let error {
             os_log(.error, log: .general, "Cache Decode Error: \(error)")
             return nil
         }

--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -56,7 +56,7 @@ public class AccountManager: AccountManaging {
 
     public convenience init(subscriptionAppGroup: String?, accessTokenStorage: SubscriptionTokenStorage) {
         self.init(accessTokenStorage: accessTokenStorage,
-                  entitlementsCache: UserDefaultsCache<[Entitlement]>(subscriptionAppGroup: subscriptionAppGroup,
+                  entitlementsCache: UserDefaultsCache<[Entitlement]>(userDefaults: UserDefaults.init(suiteName: subscriptionAppGroup) ?? UserDefaults.standard,
                                                                       key: UserDefaultsCacheKey.subscriptionEntitlements,
                                                                       settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20))))
     }
@@ -64,7 +64,7 @@ public class AccountManager: AccountManaging {
     public convenience init(subscriptionAppGroup: String) {
         let accessTokenStorage = SubscriptionTokenKeychainStorage(keychainType: .dataProtection(.named(subscriptionAppGroup)))
         self.init(accessTokenStorage: accessTokenStorage,
-                  entitlementsCache: UserDefaultsCache<[Entitlement]>(subscriptionAppGroup: subscriptionAppGroup,
+                  entitlementsCache: UserDefaultsCache<[Entitlement]>(userDefaults: UserDefaults.init(suiteName: subscriptionAppGroup) ?? UserDefaults.standard,
                                                                       key: UserDefaultsCacheKey.subscriptionEntitlements,
                                                                       settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20))))
     }

--- a/Sources/Subscription/AccountManager.swift
+++ b/Sources/Subscription/AccountManager.swift
@@ -56,7 +56,7 @@ public class AccountManager: AccountManaging {
 
     public convenience init(subscriptionAppGroup: String?, accessTokenStorage: SubscriptionTokenStorage) {
         self.init(accessTokenStorage: accessTokenStorage,
-                  entitlementsCache: UserDefaultsCache<[Entitlement]>(userDefaults: UserDefaults.init(suiteName: subscriptionAppGroup) ?? UserDefaults.standard,
+                  entitlementsCache: UserDefaultsCache<[Entitlement]>(userDefaults: UserDefaults(suiteName: subscriptionAppGroup) ?? UserDefaults.standard,
                                                                       key: UserDefaultsCacheKey.subscriptionEntitlements,
                                                                       settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20))))
     }
@@ -64,7 +64,7 @@ public class AccountManager: AccountManaging {
     public convenience init(subscriptionAppGroup: String) {
         let accessTokenStorage = SubscriptionTokenKeychainStorage(keychainType: .dataProtection(.named(subscriptionAppGroup)))
         self.init(accessTokenStorage: accessTokenStorage,
-                  entitlementsCache: UserDefaultsCache<[Entitlement]>(userDefaults: UserDefaults.init(suiteName: subscriptionAppGroup) ?? UserDefaults.standard,
+                  entitlementsCache: UserDefaultsCache<[Entitlement]>(userDefaults: UserDefaults(suiteName: subscriptionAppGroup) ?? UserDefaults.standard,
                                                                       key: UserDefaultsCacheKey.subscriptionEntitlements,
                                                                       settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20))))
     }

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -170,15 +170,15 @@ public final class AppStorePurchaseFlow {
 
         return successful
     }
-    
+
     private static func getExpiredSubscriptionID(accountManager: AccountManager) async -> String? {
         guard accountManager.isUserAuthenticated,
               let externalID = accountManager.externalID,
               let token = accountManager.accessToken
         else { return nil }
-        
+
         let subscriptionInfo = await SubscriptionService.getSubscription(accessToken: token, cachePolicy: .reloadIgnoringLocalCacheData)
-        
+
         // Only return an externalID if the subscription is expired
         // To prevent creating multiple subscriptions in the same account
         if case .success(let subscription) = subscriptionInfo,

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -182,7 +182,7 @@ public final class AppStorePurchaseFlow {
         // Only return an externalID if the subscription is expired
         // To prevent creating multiple subscriptions in the same account
         if case .success(let subscription) = subscriptionInfo,
-           subscription.isActive,
+           !subscription.isActive,
             subscription.platform != .apple {
             return externalID
         }

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -110,7 +110,7 @@ public final class AppStorePurchaseFlow {
                 }
             }
         }
-        
+
         // Make the purchase
         switch await PurchaseManager.shared.purchaseSubscription(with: subscriptionIdentifier, externalID: externalID) {
         case .success(let transactionJWS):

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -67,45 +67,50 @@ public final class AppStorePurchaseFlow {
     public typealias TransactionJWS = String
 
     // swiftlint:disable cyclomatic_complexity
-    public static func purchaseSubscription(with subscriptionIdentifier: String, emailAccessToken: String?, subscriptionAppGroup: String) async -> Result<TransactionJWS, AppStorePurchaseFlow.Error> {
+    public static func purchaseSubscription(with subscriptionIdentifier: String,
+                                            emailAccessToken: String?,
+                                            subscriptionAppGroup: String) async -> Result<TransactionJWS, AppStorePurchaseFlow.Error> {
         os_log(.info, log: .subscription, "[AppStorePurchaseFlow] purchaseSubscription")
 
         let accountManager = AccountManager(subscriptionAppGroup: subscriptionAppGroup)
         let externalID: String
 
-        // Clear the Subscription cache
-        SubscriptionService.signOut()
+        // If the current account is a third party expired account, we want to purchase and attach subs to it
+        if let existingExternalID = await getExpiredSubscriptionID(accountManager: accountManager) {
+            externalID = existingExternalID
 
-        // Check for past transactions most recent
-        switch await AppStoreRestoreFlow.restoreAccountFromPastPurchase(subscriptionAppGroup: subscriptionAppGroup) {
-        case .success:
-            os_log(.info, log: .subscription, "[AppStorePurchaseFlow] purchaseSubscription -> restoreAccountFromPastPurchase: activeSubscriptionAlreadyPresent")
-            return .failure(.activeSubscriptionAlreadyPresent)
-        case .failure(let error):
-            os_log(.info, log: .subscription, "[AppStorePurchaseFlow] purchaseSubscription -> restoreAccountFromPastPurchase: %{public}s", String(reflecting: error))
-            switch error {
-            case .subscriptionExpired(let expiredAccountDetails):
-                externalID = expiredAccountDetails.externalID
-                accountManager.storeAuthToken(token: expiredAccountDetails.authToken)
-                accountManager.storeAccount(token: expiredAccountDetails.accessToken, email: expiredAccountDetails.email, externalID: expiredAccountDetails.externalID)
-            default:
-                // No history, create new account
-                switch await AuthService.createAccount(emailAccessToken: emailAccessToken) {
-                case .success(let response):
-                    externalID = response.externalID
+        // Otherwise, try to retrieve an expired Apple subscription or create a new one
+        } else {
+            // Check for past transactions most recent
+            switch await AppStoreRestoreFlow.restoreAccountFromPastPurchase(subscriptionAppGroup: subscriptionAppGroup) {
+            case .success:
+                os_log(.info, log: .subscription, "[AppStorePurchaseFlow] purchaseSubscription -> restoreAccountFromPastPurchase: activeSubscriptionAlreadyPresent")
+                return .failure(.activeSubscriptionAlreadyPresent)
+            case .failure(let error):
+                os_log(.info, log: .subscription, "[AppStorePurchaseFlow] purchaseSubscription -> restoreAccountFromPastPurchase: %{public}s", String(reflecting: error))
+                switch error {
+                case .subscriptionExpired(let expiredAccountDetails):
+                    externalID = expiredAccountDetails.externalID
+                    accountManager.storeAuthToken(token: expiredAccountDetails.authToken)
+                    accountManager.storeAccount(token: expiredAccountDetails.accessToken, email: expiredAccountDetails.email, externalID: expiredAccountDetails.externalID)
+                default:
+                    switch await AuthService.createAccount(emailAccessToken: emailAccessToken) {
+                    case .success(let response):
+                        externalID = response.externalID
 
-                    if case let .success(accessToken) = await accountManager.exchangeAuthTokenToAccessToken(response.authToken),
-                       case let .success(accountDetails) = await accountManager.fetchAccountDetails(with: accessToken) {
-                        accountManager.storeAuthToken(token: response.authToken)
-                        accountManager.storeAccount(token: accessToken, email: accountDetails.email, externalID: accountDetails.externalID)
+                        if case let .success(accessToken) = await accountManager.exchangeAuthTokenToAccessToken(response.authToken),
+                           case let .success(accountDetails) = await accountManager.fetchAccountDetails(with: accessToken) {
+                            accountManager.storeAuthToken(token: response.authToken)
+                            accountManager.storeAccount(token: accessToken, email: accountDetails.email, externalID: accountDetails.externalID)
+                        }
+                    case .failure(let error):
+                        os_log(.error, log: .subscription, "[AppStorePurchaseFlow] createAccount error: %{public}s", String(reflecting: error))
+                        return .failure(.accountCreationFailed)
                     }
-                case .failure(let error):
-                    os_log(.error, log: .subscription, "[AppStorePurchaseFlow] createAccount error: %{public}s", String(reflecting: error))
-                    return .failure(.accountCreationFailed)
                 }
             }
         }
-
+        
         // Make the purchase
         switch await PurchaseManager.shared.purchaseSubscription(with: subscriptionIdentifier, externalID: externalID) {
         case .success(let transactionJWS):
@@ -164,5 +169,23 @@ public final class AppStorePurchaseFlow {
         } while !successful && count < retryCount
 
         return successful
+    }
+    
+    private static func getExpiredSubscriptionID(accountManager: AccountManager) async -> String? {
+        guard accountManager.isUserAuthenticated,
+              let externalID = accountManager.externalID,
+              let token = accountManager.accessToken
+        else { return nil }
+        
+        let subscriptionInfo = await SubscriptionService.getSubscription(accessToken: token, cachePolicy: .reloadIgnoringLocalCacheData)
+        
+        // Only return an externalID if the subscription is expired
+        // To prevent creating multiple subscriptions in the same account
+        if case .success(let subscription) = subscriptionInfo,
+           subscription.isActive,
+            subscription.platform != .apple {
+            return externalID
+        }
+        return nil
     }
 }

--- a/Sources/Subscription/Services/SubscriptionService.swift
+++ b/Sources/Subscription/Services/SubscriptionService.swift
@@ -35,8 +35,7 @@ public final class SubscriptionService: APIService {
         }
     }
 
-    private static let subscriptionCache = UserDefaultsCache<Subscription>(subscriptionAppGroup: nil,
-                                                                           key: UserDefaultsCacheKey.subscription,
+    private static let subscriptionCache = UserDefaultsCache<Subscription>(key: UserDefaultsCacheKey.subscription,
                                                                            settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20)))
 
     public enum CachePolicy {

--- a/Sources/Subscription/URL+Subscription.swift
+++ b/Sources/Subscription/URL+Subscription.swift
@@ -53,12 +53,12 @@ public extension URL {
     static var subscriptionActivateSuccess: URL {
         subscriptionBaseURL.appendingPathComponent("activate/success")
     }
-    
+
     // Add Email Success
     static var addEmailToSubscriptionSuccess: URL {
         subscriptionBaseURL.appendingPathComponent("add-email/success")
     }
-    
+
     // Add Email OTP
     static var addEmailToSubscriptionOTP: URL {
         subscriptionBaseURL.appendingPathComponent("add-email/otp")

--- a/Sources/Subscription/URL+Subscription.swift
+++ b/Sources/Subscription/URL+Subscription.swift
@@ -53,6 +53,16 @@ public extension URL {
     static var subscriptionActivateSuccess: URL {
         subscriptionBaseURL.appendingPathComponent("activate/success")
     }
+    
+    // Add Email Success
+    static var addEmailToSubscriptionSuccess: URL {
+        subscriptionBaseURL.appendingPathComponent("add-email/success")
+    }
+    
+    // Add Email OTP
+    static var addEmailToSubscriptionOTP: URL {
+        subscriptionBaseURL.appendingPathComponent("add-email/otp")
+    }
 
     // MARK: - App Store app manage subscription URL
 

--- a/Sources/Subscription/UserDefaultsCache.swift
+++ b/Sources/Subscription/UserDefaultsCache.swift
@@ -23,7 +23,11 @@ public struct UserDefaultsCacheSettings {
     public let defaultExpirationInterval: TimeInterval
 }
 
-public enum UserDefaultsCacheKey: String {
+public protocol UserDefaultsCacheKeyStore {
+    var rawValue: String { get }
+}
+
+public enum UserDefaultsCacheKey: String, UserDefaultsCacheKeyStore {
     case subscriptionEntitlements = "com.duckduckgo.bsk.subscription.entitlements"
     case subscription = "com.duckduckgo.bsk.subscription.info"
 }
@@ -46,9 +50,9 @@ public class UserDefaultsCache<ObjectType: Codable> {
         }
     }()
 
-    private let key: UserDefaultsCacheKey
+    private let key: UserDefaultsCacheKeyStore
 
-    public init(subscriptionAppGroup: String?, key: UserDefaultsCacheKey,
+    public init(subscriptionAppGroup: String?, key: UserDefaultsCacheKeyStore,
                 settings: UserDefaultsCacheSettings) {
         self.subscriptionAppGroup = subscriptionAppGroup
         self.key = key

--- a/Tests/CommonTests/UserDefaultsCacheTests.swift
+++ b/Tests/CommonTests/UserDefaultsCacheTests.swift
@@ -1,0 +1,76 @@
+//
+//  UserDefaultsCacheTests.swift
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import Common
+
+final class UserDefaultsCacheTests: XCTestCase {
+
+    private var userDefaults: UserDefaults!
+    var cache: UserDefaultsCache<TestObject>!
+    let testKey = UserDefaultsCacheKey.subscription
+    let settings = UserDefaultsCacheSettings(defaultExpirationInterval: 300) // 5 minutes
+    
+    override func setUp() {
+        super.setUp()
+        userDefaults = UserDefaults(suiteName: #file)
+        userDefaults.removePersistentDomain(forName: #file)
+        cache = UserDefaultsCache<TestObject>(userDefaults: userDefaults, key: testKey, settings: settings)
+    }
+
+    override func tearDown() {
+        // Clean up UserDefaults after tests
+        userDefaults.removePersistentDomain(forName: #file)
+        super.tearDown()
+    }
+
+    func testSetObject() {
+        let testObject = TestObject(name: "Test")
+        cache.set(testObject)
+        let data = userDefaults?.data(forKey: testKey.rawValue)
+        XCTAssertNotNil(data, "Data should be stored in UserDefaults")
+    }
+
+    func testGetObjectNotExpired() {
+        let testObject = TestObject(name: "Test")
+        cache.set(testObject)
+        let fetchedObject = cache.get()
+        XCTAssertNotNil(fetchedObject, "Should retrieve the object as it is not expired")
+        XCTAssertEqual(fetchedObject?.name, "Test", "The fetched object should have the correct properties")
+    }
+
+    func testGetObjectExpired() {
+        let testObject = TestObject(name: "Test")
+        // Set with a past expiration date
+        cache.set(testObject, expires: Date().addingTimeInterval(-3600))
+        let fetchedObject = cache.get()
+        XCTAssertNil(fetchedObject, "Should not retrieve the object as it has expired")
+    }
+
+    func testReset() {
+        let testObject = TestObject(name: "Test")
+        cache.set(testObject)
+        cache.reset()
+        let data = userDefaults?.data(forKey: testKey.rawValue)
+        XCTAssertNil(data, "UserDefaults should be empty after reset")
+    }
+}
+
+struct TestObject: Codable, Equatable {
+    let name: String
+}

--- a/Tests/CommonTests/UserDefaultsCacheTests.swift
+++ b/Tests/CommonTests/UserDefaultsCacheTests.swift
@@ -25,7 +25,7 @@ final class UserDefaultsCacheTests: XCTestCase {
     var cache: UserDefaultsCache<TestObject>!
     let testKey = UserDefaultsCacheKey.subscription
     let settings = UserDefaultsCacheSettings(defaultExpirationInterval: 300) // 5 minutes
-    
+
     override func setUp() {
         super.setUp()
         userDefaults = UserDefaults(suiteName: #file)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL:  https://app.asana.com/0/1204099484721401/1207112724044306/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2764/files
macOS PR: TBD
What kind of version bump will this require?: Major/Minor/Patch

**Description**:
- Checks for the current subscription and if exired allows using the existing account to repurchase on Apple.
- Moves URLs from iOS app 
- Decouples  from subscription, to make it extensible and more generic.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.  See iOS PR
