### PR TITLE
VPN server failure recovery pixels + reasserting fix

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1230,6 +1230,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     private lazy var failureRecoveryHandler: FailureRecoveryHandling = FailureRecoveryHandler(
         deviceManager: deviceManager,
+        reassertingControl: self,
         eventHandler: { [weak self] step in
             self?.providerEvents.fire(.failureRecoveryAttempt(step))
         }
@@ -1240,8 +1241,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             guard let server = await self.lastSelectedServer else {
                 return
             }
-            await self.startReasserting()
-
             await self.failureRecoveryHandler.attemptRecovery(
                 to: server,
                 includedRoutes: self.includedRoutes ?? [],

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1236,23 +1236,20 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     )
 
     private func startServerFailureRecovery() {
-        providerEvents.fire(.failureRecoveryAttempt(.started))
         Task {
             guard let server = await self.lastSelectedServer else {
                 return
             }
             await self.startReasserting()
 
-            do {
-                try? await self.failureRecoveryHandler.attemptRecovery(
-                    to: server,
-                    includedRoutes: self.includedRoutes ?? [],
-                    excludedRoutes: self.settings.excludedRanges,
-                    isKillSwitchEnabled: self.isKillSwitchEnabled
-                ) { [weak self] generateConfigResult in
-                    try await self?.handleFailureRecoveryConfigUpdate(result: generateConfigResult)
-                    self?.providerEvents.fire(.failureRecoveryAttempt(.completed(.unhealthy)))
-                }
+            await self.failureRecoveryHandler.attemptRecovery(
+                to: server,
+                includedRoutes: self.includedRoutes ?? [],
+                excludedRoutes: self.settings.excludedRanges,
+                isKillSwitchEnabled: self.isKillSwitchEnabled
+            ) { [weak self] generateConfigResult in
+                try await self?.handleFailureRecoveryConfigUpdate(result: generateConfigResult)
+                self?.providerEvents.fire(.failureRecoveryAttempt(.completed(.unhealthy)))
             }
         }
     }

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -847,8 +847,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     // MARK: - App Messages
 
     // swiftlint:disable:next cyclomatic_complexity
-    @MainActor
-    public override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {
+    @MainActor public override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {
         guard let message = ExtensionMessage(rawValue: messageData) else {
             completionHandler?(nil)
             return

--- a/Sources/NetworkProtectionTestUtils/MockNetworkProtectionDeviceManagement.swift
+++ b/Sources/NetworkProtectionTestUtils/MockNetworkProtectionDeviceManagement.swift
@@ -24,6 +24,7 @@ public final class MockNetworkProtectionDeviceManagement: NetworkProtectionDevic
         case noStubSet
     }
 
+    // swiftlint:disable:next large_tuple
     public var spyGenerateTunnelConfiguration: (
         selectionMethod: NetworkProtection.NetworkProtectionServerSelectionMethod,
         includedRoutes: [NetworkProtection.IPAddressRange],

--- a/Tests/NetworkProtectionTests/Mocks/MockReasserting.swift
+++ b/Tests/NetworkProtectionTests/Mocks/MockReasserting.swift
@@ -1,5 +1,6 @@
 //
-//  Reasserting.swift
+//  MockReasserting.swift
+//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //
@@ -17,22 +18,17 @@
 //
 
 import Foundation
-import NetworkExtension
+@testable import NetworkProtection
 
-protocol Reasserting: AnyObject {
-    func startReasserting()
-    func stopReasserting()
-}
+class MockReasserting: Reasserting {
 
-extension NEPacketTunnelProvider: Reasserting {
-
-    @MainActor
+    var startReassertingCallCount = 0
     func startReasserting() {
-        reasserting = true
+        startReassertingCallCount += 1
     }
-
-    @MainActor
+    
+    var stopReassertingCallCount = 0
     func stopReasserting() {
-        reasserting = false
+        stopReassertingCallCount += 1
     }
 }

--- a/Tests/NetworkProtectionTests/Mocks/MockReasserting.swift
+++ b/Tests/NetworkProtectionTests/Mocks/MockReasserting.swift
@@ -1,6 +1,5 @@
 //
 //  MockReasserting.swift
-//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //

--- a/Tests/NetworkProtectionTests/Mocks/MockReasserting.swift
+++ b/Tests/NetworkProtectionTests/Mocks/MockReasserting.swift
@@ -26,7 +26,7 @@ class MockReasserting: Reasserting {
     func startReasserting() {
         startReassertingCallCount += 1
     }
-    
+
     var stopReassertingCallCount = 0
     func stopReasserting() {
         stopReassertingCallCount += 1

--- a/Tests/NetworkProtectionTests/Mocks/MockURLProtocol.swift
+++ b/Tests/NetworkProtectionTests/Mocks/MockURLProtocol.swift
@@ -36,7 +36,7 @@ final class MockURLProtocol: URLProtocol {
             fatalError(
                 "No mock response for \(request.url!). This should never happen. Check " +
                 "the implementation of `canInit(with request: URLRequest) -> Bool`"
-            )
+            )x
         }
 
         self.client?.urlProtocol(self, didReceive: stub.response, cacheStoragePolicy: .allowed)

--- a/Tests/NetworkProtectionTests/Mocks/TunnelConfigurationMocks.swift
+++ b/Tests/NetworkProtectionTests/Mocks/TunnelConfigurationMocks.swift
@@ -1,6 +1,5 @@
 //
 //  TunnelConfigurationMocks.swift
-//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206939413299475/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2779
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2657
What kind of version bump will this require?: Major

**Description**:

Adds Pixels described in the task to monitor how often VPN server failure recovery is happening and succeeding.

**Steps to test this PR**:
1. Follow steps in https://app.asana.com/0/72649045549333/1207063933755975/f
2. Check that the right pixel appears in the console after each step.

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
