### PR TITLE
Enable gzip compression for Sync PATCH payloads

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "gzipswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/1024jp/GzipSwift.git",
+      "state" : {
+        "revision" : "731037f6cc2be2ec01562f6597c1d0aa3fe6fd05",
+        "version" : "6.0.1"
+      }
+    },
+    {
       "identity" : "privacy-dashboard",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",

--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/wireguard-apple", exact: "1.1.3"),
+        .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1")
     ],
     targets: [
         .target(
@@ -152,6 +153,7 @@ let package = Package(
                 "BrowserServicesKit",
                 "Common",
                 .product(name: "DDGSyncCrypto", package: "sync_crypto"),
+                .product(name: "Gzip", package: "GzipSwift"),
                 "Networking",
             ],
             resources: [

--- a/Sources/DDGSync/SyncError.swift
+++ b/Sources/DDGSync/SyncError.swift
@@ -57,6 +57,7 @@ public enum SyncError: Error, Equatable {
     case settingsMetadataNotPresent
 
     case unauthenticatedWhileLoggedIn
+    case patchPayloadCompressionFailed(_ errorCode: Int)
 
     public var isServerError: Bool {
         switch self {
@@ -137,6 +138,8 @@ public enum SyncError: Error, Equatable {
             return [syncErrorString: "settingsMetadataNotPresent"]
         case .unauthenticatedWhileLoggedIn:
             return [syncErrorString: "unauthenticatedWhileLoggedIn"]
+        case .patchPayloadCompressionFailed:
+            return [syncErrorString: "patchPayloadCompressionFailed"]
         }
     }
 }
@@ -183,6 +186,7 @@ extension SyncError: CustomNSError {
         case .emailProtectionUsernamePresentButTokenMissing: return 26
         case .settingsMetadataNotPresent: return 27
         case .unauthenticatedWhileLoggedIn: return 28
+        case .patchPayloadCompressionFailed: return 29
         }
     }
 

--- a/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -27,6 +27,7 @@ struct ProductionDependencies: SyncDependencies {
     let endpoints: Endpoints
     let account: AccountManaging
     let api: RemoteAPIRequestCreating
+    let payloadCompressor: SyncPayloadCompressing
     var keyValueStore: KeyValueStoring
     let secureStore: SecureStoring
     let crypter: CryptingInternal
@@ -72,6 +73,7 @@ struct ProductionDependencies: SyncDependencies {
         self.getLog = log
 
         api = RemoteAPIRequestCreator(log: log())
+        payloadCompressor = SyncPayloadCompressor()
 
         crypter = Crypter(secureStore: secureStore)
         account = AccountManager(endpoints: endpoints, api: api, crypter: crypter)

--- a/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -73,7 +73,7 @@ struct ProductionDependencies: SyncDependencies {
         self.getLog = log
 
         api = RemoteAPIRequestCreator(log: log())
-        payloadCompressor = SyncPayloadCompressor()
+        payloadCompressor = SyncGzipPayloadCompressor()
 
         crypter = Crypter(secureStore: secureStore)
         account = AccountManager(endpoints: endpoints, api: api, crypter: crypter)

--- a/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/Sources/DDGSync/internal/SyncDependencies.swift
@@ -31,6 +31,7 @@ protocol SyncDependencies: SyncDependenciesDebuggingSupport {
     var endpoints: Endpoints { get }
     var account: AccountManaging { get }
     var api: RemoteAPIRequestCreating { get }
+    var payloadCompressor: SyncPayloadCompressing { get }
     var keyValueStore: KeyValueStoring { get }
     var secureStore: SecureStoring { get }
     var crypter: CryptingInternal { get }

--- a/Sources/DDGSync/internal/SyncGzipPayloadCompressor.swift
+++ b/Sources/DDGSync/internal/SyncGzipPayloadCompressor.swift
@@ -1,5 +1,5 @@
 //
-//  SyncPayloadCompressor.swift
+//  SyncGzipPayloadCompressor.swift
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //
@@ -23,7 +23,7 @@ protocol SyncPayloadCompressing {
     func compress(_ payload: Data) throws -> Data
 }
 
-struct SyncPayloadCompressor: SyncPayloadCompressing {
+struct SyncGzipPayloadCompressor: SyncPayloadCompressing {
     func compress(_ payload: Data) throws -> Data {
         try payload.gzipped()
     }

--- a/Sources/DDGSync/internal/SyncOperation.swift
+++ b/Sources/DDGSync/internal/SyncOperation.swift
@@ -218,7 +218,7 @@ final class SyncOperation: Operation {
             do {
                 return try requestMaker.makePatchRequest(with: syncRequest, clientTimestamp: timestamp, isCompressed: true)
             } catch let error as GzipError {
-                dataProvider.handleSyncError(error)
+                dataProvider.handleSyncError(SyncError.patchPayloadCompressionFailed(error.errorCode))
                 return try requestMaker.makePatchRequest(with: syncRequest, clientTimestamp: timestamp, isCompressed: false)
             }
         }

--- a/Sources/DDGSync/internal/SyncOperation.swift
+++ b/Sources/DDGSync/internal/SyncOperation.swift
@@ -19,6 +19,7 @@
 import Foundation
 import Combine
 import Common
+import Gzip
 
 final class SyncOperation: Operation {
 
@@ -143,7 +144,7 @@ final class SyncOperation: Operation {
                         try checkCancellation()
                         let syncRequest = try await self.makeSyncRequest(for: dataProvider, fetchOnly: fetchOnly)
                         let clientTimestamp = Date()
-                        let httpRequest = try self.makeHTTPRequest(with: syncRequest, timestamp: clientTimestamp)
+                        let httpRequest = try self.makeHTTPRequest(for: dataProvider, with: syncRequest, timestamp: clientTimestamp)
 
                         try checkCancellation()
                         let httpResult: HTTPResult = try await httpRequest.execute()
@@ -211,10 +212,15 @@ final class SyncOperation: Operation {
         return SyncRequest(feature: dataProvider.feature, previousSyncTimestamp: dataProvider.lastSyncTimestamp, sent: localChanges)
     }
 
-    private func makeHTTPRequest(with syncRequest: SyncRequest, timestamp: Date) throws -> HTTPRequesting {
+    private func makeHTTPRequest(for dataProvider: DataProviding, with syncRequest: SyncRequest, timestamp: Date) throws -> HTTPRequesting {
         let hasLocalChanges = !syncRequest.sent.isEmpty
         if hasLocalChanges {
-            return try requestMaker.makePatchRequest(with: syncRequest, clientTimestamp: timestamp)
+            do {
+                return try requestMaker.makePatchRequest(with: syncRequest, clientTimestamp: timestamp, isCompressed: true)
+            } catch let error as GzipError {
+                dataProvider.handleSyncError(error)
+                return try requestMaker.makePatchRequest(with: syncRequest, clientTimestamp: timestamp, isCompressed: false)
+            }
         }
         return try requestMaker.makeGetRequest(with: syncRequest)
     }

--- a/Sources/DDGSync/internal/SyncPayloadCompressor.swift
+++ b/Sources/DDGSync/internal/SyncPayloadCompressor.swift
@@ -28,3 +28,24 @@ struct SyncPayloadCompressor: SyncPayloadCompressing {
         try payload.gzipped()
     }
 }
+
+extension GzipError: CustomNSError {
+    public static let errorDomain: String = "GzipError"
+
+    public var errorCode: Int {
+        switch kind {
+        case .stream:
+            return -2
+        case .data:
+            return -3
+        case .memory:
+            return -4
+        case .buffer:
+            return -5
+        case .version:
+            return -6
+        case .unknown(let code):
+            return code
+        }
+    }
+}

--- a/Sources/DDGSync/internal/SyncPayloadCompressor.swift
+++ b/Sources/DDGSync/internal/SyncPayloadCompressor.swift
@@ -29,10 +29,10 @@ struct SyncPayloadCompressor: SyncPayloadCompressing {
     }
 }
 
-extension GzipError: CustomNSError {
-    public static let errorDomain: String = "GzipError"
-
-    public var errorCode: Int {
+extension GzipError {
+    /// Mapping is taken from `GzipError.Kind` documentation which maps zlib error codes to enum cases,
+    /// and we're effectively reversing that mapping here.
+    var errorCode: Int {
         switch kind {
         case .stream:
             return -2

--- a/Sources/DDGSync/internal/SyncPayloadCompressor.swift
+++ b/Sources/DDGSync/internal/SyncPayloadCompressor.swift
@@ -17,7 +17,7 @@
 //
 
 import Foundation
-@testable import Gzip
+import Gzip
 
 protocol SyncPayloadCompressing {
     func compress(_ payload: Data) throws -> Data
@@ -25,7 +25,6 @@ protocol SyncPayloadCompressing {
 
 struct SyncPayloadCompressor: SyncPayloadCompressing {
     func compress(_ payload: Data) throws -> Data {
-        throw GzipError(code: 400, msg: nil)
         try payload.gzipped()
     }
 }

--- a/Sources/DDGSync/internal/SyncPayloadCompressor.swift
+++ b/Sources/DDGSync/internal/SyncPayloadCompressor.swift
@@ -1,6 +1,5 @@
 //
 //  SyncPayloadCompressor.swift
-//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //

--- a/Sources/DDGSync/internal/SyncPayloadCompressor.swift
+++ b/Sources/DDGSync/internal/SyncPayloadCompressor.swift
@@ -1,0 +1,31 @@
+//
+//  SyncPayloadCompressor.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Gzip
+
+protocol SyncPayloadCompressing {
+    func compress(_ payload: Data) throws -> Data
+}
+
+struct SyncPayloadCompressor: SyncPayloadCompressing {
+    func compress(_ payload: Data) throws -> Data {
+        try payload.gzipped()
+    }
+}

--- a/Sources/DDGSync/internal/SyncPayloadCompressor.swift
+++ b/Sources/DDGSync/internal/SyncPayloadCompressor.swift
@@ -17,7 +17,7 @@
 //
 
 import Foundation
-import Gzip
+@testable import Gzip
 
 protocol SyncPayloadCompressing {
     func compress(_ payload: Data) throws -> Data
@@ -25,6 +25,7 @@ protocol SyncPayloadCompressing {
 
 struct SyncPayloadCompressor: SyncPayloadCompressing {
     func compress(_ payload: Data) throws -> Data {
+        throw GzipError(code: 400, msg: nil)
         try payload.gzipped()
     }
 }

--- a/Sources/DDGSync/internal/SyncQueue.swift
+++ b/Sources/DDGSync/internal/SyncQueue.swift
@@ -69,6 +69,7 @@ final class SyncQueue {
             crypter: dependencies.crypter,
             api: dependencies.api,
             endpoints: dependencies.endpoints,
+            payloadCompressor: dependencies.payloadCompressor,
             log: dependencies.log
         )
     }
@@ -79,13 +80,14 @@ final class SyncQueue {
         crypter: Crypting,
         api: RemoteAPIRequestCreating,
         endpoints: Endpoints,
+        payloadCompressor: SyncPayloadCompressing,
         log: @escaping @autoclosure () -> OSLog = .disabled
     ) {
         self.dataProviders = dataProviders
         self.storage = storage
         self.crypter = crypter
         self.getLog = log
-        requestMaker = SyncRequestMaker(storage: storage, api: api, endpoints: endpoints)
+        requestMaker = SyncRequestMaker(storage: storage, api: api, endpoints: endpoints, payloadCompressor: payloadCompressor)
         syncDidFinishPublisher = syncDidFinishSubject.eraseToAnyPublisher()
         syncHTTPRequestErrorPublisher = syncHTTPRequestErrorSubject.eraseToAnyPublisher()
         isSyncInProgressPublisher = Publishers

--- a/Sources/DDGSync/internal/SyncRequestMaker.swift
+++ b/Sources/DDGSync/internal/SyncRequestMaker.swift
@@ -59,7 +59,12 @@ struct SyncRequestMaker: SyncRequestMaking {
         let body = try JSONSerialization.data(withJSONObject: json, options: [])
 
         guard isCompressed else {
-            return api.createAuthenticatedJSONRequest(url: endpoints.syncPatch, method: .PATCH, authToken: try getToken(), json: body)
+            return api.createAuthenticatedJSONRequest(
+                url: endpoints.syncPatch,
+                method: .PATCH,
+                authToken: try getToken(),
+                json: body
+            )
         }
 
         let compressedBody = try payloadCompressor.compress(body)

--- a/Sources/DDGSync/internal/SyncRequestMaker.swift
+++ b/Sources/DDGSync/internal/SyncRequestMaker.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import Gzip
 
 protocol SyncRequestMaking {
     func makeGetRequest(with result: SyncRequest) throws -> HTTPRequesting
@@ -54,8 +55,10 @@ struct SyncRequestMaker: SyncRequestMaking {
             throw SyncError.unableToEncodeRequestBody("Sync PATCH payload is not a valid JSON")
         }
 
-        let body = try JSONSerialization.data(withJSONObject: json, options: [])
-        return api.createAuthenticatedJSONRequest(url: endpoints.syncPatch, method: .PATCH, authToken: try getToken(), json: body)
+        let headers = ["Content-Encoding": "gzip"]
+
+        let body = try JSONSerialization.data(withJSONObject: json, options: []).gzipped()
+        return api.createAuthenticatedJSONRequest(url: endpoints.syncPatch, method: .PATCH, authToken: try getToken(), json: body, headers: headers)
     }
 
     private func getToken() throws -> String {

--- a/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -200,7 +200,7 @@ struct MockSyncDependencies: SyncDependencies, SyncDependenciesDebuggingSupport 
     var endpoints: Endpoints = Endpoints(baseURL: URL(string: "https://dev.null")!)
     var account: AccountManaging = AccountManagingMock()
     var api: RemoteAPIRequestCreating = RemoteAPIRequestCreatingMock()
-    var payloadCompressor: SyncPayloadCompressing = SyncPayloadCompressorMock()
+    var payloadCompressor: SyncPayloadCompressing = SyncGzipPayloadCompressorMock()
     var secureStore: SecureStoring = SecureStorageStub()
     var crypter: CryptingInternal = CryptingMock()
     var scheduler: SchedulingInternal = SchedulerMock()
@@ -306,7 +306,7 @@ class InspectableSyncRequestMaker: SyncRequestMaking {
     var makePatchRequestCallArgs: [MakePatchRequestCallArgs] = []
 }
 
-class SyncPayloadCompressorMock: SyncPayloadCompressing {
+class SyncGzipPayloadCompressorMock: SyncPayloadCompressing {
     var error: Error?
 
     func compress(_ payload: Data) throws -> Data {

--- a/Tests/DDGSyncTests/SyncOperationTests.swift
+++ b/Tests/DDGSyncTests/SyncOperationTests.swift
@@ -25,7 +25,7 @@ class SyncOperationTests: XCTestCase {
     var apiMock: RemoteAPIRequestCreatingMock!
     var request: HTTPRequestingMock!
     var endpoints: Endpoints!
-    var payloadCompressor: SyncPayloadCompressorMock!
+    var payloadCompressor: SyncGzipPayloadCompressorMock!
     var storage: SecureStorageStub!
     var crypter: CryptingMock!
     var requestMaker: InspectableSyncRequestMaker!
@@ -37,7 +37,7 @@ class SyncOperationTests: XCTestCase {
         request = HTTPRequestingMock()
         apiMock.request = request
         endpoints = Endpoints(baseURL: URL(string: "https://example.com")!)
-        payloadCompressor = SyncPayloadCompressorMock()
+        payloadCompressor = SyncGzipPayloadCompressorMock()
         storage = SecureStorageStub()
         crypter = CryptingMock()
         try storage.persistAccount(

--- a/Tests/DDGSyncTests/SyncOperationTests.swift
+++ b/Tests/DDGSyncTests/SyncOperationTests.swift
@@ -167,16 +167,16 @@ class SyncOperationTests: XCTestCase {
 
         for body in bodies.compactMap({$0}) {
             do {
-                let payload = try JSONDecoder.snakeCaseKeys.decode(BookmarksPayload.self, from: body)
+                let payload = try JSONDecoder.snakeCaseKeys.decode(BookmarksPayload.self, from: body.gunzipped())
                 XCTAssertEqual(payload, bookmarks)
                 payloadCount -= 1
             } catch {
                 do {
-                    let payload = try JSONDecoder.snakeCaseKeys.decode(SettingsPayload.self, from: body)
+                    let payload = try JSONDecoder.snakeCaseKeys.decode(SettingsPayload.self, from: body.gunzipped())
                     XCTAssertEqual(payload, settings)
                     payloadCount -= 1
                 } catch {
-                    let payload = try JSONDecoder.snakeCaseKeys.decode(AutofillPayload.self, from: body)
+                    let payload = try JSONDecoder.snakeCaseKeys.decode(AutofillPayload.self, from: body.gunzipped())
                     XCTAssertEqual(payload, autofill)
                     payloadCount -= 1
                 }

--- a/Tests/DDGSyncTests/SyncQueueTests.swift
+++ b/Tests/DDGSyncTests/SyncQueueTests.swift
@@ -35,7 +35,7 @@ class SyncQueueTests: XCTestCase {
         apiMock = RemoteAPIRequestCreatingMock()
         request = HTTPRequestingMock()
         apiMock.request = request
-        payloadCompressor = SyncPayloadCompressorMock()
+        payloadCompressor = SyncGzipPayloadCompressorMock()
         endpoints = Endpoints(baseURL: URL(string: "https://example.com")!)
         storage = SecureStorageStub()
         crypter = CryptingMock()

--- a/Tests/DDGSyncTests/SyncQueueTests.swift
+++ b/Tests/DDGSyncTests/SyncQueueTests.swift
@@ -27,6 +27,7 @@ class SyncQueueTests: XCTestCase {
     var storage: SecureStorageStub!
     var crypter: CryptingMock!
     var requestMaker: SyncRequestMaking!
+    var payloadCompressor: SyncPayloadCompressing!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -34,6 +35,7 @@ class SyncQueueTests: XCTestCase {
         apiMock = RemoteAPIRequestCreatingMock()
         request = HTTPRequestingMock()
         apiMock.request = request
+        payloadCompressor = SyncPayloadCompressorMock()
         endpoints = Endpoints(baseURL: URL(string: "https://example.com")!)
         storage = SecureStorageStub()
         crypter = CryptingMock()
@@ -50,11 +52,18 @@ class SyncQueueTests: XCTestCase {
             )
         )
 
-        requestMaker = SyncRequestMaker(storage: storage, api: apiMock, endpoints: endpoints)
+        requestMaker = SyncRequestMaker(storage: storage, api: apiMock, endpoints: endpoints, payloadCompressor: payloadCompressor)
     }
 
     func testWhenDataSyncingFeatureFlagIsDisabledThenNewOperationsAreNotEnqueued() async {
-        let syncQueue = SyncQueue(dataProviders: [], storage: storage, crypter: crypter, api: apiMock, endpoints: endpoints)
+        let syncQueue = SyncQueue(
+            dataProviders: [],
+            storage: storage,
+            crypter: crypter,
+            api: apiMock,
+            endpoints: endpoints,
+            payloadCompressor: payloadCompressor
+        )
         XCTAssertFalse(syncQueue.operationQueue.isSuspended)
 
         var syncDidStartEvents = [Bool]()
@@ -81,7 +90,14 @@ class SyncQueueTests: XCTestCase {
     func testThatInProgressPublisherEmitsValuesWhenSyncStartsAndEndsWithSuccess() async throws {
         let feature = Feature(name: "bookmarks")
         let dataProvider = DataProvidingMock(feature: feature)
-        let syncQueue = SyncQueue(dataProviders: [dataProvider], storage: storage, crypter: crypter, api: apiMock, endpoints: endpoints)
+        let syncQueue = SyncQueue(
+            dataProviders: [dataProvider],
+            storage: storage,
+            crypter: crypter,
+            api: apiMock,
+            endpoints: endpoints,
+            payloadCompressor: payloadCompressor
+        )
 
         var isInProgressEvents = [Bool]()
 
@@ -99,7 +115,14 @@ class SyncQueueTests: XCTestCase {
     func testThatInProgressPublisherEmitsValuesWhenSyncStartsAndEndsWithError() async throws {
         let feature = Feature(name: "bookmarks")
         let dataProvider = DataProvidingMock(feature: feature)
-        let syncQueue = SyncQueue(dataProviders: [dataProvider], storage: storage, crypter: crypter, api: apiMock, endpoints: endpoints)
+        let syncQueue = SyncQueue(
+            dataProviders: [dataProvider],
+            storage: storage,
+            crypter: crypter,
+            api: apiMock,
+            endpoints: endpoints,
+            payloadCompressor: payloadCompressor
+        )
 
         var isInProgressEvents = [Bool]()
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1206919211758354/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2805
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2723
What kind of version bump will this require?: Patch

**Description**:
This change adds gzip compression to all Sync data PATCH requests.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run both iOS and macOS apps from branches in linked PRs.
2. Connect devices with Sync and smoke test syncing data.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
