### PR TITLE
VPN server failure recovery retry logic

### DIFF
--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -44,6 +44,7 @@ public enum NetworkProtectionServerSelectionMethod: CustomDebugStringConvertible
 }
 
 public protocol NetworkProtectionDeviceManagement {
+    typealias GenerateTunnelConfigResult = (tunnelConfig: TunnelConfiguration, server: NetworkProtectionServer)
 
     func generateTunnelConfiguration(selectionMethod: NetworkProtectionServerSelectionMethod,
                                      includedRoutes: [IPAddressRange],

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1220,7 +1220,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     lazy var failureRecoveryHandler: FailureRecoveryHandling = FailureRecoveryHandler(deviceManager: deviceManager)
-    
+
     private func startServerFailureMonitor() async {
         if await serverFailureMonitor.isStarted {
             await serverFailureMonitor.stop()
@@ -1257,8 +1257,14 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                     ) { [weak self] generateConfigResult in
                         try await self?.handleFailureRecoveryConfigUpdate(result: generateConfigResult)
                     }
+                } catch let error as FailureRecoveryError {
+                    switch error {
+                    case .noRecoveryNecessary:
+                        os_log("🟢 Failure recovery fire noRecoveryNecessary pixel", log: .networkProtectionServerFailureRecoveryLog, type: .error)
+                    case .reachedMaximumRetries(let lastError):
+                        os_log("🟢 Failure recovery max retry error: %{public}@", log: .networkProtectionServerFailureRecoveryLog, type: .error, String(reflecting: error))
+                    }
                 } catch {
-                    // Pixel here sent as part of https://app.asana.com/0/0/1206939413299475/f
                     os_log("🟢 Failure recovery error: %{public}@", log: .networkProtectionServerFailureRecoveryLog, type: .error, String(reflecting: error))
                 }
             }

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1220,7 +1220,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     lazy var failureRecoveryHandler: FailureRecoveryHandling = FailureRecoveryHandler(deviceManager: deviceManager)
-
+    
     private func startServerFailureMonitor() async {
         if await serverFailureMonitor.isStarted {
             await serverFailureMonitor.stop()
@@ -1249,13 +1249,14 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
                 let recoveryResult: (tunnelConfig: TunnelConfiguration, server: NetworkProtectionServer)
                 do {
-                    recoveryResult = try await self.failureRecoveryHandler.attemptRecovery(
+                    try await self.failureRecoveryHandler.attemptRecovery(
                         to: server,
                         includedRoutes: self.includedRoutes ?? [],
                         excludedRoutes: self.settings.excludedRanges,
                         isKillSwitchEnabled: self.isKillSwitchEnabled
-                    )
-                    await self.handleFailureRecovery(tunnelConfig: recoveryResult.tunnelConfig, server: recoveryResult.server)
+                    ) { [weak self] generateConfigResult in
+                        try await self?.handleFailureRecoveryConfigUpdate(result: generateConfigResult)
+                    }
                 } catch {
                     // Pixel here sent as part of https://app.asana.com/0/0/1206939413299475/f
                     os_log("🟢 Failure recovery error: %{public}@", log: .networkProtectionServerFailureRecoveryLog, type: .error, String(reflecting: error))
@@ -1265,11 +1266,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     @MainActor
-    private func handleFailureRecovery(tunnelConfig: TunnelConfiguration, server: NetworkProtectionServer) {
-        self.lastSelectedServer = server
-        Task {
-            try await self.updateAdapterConfig(tunnelConfiguration: tunnelConfig, reassert: true)
-        }
+    private func handleFailureRecoveryConfigUpdate(result: NetworkProtectionDeviceManagement.GenerateTunnelConfigResult) async throws {
+        self.lastSelectedServer = result.server
+        try await self.updateAdapterConfig(tunnelConfiguration: result.tunnelConfig, reassert: true)
     }
 
     @MainActor

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1235,38 +1235,48 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 return
             }
 
+            switch result {
+            case .failureDetected:
+                startServerFailureRecovery()
+            case .failureRecovered:
+                Task {
+                    await self.failureRecoveryHandler.stop()
+                }
+            case .networkPathChanged: break
+            }
             guard case .failureDetected = result else {
                 return
             }
+        }
+    }
 
-            Task {
-                guard let server = await self.lastSelectedServer else {
-                    os_log("🟢 No last server info found for recovery", log: .networkProtectionServerFailureRecoveryLog, type: .info)
-                    return
-                }
-                await self.startReasserting()
-                await self.serverFailureMonitor.stop()
+    private func startServerFailureRecovery() {
+        Task {
+            guard let server = await self.lastSelectedServer else {
+                os_log("🟢 No last server info found for recovery", log: .networkProtectionServerFailureRecoveryLog, type: .info)
+                return
+            }
+            await self.startReasserting()
+            await self.serverFailureMonitor.stop()
 
-                let recoveryResult: (tunnelConfig: TunnelConfiguration, server: NetworkProtectionServer)
-                do {
-                    try await self.failureRecoveryHandler.attemptRecovery(
-                        to: server,
-                        includedRoutes: self.includedRoutes ?? [],
-                        excludedRoutes: self.settings.excludedRanges,
-                        isKillSwitchEnabled: self.isKillSwitchEnabled
-                    ) { [weak self] generateConfigResult in
-                        try await self?.handleFailureRecoveryConfigUpdate(result: generateConfigResult)
-                    }
-                } catch let error as FailureRecoveryError {
-                    switch error {
-                    case .noRecoveryNecessary:
-                        os_log("🟢 Failure recovery fire noRecoveryNecessary pixel", log: .networkProtectionServerFailureRecoveryLog, type: .error)
-                    case .reachedMaximumRetries(let lastError):
-                        os_log("🟢 Failure recovery max retry error: %{public}@", log: .networkProtectionServerFailureRecoveryLog, type: .error, String(reflecting: error))
-                    }
-                } catch {
-                    os_log("🟢 Failure recovery error: %{public}@", log: .networkProtectionServerFailureRecoveryLog, type: .error, String(reflecting: error))
+            do {
+                try await self.failureRecoveryHandler.attemptRecovery(
+                    to: server,
+                    includedRoutes: self.includedRoutes ?? [],
+                    excludedRoutes: self.settings.excludedRanges,
+                    isKillSwitchEnabled: self.isKillSwitchEnabled
+                ) { [weak self] generateConfigResult in
+                    try await self?.handleFailureRecoveryConfigUpdate(result: generateConfigResult)
                 }
+            } catch let error as FailureRecoveryError {
+                switch error {
+                case .noRecoveryNecessary:
+                    os_log("🟢 Failure recovery fire noRecoveryNecessary pixel", log: .networkProtectionServerFailureRecoveryLog, type: .error)
+                case .reachedMaximumRetries(let lastError):
+                    os_log("🟢 Failure recovery max retry error: %{public}@", log: .networkProtectionServerFailureRecoveryLog, type: .error, String(reflecting: lastError))
+                }
+            } catch {
+                os_log("🟢 Failure recovery error: %{public}@", log: .networkProtectionServerFailureRecoveryLog, type: .error, String(reflecting: error))
             }
         }
     }

--- a/Sources/NetworkProtection/Recovery/FailureRecoveryHandler.swift
+++ b/Sources/NetworkProtection/Recovery/FailureRecoveryHandler.swift
@@ -120,9 +120,12 @@ actor FailureRecoveryHandler: FailureRecoveryHandling {
             var lastError: Error
             repeat {
                 do {
-                    return try await action()
+                    try await action()
+                    os_log("🟢 Failure recovery success!", log: .networkProtectionServerFailureRecoveryLog, type: .info)
+                    return
                 } catch {
                     lastError = error
+                    os_log("🟢 Failure recovery failed. Retrying...", log: .networkProtectionServerFailureRecoveryLog, type: .info)
                     try? await Task.sleep(interval: currentDelay)
                 }
                 count += 1

--- a/Sources/NetworkProtection/Recovery/FailureRecoveryHandler.swift
+++ b/Sources/NetworkProtection/Recovery/FailureRecoveryHandler.swift
@@ -124,6 +124,9 @@ actor FailureRecoveryHandler: FailureRecoveryHandling {
                     os_log("🟢 Failure recovery success!", log: .networkProtectionServerFailureRecoveryLog, type: .info)
                     return
                 } catch {
+                    if case FailureRecoveryError.noRecoveryNecessary = error {
+                        throw error
+                    }
                     lastError = error
                     os_log("🟢 Failure recovery failed. Retrying...", log: .networkProtectionServerFailureRecoveryLog, type: .info)
                     try? await Task.sleep(interval: currentDelay)

--- a/Sources/NetworkProtection/Recovery/FailureRecoveryHandler.swift
+++ b/Sources/NetworkProtection/Recovery/FailureRecoveryHandler.swift
@@ -27,6 +27,8 @@ protocol FailureRecoveryHandling {
         isKillSwitchEnabled: Bool,
         updateConfig: @escaping (NetworkProtectionDeviceManagement.GenerateTunnelConfigResult) async throws -> Void
     ) async throws
+
+    func stop() async
 }
 
 enum FailureRecoveryError: Error {

--- a/Sources/NetworkProtection/Recovery/Reasserting.swift
+++ b/Sources/NetworkProtection/Recovery/Reasserting.swift
@@ -21,7 +21,6 @@ import NetworkExtension
 
 protocol Reasserting: AnyObject {
     func startReasserting()
-    func stopReasserting()
 }
 
 extension NEPacketTunnelProvider: Reasserting {
@@ -29,10 +28,5 @@ extension NEPacketTunnelProvider: Reasserting {
     @MainActor
     func startReasserting() {
         reasserting = true
-    }
-
-    @MainActor
-    func stopReasserting() {
-        reasserting = false
     }
 }

--- a/Sources/NetworkProtectionTestUtils/MockNetworkProtectionDeviceManagement.swift
+++ b/Sources/NetworkProtectionTestUtils/MockNetworkProtectionDeviceManagement.swift
@@ -30,7 +30,7 @@ public final class MockNetworkProtectionDeviceManagement: NetworkProtectionDevic
         excludedRoutes: [NetworkProtection.IPAddressRange],
         isKillSwitchEnabled: Bool,
         regenerateKey: Bool
-    )? = nil
+    )?
 
     public var stubGenerateTunnelConfiguration: (
         tunnelConfig: NetworkProtection.TunnelConfiguration,
@@ -61,6 +61,5 @@ public final class MockNetworkProtectionDeviceManagement: NetworkProtectionDevic
             }
             throw MockError.noStubSet
     }
-    
 
 }


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206669588477115/f
iOS PR: TODO
macOS PR: duckduckgo/macos-browser#2657
What kind of version bump will this require?: Major

**Description**:
If the “rekey" fails (unable to /register and get server), we do a backoff of x2 starting with 30 seconds (attempts done right away, after 30 sec, after 1 minute, after 2 minutes, after 4 minutes). We also limit the backoff to 5 times only.
If a wireguard handshake successfully occurs, we cancel the backoff and all the attempts to rekey.

**Steps to test this PR**:
1. Start VPN
2. Open Console.App and filter by Category: Network Protection
3. Use `pfctl` to block UDP packets systemwide simulating a connection failure ([instructions here](https://app.asana.com/0/0/1207029295107667/f)
4. To test a retry triggered by the config fetch failing, use a proxy (e.g Proxyman) to block requests to the controller (https://controller.netp.duckduckgo.com)
5. Look for logs in the console indicating that the request was made, failed and the retry is triggered
6. To test a retry triggered by the WG config update failing, either manipulate the `register` response to give a different egress server (find names in the servers list in the macOS debug menu) or hardcode a response to do this e.g after the first retry
7. Look for logs in the console indicating that the request was made, failed and the retry is triggered
8. To test when a recovery is necessary, before the failure recovery is attempted, remove the `DuckDuckGo Network Protection Private Key` from your keychain, then let the `register` request succeed.
9. Look for logs in the console indicating that the recovery succeeded
10. To test when a recovery is not necessary, unblock the packets using `pfctl` and re-do step 3
11. Look for logs indicating that recovery was not necessary.

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
