### PR TITLE
Break the Subscription module’s dependency on BSK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,7 @@ let package = Package(
                 "UserScript",
                 "ContentBlocking",
                 "SecureStorage",
+                "Subscription"
             ],
             resources: [
                 .process("ContentBlocking/UserScripts/contentblockerrules.js"),
@@ -322,8 +323,7 @@ let package = Package(
         .target(
             name: "Subscription",
             dependencies: [
-                "BrowserServicesKit",
-                "Common",
+                "Common"
             ],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug))

--- a/Package.swift
+++ b/Package.swift
@@ -386,6 +386,7 @@ let package = Package(
                 "RemoteMessaging", // Move tests later (lots of test dependencies in BSK)
                 "SecureStorageTestsUtils",
                 "TestUtils",
+                "Subscription"
             ],
             resources: [
                 .copy("Resources")
@@ -500,12 +501,6 @@ let package = Package(
             dependencies: [
                 "PrivacyDashboard",
                 "TestUtils",
-            ]
-        ),
-        .testTarget(
-            name: "SubscriptionTests",
-            dependencies: [
-                "Subscription",
             ]
         ),
         .testTarget(

--- a/Sources/BrowserServicesKit/SubscriptionFeatureAvailability.swift
+++ b/Sources/BrowserServicesKit/SubscriptionFeatureAvailability.swift
@@ -16,7 +16,7 @@
 //  limitations under the License.
 //
 
-import BrowserServicesKit
+import Subscription
 
 public protocol SubscriptionFeatureAvailability {
     var isFeatureAvailable: Bool { get }

--- a/Tests/BrowserServicesKitTests/Subscription/SubscriptionFeatureAvailabilityTests.swift
+++ b/Tests/BrowserServicesKitTests/Subscription/SubscriptionFeatureAvailabilityTests.swift
@@ -17,10 +17,10 @@
 //
 
 import XCTest
-import BrowserServicesKit
 import Common
 import Combine
 @testable import Subscription
+@testable import BrowserServicesKit
 
 final class SubscriptionFeatureAvailabilityTests: XCTestCase {
 
@@ -229,10 +229,6 @@ final class SubscriptionFeatureAvailabilityTests: XCTestCase {
             return enabledSubfeatures.contains(subfeature)
         }
     }
-}
-
-class MockInternalUserStoring: InternalUserStoring {
-    var isInternalUser: Bool = false
 }
 
 class MockPrivacyConfiguration: PrivacyConfiguration {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207201481522088/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2804
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2721
What kind of version bump will this require?: Major

**Description**:

This PR removes the BSK dependency from the Subscription library.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
