### PR TITLE
Enable field validation for Sync payloads

### DIFF
--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -23,13 +23,6 @@ import DDGSyncCrypto
 import Foundation
 
 public class DDGSync: DDGSyncing {
-    /**
-     * Temporary feature flag that controls field validation feature.
-     *
-     * The flag must be set to false at all times before field validation is released.
-     * Before field validations release, it should be removed.
-     */
-    public static let isFieldValidationEnabled = false
 
     public static let bundle = Bundle.module
 

--- a/Sources/DDGSync/SyncMetadataStore.swift
+++ b/Sources/DDGSync/SyncMetadataStore.swift
@@ -124,9 +124,6 @@ public final class LocalSyncMetadataStore: SyncMetadataStore {
     }
 
     public func updateLocalTimestamp(_ localTimestamp: Date?, forFeatureNamed name: String) {
-        guard DDGSync.isFieldValidationEnabled else {
-            return
-        }
         context.performAndWait {
             let feature = SyncFeatureUtils.fetchFeature(with: name, in: context)
             feature?.lastSyncLocalTimestamp = localTimestamp
@@ -138,9 +135,7 @@ public final class LocalSyncMetadataStore: SyncMetadataStore {
         context.performAndWait {
             let feature = SyncFeatureUtils.fetchFeature(with: name, in: context)
             feature?.lastModified = serverTimestamp
-            if DDGSync.isFieldValidationEnabled {
-                feature?.lastSyncLocalTimestamp = localTimestamp
-            }
+            feature?.lastSyncLocalTimestamp = localTimestamp
             feature?.featureState = state
 
             try? context.save()

--- a/Sources/SyncDataProviders/Bookmarks/internal/SyncableBookmarkAdapter.swift
+++ b/Sources/SyncDataProviders/Bookmarks/internal/SyncableBookmarkAdapter.swift
@@ -125,19 +125,15 @@ extension Syncable {
 
                 if let title = bookmark.title {
                     let encryptedTitle = try encrypt(title)
-                    if DDGSync.isFieldValidationEnabled {
-                        guard encryptedTitle.count <= BookmarkValidationConstraints.maxEncryptedBookmarkTitleLength else {
-                            throw SyncableBookmarkError.validationFailed
-                        }
+                    guard encryptedTitle.count <= BookmarkValidationConstraints.maxEncryptedBookmarkTitleLength else {
+                        throw SyncableBookmarkError.validationFailed
                     }
                     payload["title"] = encryptedTitle
                 }
                 if let url = bookmark.url {
                     let encryptedURL = try encrypt(url)
-                    if DDGSync.isFieldValidationEnabled {
-                        guard encryptedURL.count <= BookmarkValidationConstraints.maxEncryptedBookmarkURLLength else {
-                            throw SyncableBookmarkError.validationFailed
-                        }
+                    guard encryptedURL.count <= BookmarkValidationConstraints.maxEncryptedBookmarkURLLength else {
+                        throw SyncableBookmarkError.validationFailed
                     }
                     payload["page"] = ["url": encryptedURL]
                 }

--- a/Sources/SyncDataProviders/Credentials/internal/SyncableCredentialsAdapter.swift
+++ b/Sources/SyncDataProviders/Credentials/internal/SyncableCredentialsAdapter.swift
@@ -85,47 +85,37 @@ extension Syncable {
 
         if let title = credential.account.title {
             let encryptedTitle = try encrypt(title)
-            if DDGSync.isFieldValidationEnabled {
-                guard encryptedTitle.count <= CredentialValidationConstraints.maxEncryptedTitleLength else {
-                    throw SyncableCredentialError.validationFailed
-                }
+            guard encryptedTitle.count <= CredentialValidationConstraints.maxEncryptedTitleLength else {
+                throw SyncableCredentialError.validationFailed
             }
             payload["title"] = encryptedTitle
         }
         if let domain = credential.account.domain {
             let encryptedDomain = try encrypt(domain)
-            if DDGSync.isFieldValidationEnabled {
-                guard encryptedDomain.count <= CredentialValidationConstraints.maxEncryptedDomainLength else {
-                    throw SyncableCredentialError.validationFailed
-                }
+            guard encryptedDomain.count <= CredentialValidationConstraints.maxEncryptedDomainLength else {
+                throw SyncableCredentialError.validationFailed
             }
             payload["domain"] = encryptedDomain
         }
         if let username = credential.account.username {
             let encryptedUsername = try encrypt(username)
-            if DDGSync.isFieldValidationEnabled {
-                guard encryptedUsername.count <= CredentialValidationConstraints.maxEncryptedUsernameLength else {
-                    throw SyncableCredentialError.validationFailed
-                }
+            guard encryptedUsername.count <= CredentialValidationConstraints.maxEncryptedUsernameLength else {
+                throw SyncableCredentialError.validationFailed
             }
             payload["username"] = encryptedUsername
         }
         if let notes = credential.account.notes {
             let encryptedNotes = try encrypt(notes)
-            if DDGSync.isFieldValidationEnabled {
-                guard encryptedNotes.count <= CredentialValidationConstraints.maxEncryptedNotesLength else {
-                    throw SyncableCredentialError.validationFailed
-                }
+            guard encryptedNotes.count <= CredentialValidationConstraints.maxEncryptedNotesLength else {
+                throw SyncableCredentialError.validationFailed
             }
             payload["notes"] = encryptedNotes
         }
 
         if let passwordData = credential.password, let password = String(data: passwordData, encoding: .utf8) {
             let encryptedPassword = try encrypt(password)
-            if DDGSync.isFieldValidationEnabled {
-                guard encryptedPassword.count <= CredentialValidationConstraints.maxEncryptedPasswordLength else {
-                    throw SyncableCredentialError.validationFailed
-                }
+            guard encryptedPassword.count <= CredentialValidationConstraints.maxEncryptedPasswordLength else {
+                throw SyncableCredentialError.validationFailed
             }
             payload["password"] = encryptedPassword
         }

--- a/Sources/SyncDataProviders/Credentials/internal/SyncableCredentialsAdapter.swift
+++ b/Sources/SyncDataProviders/Credentials/internal/SyncableCredentialsAdapter.swift
@@ -71,7 +71,7 @@ extension Syncable {
         static let maxEncryptedNotesLength = 1000
     }
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    // swiftlint:disable:next cyclomatic_complexity
     init(syncableCredentials: SecureVaultModels.SyncableCredentials, encryptedUsing encrypt: (String) throws -> String) throws {
         var payload: [String: Any] = [:]
 

--- a/Tests/SyncDataProvidersTests/Bookmarks/BookmarksProviderTests.swift
+++ b/Tests/SyncDataProvidersTests/Bookmarks/BookmarksProviderTests.swift
@@ -29,9 +29,7 @@ internal class BookmarksProviderTests: BookmarksProviderTestsBase {
 
     func testThatLastSyncTimestampIsNilByDefault() {
         XCTAssertNil(provider.lastSyncTimestamp)
-        if DDGSync.isFieldValidationEnabled {
-            XCTAssertNil(provider.lastSyncLocalTimestamp)
-        }
+        XCTAssertNil(provider.lastSyncLocalTimestamp)
     }
 
     func testThatLastSyncTimestampIsPersisted() throws {
@@ -39,9 +37,7 @@ internal class BookmarksProviderTests: BookmarksProviderTestsBase {
         let date = Date()
         provider.updateSyncTimestamps(server: "12345", local: date)
         XCTAssertEqual(provider.lastSyncTimestamp, "12345")
-        if DDGSync.isFieldValidationEnabled {
-            XCTAssertEqual(provider.lastSyncLocalTimestamp, date)
-        }
+        XCTAssertEqual(provider.lastSyncLocalTimestamp, date)
     }
 
     func testThatPrepareForFirstSyncClearsLastSyncTimestampAndSetsModifiedAtForAllBookmarks() async throws {
@@ -146,9 +142,6 @@ internal class BookmarksProviderTests: BookmarksProviderTestsBase {
     }
 
     func testThatFetchChangedObjectsFiltersOutInvalidBookmarksAndTruncatesFolderTitles() async throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
         let context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
 
         let longTitle = String(repeating: "x", count: 10000)
@@ -262,10 +255,6 @@ internal class BookmarksProviderTests: BookmarksProviderTestsBase {
     }
 
     func testThatItemsThatFailedValidationRetainTheirTimestamps() async throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         let context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
         let longValue = String(repeating: "x", count: 10000)
         let timestamp = Date()

--- a/Tests/SyncDataProvidersTests/Bookmarks/SyncableBookmarkValidationTests.swift
+++ b/Tests/SyncDataProvidersTests/Bookmarks/SyncableBookmarkValidationTests.swift
@@ -60,27 +60,15 @@ final class SyncableBookmarkValidationTests: XCTestCase {
     }
 
     func testWhenBookmarkFieldsPassLengthValidationThenSyncableIsInitializedWithoutThrowingErrors() throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         XCTAssertNoThrow(try Syncable(bookmark: bookmark, encryptedUsing: { $0 }))
     }
 
     func testWhenBookmarkTitleIsTooLongThenSyncableInitializerThrowsError() throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         bookmark.title = String(repeating: "x", count: 10000)
         assertSyncableInitializerThrowsValidationError()
     }
 
     func testWhenBookmarkURLIsTooLongThenSyncableInitializerThrowsError() throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         bookmark.url = String(repeating: "x", count: 10000)
         assertSyncableInitializerThrowsValidationError()
     }

--- a/Tests/SyncDataProvidersTests/Credentials/CredentialsProviderTests.swift
+++ b/Tests/SyncDataProvidersTests/Credentials/CredentialsProviderTests.swift
@@ -28,9 +28,7 @@ final class CredentialsProviderTests: CredentialsProviderTestsBase {
 
     func testThatLastSyncTimestampIsNilByDefault() {
         XCTAssertNil(provider.lastSyncTimestamp)
-        if DDGSync.isFieldValidationEnabled {
-            XCTAssertNil(provider.lastSyncLocalTimestamp)
-        }
+        XCTAssertNil(provider.lastSyncLocalTimestamp)
     }
 
     func testThatLastSyncTimestampIsPersisted() throws {
@@ -38,9 +36,7 @@ final class CredentialsProviderTests: CredentialsProviderTestsBase {
         let date = Date()
         provider.updateSyncTimestamps(server: "12345", local: date)
         XCTAssertEqual(provider.lastSyncTimestamp, "12345")
-        if DDGSync.isFieldValidationEnabled {
-            XCTAssertEqual(provider.lastSyncLocalTimestamp, date)
-        }
+        XCTAssertEqual(provider.lastSyncLocalTimestamp, date)
     }
 
     func testThatPrepareForFirstSyncClearsLastSyncTimestampAndSetsModifiedAtForAllCredentials() throws {
@@ -82,10 +78,6 @@ final class CredentialsProviderTests: CredentialsProviderTestsBase {
     }
 
     func testThatFetchChangedObjectsFiltersOutInvalidCredentials() async throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         let longValue = String(repeating: "x", count: 10000)
 
         try secureVault.inDatabaseTransaction { database in
@@ -148,10 +140,6 @@ final class CredentialsProviderTests: CredentialsProviderTestsBase {
     }
 
     func testThatItemsThatFailedValidationRetainTheirTimestamps() async throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         let longValue = String(repeating: "x", count: 10000)
         let timestamp = Date().withMillisecondPrecision
 

--- a/Tests/SyncDataProvidersTests/Credentials/SyncableCredentialsValidationTests.swift
+++ b/Tests/SyncDataProvidersTests/Credentials/SyncableCredentialsValidationTests.swift
@@ -34,54 +34,30 @@ final class SyncableCredentialsValidationTests: XCTestCase {
     }
 
     func testWhenCredentialsFieldsPassLengthValidationThenSyncableIsInitializedWithoutThrowingErrors() throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         XCTAssertNoThrow(try Syncable(syncableCredentials: syncableCredentials, encryptedUsing: { $0 }))
     }
 
     func testWhenAccountTitleIsTooLongThenSyncableInitializerThrowsError() throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         syncableCredentials.account?.title = String(repeating: "x", count: 10000)
         assertSyncableInitializerThrowsValidationError()
     }
 
     func testWhenAccountUsernameIsTooLongThenSyncableInitializerThrowsError() throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         syncableCredentials.account?.username = String(repeating: "x", count: 10000)
         assertSyncableInitializerThrowsValidationError()
     }
 
     func testWhenAccountDomainIsTooLongThenSyncableInitializerThrowsError() throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         syncableCredentials.account?.domain = String(repeating: "x", count: 10000)
         assertSyncableInitializerThrowsValidationError()
     }
 
     func testWhenAccountNotesIsTooLongThenSyncableInitializerThrowsError() throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         syncableCredentials.account?.notes = String(repeating: "x", count: 10000)
         assertSyncableInitializerThrowsValidationError()
     }
 
     func testWhenPasswordIsTooLongThenSyncableInitializerThrowsError() throws {
-        guard DDGSync.isFieldValidationEnabled else {
-            throw XCTSkip("Field validation is disabled")
-        }
-
         syncableCredentials.credentials?.password = String(repeating: "x", count: 10000).data(using: .utf8)
         assertSyncableInitializerThrowsValidationError()
     }

--- a/Tests/SyncDataProvidersTests/Settings/SettingsProviderTests.swift
+++ b/Tests/SyncDataProvidersTests/Settings/SettingsProviderTests.swift
@@ -28,9 +28,7 @@ final class SettingsProviderTests: SettingsProviderTestsBase {
 
     func testThatLastSyncTimestampIsNilByDefault() {
         XCTAssertNil(provider.lastSyncTimestamp)
-        if DDGSync.isFieldValidationEnabled {
-            XCTAssertNil(provider.lastSyncLocalTimestamp)
-        }
+        XCTAssertNil(provider.lastSyncLocalTimestamp)
     }
 
     func testThatLastSyncTimestampIsPersisted() throws {
@@ -38,9 +36,7 @@ final class SettingsProviderTests: SettingsProviderTestsBase {
         let date = Date()
         provider.updateSyncTimestamps(server: "12345", local: date)
         XCTAssertEqual(provider.lastSyncTimestamp, "12345")
-        if DDGSync.isFieldValidationEnabled {
-            XCTAssertEqual(provider.lastSyncLocalTimestamp, date)
-        }
+        XCTAssertEqual(provider.lastSyncLocalTimestamp, date)
     }
 
     func testThatPrepareForFirstSyncClearsLastSyncTimestampAndSetsModifiedAtForAllSettings() throws {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1207196051122978/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2807
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2725
What kind of version bump will this require?: Major

**Description**:
This change enables local field validation mechanism for Sync payloads, implemented a while ago (https://github.com/duckduckgo/BrowserServicesKit/pull/735)
and kept behind a feature flag. The validation mechanism filters out syncable objects that would
fail validation on the backend before sending Sync patch request. Objects rejected from patch
payload are retried on every subsequent Sync request, until they're updated to pass validation or deleted.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Go through testing scenarios in [this Asana task](https://app.asana.com/0/72649045549333/1206754264327477/f). Have a look at [this comment](https://app.asana.com/0/0/1206754264327477/1206880070407408/f) for an exception for Scenario B.
1. Smoke test Sync overall


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
