### PR TITLE
Add parameter allowed encoding to error descriptions

### DIFF
--- a/Sources/Common/Extensions/URLExtension.swift
+++ b/Sources/Common/Extensions/URLExtension.swift
@@ -425,7 +425,7 @@ extension URL {
 
 }
 
-fileprivate extension CharacterSet {
+public extension CharacterSet {
 
     /**
      * As per [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.2).

--- a/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -236,14 +236,7 @@ public struct BrokenSiteReport {
         }
 
         if let errors {
-            let errorDescriptions: [String] = errors.map {
-                let error = $0 as NSError
-                return "\(error.code) - \(error.domain):\(error.localizedDescription)"
-            }
-            let jsonString = try? String(data: JSONSerialization.data(withJSONObject: errorDescriptions), encoding: .utf8)!
-            if let encodedString = jsonString?.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed) {
-                result["errorDescriptions"] = encodedString
-            }
+            result["errorDescriptions"] = encodeErrors(errors)
         }
 
         if let jsPerformance {
@@ -257,6 +250,16 @@ public struct BrokenSiteReport {
         result["model"] = model
 #endif
         return result
+    }
+
+    private func encodeErrors(_ errors: [Error]) -> String {
+        let errorDescriptions: [String] = errors.map {
+            let error = $0 as NSError
+            return "\(error.code) - \(error.domain):\(error.localizedDescription)"
+        }
+        let jsonString = try? String(data: JSONSerialization.data(withJSONObject: errorDescriptions), encoding: .utf8)!
+        let encodedString = jsonString?.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed)
+        return encodedString ?? ""
     }
 
 }

--- a/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -240,7 +240,10 @@ public struct BrokenSiteReport {
                 let error = $0 as NSError
                 return "\(error.code) - \(error.domain):\(error.localizedDescription)"
             }
-            result["errorDescriptions"] = errorDescriptions.joined(separator: ",")
+            let jsonString = try? String(data: JSONSerialization.data(withJSONObject: errorDescriptions), encoding: .utf8)!
+            if let encodedString = jsonString?.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed) {
+                result["errorDescriptions"] = encodedString
+            }
         }
 
         if let jsPerformance {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203790657351911/1207097497487052/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2781
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2691
What kind of version bump will this require?: Patch

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open https://expired.badssl.com/
1. Send broken site report.
1. Put a breakpoint in BrokenSiteReport.swift:245 and make sure the array of errors is properly encoded.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
