### PR TITLE
autofill: send current language in runtime config

### DIFF
--- a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -27,15 +27,28 @@ public final class ContentScopeProperties: Encodable {
     public let globalPrivacyControlValue: Bool
     public let debug: Bool = false
     public let sessionKey: String
+    public let languageCode: String
     public let platform = ContentScopePlatform()
     public let features: [String: ContentScopeFeature]
 
     public init(gpcEnabled: Bool, sessionKey: String, featureToggles: ContentScopeFeatureToggles) {
         self.globalPrivacyControlValue = gpcEnabled
         self.sessionKey = sessionKey
+        languageCode = Locale.current.languageCode ?? "en"
         features = [
             "autofill": ContentScopeFeature(featureToggles: featureToggles)
         ]
+    }
+
+    enum CodingKeys: String, CodingKey {
+        // Rename 'languageCode' to 'language' to conform to autofill.js's interface.
+        case languageCode = "language"
+
+        case globalPrivacyControlValue
+        case debug
+        case sessionKey
+        case platform
+        case features
     }
 }
 


### PR DESCRIPTION
ℹ️ This PR replaces #752. There's a small amount of extra context in that PR, based on my original diff ℹ️ 

<!-- Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426). -->

**Required**:

Task/Issue URL: https://app.asana.com/0/11984721910118/1206933877192910/f
iOS PR: N/A
macOS PR: N/A
What kind of version bump will this require?: Patch. This is backwards-compatible, and the autofill codebase falls back to 'en' when it doesn't receive a language.

**Optional**:

Tech Design URL: N/A
CC: @amddg44 @shakyShane 

**Description**:
The HTML autofill UI will be translated shortly, but doing so is only possible once that UI knows which language to use. Send the current locale's two-character language code as part of the privacy config (aka 'runtime config' in the autofill codebase).

This is a backwards-compatible change, since 'language' is currently an optional input to the autofill HTML pages.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Use autofill from https://github.com/duckduckgo/duckduckgo-autofill/pull/541 + https://github.com/duckduckgo/duckduckgo-autofill/pull/558
2. Use BSK from this PR
3. (Optional) Apply this patch to force a pseudolocale:
```diff
diff --git a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
index 87beab7e..7e1530ec 100644
--- a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -34,7 +34,7 @@ public final class ContentScopeProperties: Encodable {
     public init(gpcEnabled: Bool, sessionKey: String, featureToggles: ContentScopeFeatureToggles) {
         self.globalPrivacyControlValue = gpcEnabled
         self.sessionKey = sessionKey
-        languageCode = Locale.current.languageCode ?? "en"
+        languageCode = "xa"
         features = [
             "autofill": ContentScopeFeature(featureToggles: featureToggles)
         ]
``` 
4. Build and launch the macOS app
5. Load any webpage with a signup form (I typically use IMDB)
6. Click on Dax
7. Confirm translation of the "Block email trackers" text under your personal Duck address:
    1. If you didn't apply the pseudolocale patch, you should still see English (the default in Autofill):
    ![image](https://github.com/duckduckgo/BrowserServicesKit/assets/665775/cc03d9e2-b547-454b-a88b-cf0d9476e419)
    2. If you _did_ apply the pseudolocale patch, you should see text that almost looks like English if you squint, but also has some repeated l33tspeak-style symbols:
    ![image](https://github.com/duckduckgo/BrowserServicesKit/assets/665775/0b4c30b7-6cda-4c9f-bf37-56b9f3ed52fc)


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14 — No changes, if I understand correctly.
* [ ] iOS 15 — No changes, if I understand correctly.
* [ ] iOS 16 — No changes, if I understand correctly.
* [ ] macOS 10.15 — I don't have 10.15 available
* [ ] macOS 11 — I don't have 11 available
* [ ] macOS 12 — Looking into it
* [x] macOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206933877192910