### PR TITLE
Support new privacy dashboard source

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "14b13d0c3db38f471ce4ba1ecb502ee1986c84d7",
-        "version" : "3.5.0"
+        "revision" : "25b8903191a40b21b09525085fe325ae3386092e",
+        "version" : "3.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "2.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
-        .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "3.5.0"),
+        .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "3.6.0"),
         .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "5.12.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),

--- a/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -29,16 +29,28 @@ public struct BrokenSiteReport {
 
     }
 
-    public enum Source: String {
+    public enum Source {
 
         /// From the app menu's "Report Broken Site"
-        case appMenu = "menu"
+        case appMenu
         /// From the privacy dashboard's "Website not working?"
         case dashboard
         /// From the app menu's "Disable Privacy Protection"
-        case onProtectionsOffMenu = "on_protections_off_menu"
+        case onProtectionsOffMenu
         /// From the privacy dashboard's on protections toggle off
-        case onProtectionsOffDashboard = "on_protections_off_dashboard_main"
+        case onProtectionsOffDashboard
+        /// From the 'Site Not Working?' prompt that appears on various events
+        case prompt(String)
+
+        public var rawValue: String {
+            switch self {
+            case .appMenu: return "menu"
+            case .dashboard: return "dashboard"
+            case .onProtectionsOffMenu: return "on_protections_off_menu"
+            case .onProtectionsOffDashboard: return "on_protections_off_dashboard_main"
+            case .prompt(let event): return event
+            }
+        }
 
     }
 

--- a/Sources/PrivacyDashboard/PrivacyDashboardController.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardController.swift
@@ -363,8 +363,8 @@ extension PrivacyDashboardController: PrivacyDashboardUserScriptDelegate {
             privacyDashboardDelegate?.privacyDashboardController(self, didChangeProtectionSwitch: protectionState, didSendReport: didSendReport)
         case .breakageForm:
             privacyDashboardReportBrokenSiteDelegate?.privacyDashboardController(self, reportBrokenSiteDidChangeProtectionSwitch: protectionState)
-        case .toggleReport:
-            assertionFailure("Simple Breakage report screen doesn't have toggling capability")
+        case .toggleReport, .promptBreakageForm:
+            assertionFailure("These screen don't have toggling capability")
         }
     }
 

--- a/Sources/PrivacyDashboard/PrivacyDashboardController.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardController.swift
@@ -485,6 +485,7 @@ extension PrivacyDashboardController: PrivacyDashboardUserScriptDelegate {
         case .report: source = .appMenu
         case .dashboard: source = .dashboard
         case .toggleReport: source = .onProtectionsOffMenu
+        case .prompt(let event): source = .prompt(event)
         }
         if protectionStateToSubmitOnToggleReportDismiss != nil {
             source = .onProtectionsOffDashboard

--- a/Sources/PrivacyDashboard/PrivacyDashboardMode.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardMode.swift
@@ -28,7 +28,7 @@ public enum PrivacyDashboardMode: Equatable {
         switch self {
         case .dashboard: return .primaryScreen
         case .report: return .breakageForm
-        case .prompt: return .breakageForm // TODO: Privacy dashboard needs to support new name here
+        case .prompt: return .promptBreakageForm
         case .toggleReport: return .toggleReport
         }
     }

--- a/Sources/PrivacyDashboard/PrivacyDashboardMode.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardMode.swift
@@ -21,19 +21,21 @@ public enum PrivacyDashboardMode: Equatable {
 
     case dashboard
     case report
+    case prompt(String)
     case toggleReport(completionHandler: (Bool) -> Void)
 
     var screen: PrivacyDashboard.Screen {
         switch self {
         case .dashboard: return .primaryScreen
         case .report: return .breakageForm
+        case .prompt: return .breakageForm // TODO: Privacy dashboard needs to support new name here
         case .toggleReport: return .toggleReport
         }
     }
 
     public static func == (lhs: PrivacyDashboardMode, rhs: PrivacyDashboardMode) -> Bool {
         switch (lhs, rhs) {
-        case (.dashboard, .dashboard), (.report, .report), (.toggleReport, .toggleReport):
+        case (.dashboard, .dashboard), (.report, .report), (.toggleReport, .toggleReport), (.prompt, .prompt):
             return true
         default:
             return false

--- a/Sources/PrivacyDashboard/PrivacyDashboardUserScript.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardUserScript.swift
@@ -53,6 +53,7 @@ public enum Screen: String, Decodable {
     case primaryScreen
     case breakageForm
     case toggleReport
+    case promptBreakageForm
 
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203790657351911/1207097497487052/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2790
macOS PR: TBD
What kind of version bump will this require?: Patch

**Description**:
Introduce new source type to privacy dashboard.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
