### PR TITLE
Add missing tests for stubs rearrangement

### DIFF
--- a/Tests/BookmarksTests/FavoriteListViewModelTests.swift
+++ b/Tests/BookmarksTests/FavoriteListViewModelTests.swift
@@ -98,6 +98,46 @@ final class FavoriteListViewModelTests: XCTestCase {
         }
     }
 
+    func testWhenBookmarkIsMovedAndThereAreStubsThenCorrectIndexIsCalculated() {
+
+        let context = favoriteListViewModel.context
+
+        let bookmarkTree = BookmarkTree {
+            Bookmark(id: "1", favoritedOn: [.mobile, .unified])
+            Bookmark(id: "s1", favoritedOn: [.mobile, .unified], isStub: true)
+            Bookmark(id: "2", favoritedOn: [.mobile, .unified])
+            Bookmark(id: "s2", favoritedOn: [.mobile, .unified], isStub: true)
+            Bookmark(id: "3", favoritedOn: [.mobile, .unified])
+            Bookmark(id: "s3", favoritedOn: [.mobile, .unified], isStub: true)
+        }
+
+        context.performAndWait {
+            bookmarkTree.createEntities(in: context)
+            try! context.save()
+
+            let bookmark = BookmarkEntity.fetchBookmark(withUUID: "1", context: context)!
+
+            let favoriteFolderUUID = favoriteListViewModel.favoritesDisplayMode.displayedFolder.rawValue
+            let rootFavoriteFolder = BookmarkUtils.fetchFavoritesFolder(withUUID: favoriteFolderUUID, in: context)!
+
+            favoriteListViewModel.reloadData()
+
+            favoriteListViewModel.moveFavorite(bookmark, fromIndex: 0, toIndex: 0)
+            XCTAssertEqual((rootFavoriteFolder.favorites?.array as! [BookmarkEntity]).map(\.uuid), ["1", "s1", "2", "s2", "3", "s3"])
+            XCTAssertEqual(rootFavoriteFolder.favoritesArray.map(\.title), ["1", "2", "3"])
+
+            favoriteListViewModel.moveFavorite(bookmark, fromIndex: 0, toIndex: 1)
+            XCTAssertEqual((rootFavoriteFolder.favorites?.array as! [BookmarkEntity]).map(\.uuid), ["s1", "2", "1", "s2", "3", "s3"])
+            XCTAssertEqual(rootFavoriteFolder.favoritesArray.map(\.title), ["2", "1", "3"])
+
+            favoriteListViewModel.moveFavorite(bookmark, fromIndex: 1, toIndex: 2)
+            XCTAssertEqual((rootFavoriteFolder.favorites?.array as! [BookmarkEntity]).map(\.uuid), ["s1", "2", "s2", "3", "1", "s3"])
+            XCTAssertEqual(rootFavoriteFolder.favoritesArray.map(\.title), ["2", "3", "1"])
+
+            XCTAssertEqual(firedEvents, [])
+        }
+    }
+
     func testDisplayNativeMode_WhenFavoriteIsUnfavoritedThenItIsRemovedFromNativeAndUnifiedFolder() async throws {
 
         favoriteListViewModel.favoritesDisplayMode = .displayNative(.mobile)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201493110486074/1207136222342904/f
iOS PR: n/a
macOS PR: n/a 
What kind of version bump will this require?: Patch

**Description**:

Expand test suite to cover stub objects when rearranging Bookmarks.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Just validate whether the tests cover the problem listed in asana.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
