### PR TITLE
Improve VPN underlying error detail

### DIFF
--- a/Sources/NetworkProtection/Networking/NetworkProtectionClient.swift
+++ b/Sources/NetworkProtection/Networking/NetworkProtectionClient.swift
@@ -79,6 +79,27 @@ public enum NetworkProtectionClientError: CustomNSError, NetworkProtectionErrorC
         case .accessDenied: return 13
         }
     }
+
+    public var errorUserInfo: [String: Any] {
+        switch self {
+        case .failedToFetchLocationList(let error),
+                .failedToParseLocationListResponse(let error),
+                .failedToFetchServerList(let error),
+                .failedToParseServerListResponse(let error),
+                .failedToFetchRegisteredServers(let error),
+                .failedToParseRegisteredServersResponse(let error),
+                .failedToRedeemInviteCode(let error),
+                .failedToParseRedeemResponse(let error):
+            return [NSUnderlyingErrorKey: error as NSError]
+        case .failedToEncodeRegisterKeyRequest,
+                .failedToEncodeRedeemRequest,
+                .invalidInviteCode,
+                .failedToRetrieveAuthToken,
+                .invalidAuthToken,
+                .accessDenied:
+            return [:]
+        }
+    }
 }
 
 struct RegisterKeyRequestBody: Encodable {

--- a/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
@@ -13,7 +13,7 @@ public enum WireGuardAdapterErrorInvalidStateReason: String {
     case updatedTunnelWhileStopped
 }
 
-public enum WireGuardAdapterError: Error {
+public enum WireGuardAdapterError: CustomNSError {
     /// Failure to locate tunnel file descriptor.
     case cannotLocateTunnelFileDescriptor
 
@@ -28,6 +28,35 @@ public enum WireGuardAdapterError: Error {
 
     /// Failure to start WireGuard backend.
     case startWireGuardBackend(Int32)
+
+    public var errorCode: Int {
+        switch self {
+        case .cannotLocateTunnelFileDescriptor: return 100
+        case .invalidState: return 101
+        case .dnsResolution: return 102
+        case .setNetworkSettings: return 103
+        case .startWireGuardBackend: return 104
+        }
+    }
+
+    public var errorUserInfo: [String: Any] {
+        switch self {
+        case .cannotLocateTunnelFileDescriptor,
+                .invalidState:
+            return [:]
+        case .dnsResolution(let errors):
+            guard let firstError = errors.first else {
+                return [:]
+            }
+
+            return [NSUnderlyingErrorKey: firstError as NSError]
+        case .setNetworkSettings(let error):
+            return [NSUnderlyingErrorKey: error as NSError]
+        case .startWireGuardBackend(let code):
+            let error = NSError(domain: "startWireGuardBackend", code: Int(code))
+            return [NSUnderlyingErrorKey: error as NSError]
+        }
+    }
 }
 
 /// Enum representing internal state of the `WireGuardAdapter`


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207221937455192/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2813
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2736
What kind of version bump will this require?: Major/Minor/Patch

## Description

Improves VPN underlying error detail for `NetworkProtectionClientError` and `WireGuardError`.

## Testing

1. Disable `dryMode` for the packet tunnel provider.
2. In `PacketTunnelProvider` right after the tunnel starts throw any `NetworkProtectionClientError` or `WireGuardError` with underlying error information.
3. Check in Kibana after a bit that you see the pixel data.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
