### PR TITLE
Add support for `targetPercentile` RMF rule parameter

### DIFF
--- a/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -197,21 +197,29 @@ struct JsonToRemoteMessageModelMapper {
         }
     }
 
-    static func maps(jsonRemoteRules: [RemoteMessageResponse.JsonMatchingRule]) -> [Int: [MatchingAttribute]] {
-        var rules: [Int: [MatchingAttribute]] = [:]
-        jsonRemoteRules.forEach { rule in
-            var matchingAttributes: [MatchingAttribute] = []
-            rule.attributes.forEach { attribute in
+    static func maps(jsonRemoteRules: [RemoteMessageResponse.JsonMatchingRule]) -> [RemoteConfigRule] {
+        return jsonRemoteRules.map { jsonRule in
+            let mappedAttributes = jsonRule.attributes.map { attribute in
                 if let key = AttributesKey(rawValue: attribute.key) {
-                    matchingAttributes.append(key.matchingAttribute(jsonMatchingAttribute: attribute.value))
+                    return key.matchingAttribute(jsonMatchingAttribute: attribute.value)
                 } else {
                     os_log("Unknown attribute key %s", log: .remoteMessaging, type: .debug, attribute.key)
-                    matchingAttributes.append(UnknownMatchingAttribute(jsonMatchingAttribute: attribute.value))
+                    return UnknownMatchingAttribute(jsonMatchingAttribute: attribute.value)
                 }
             }
-            rules[rule.id] = matchingAttributes
+
+            var mappedTargetPercentile: RemoteConfigTargetPercentile?
+
+            if let jsonTargetPercentile = jsonRule.targetPercentile {
+                mappedTargetPercentile = .init(before: jsonTargetPercentile.before)
+            }
+
+            return RemoteConfigRule(
+                id: jsonRule.id,
+                targetPercentile: mappedTargetPercentile,
+                attributes: mappedAttributes
+            )
         }
-        return rules
     }
 
     static func getTranslation(from translations: [String: RemoteMessageResponse.JsonContentTranslation]?,

--- a/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
+++ b/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
@@ -64,8 +64,13 @@ public enum RemoteMessageResponse {
         let secondaryActionText: String?
     }
 
+    struct JsonTargetPercentile: Decodable {
+        let before: Float?
+    }
+
     struct JsonMatchingRule: Decodable {
         let id: Int
+        let targetPercentile: JsonTargetPercentile?
         let attributes: [String: AnyDecodable]
     }
 

--- a/Sources/RemoteMessaging/Model/RemoteConfigModel.swift
+++ b/Sources/RemoteMessaging/Model/RemoteConfigModel.swift
@@ -20,5 +20,15 @@ import Foundation
 
 public struct RemoteConfigModel {
     let messages: [RemoteMessageModel]
-    let rules: [Int: [MatchingAttribute]]
+    let rules: [RemoteConfigRule]
+}
+
+public struct RemoteConfigRule {
+    let id: Int
+    let targetPercentile: RemoteConfigTargetPercentile?
+    let attributes: [MatchingAttribute]
+}
+
+public struct RemoteConfigTargetPercentile {
+    let before: Float?
 }

--- a/Sources/RemoteMessaging/RemoteMessagingConfigMatcher.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingConfigMatcher.swift
@@ -60,16 +60,16 @@ public struct RemoteMessagingConfigMatcher {
         return nil
     }
 
-    func evaluateMatchingRules(_ matchingRules: [Int], fromRules rules: [Int: [MatchingAttribute]]) -> EvaluationResult {
+    func evaluateMatchingRules(_ matchingRules: [Int], fromRules rules: [RemoteConfigRule]) -> EvaluationResult {
         var result: EvaluationResult = .match
 
         for rule in matchingRules {
-            guard let matchingAttributes = rules[rule] else {
+            guard let matchingRule = rules.first(where: { $0.id == rule }) else {
                 return .nextMessage
             }
             result = .match
 
-            for attribute in matchingAttributes {
+            for attribute in matchingRule.attributes {
                 result = evaluateAttribute(matchingAttribute: attribute)
                 if result == .fail || result == .nextMessage {
                     os_log("First failing matching attribute %s", log: .remoteMessaging, type: .debug, String(describing: attribute))
@@ -84,16 +84,16 @@ public struct RemoteMessagingConfigMatcher {
         return result
     }
 
-    func evaluateExclusionRules(_ exclusionRules: [Int], fromRules rules: [Int: [MatchingAttribute]]) -> EvaluationResult {
+    func evaluateExclusionRules(_ exclusionRules: [Int], fromRules rules: [RemoteConfigRule]) -> EvaluationResult {
         var result: EvaluationResult = .fail
 
         for rule in exclusionRules {
-            guard let attributes = rules[rule] else {
+            guard let matchingRule = rules.first(where: { $0.id == rule }) else {
                 return .nextMessage
             }
             result = .fail
 
-            for attribute in attributes {
+            for attribute in matchingRule.attributes {
                 result = evaluateAttribute(matchingAttribute: attribute)
                 if result == .fail || result == .nextMessage {
                     os_log("First failing exclusion attribute %s", log: .remoteMessaging, type: .debug, String(describing: attribute))

--- a/Sources/RemoteMessaging/RemoteMessagingPercentileStoring.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingPercentileStoring.swift
@@ -24,14 +24,28 @@ public protocol RemoteMessagingPercentileStoring {
 
 public class RemoteMessagingPercentileUserDefaultsStore: RemoteMessagingPercentileStoring {
 
+    enum Constants {
+        static let remoteMessagingPercentileMapping = "com.duckduckgo.app.remoteMessagingPercentileMapping"
+    }
+
     private let userDefaults: UserDefaults
 
     init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
     }
 
-    public func percentile(forMessageId: String) -> Float {
-        return 0.95
+    public func percentile(forMessageId messageID: String) -> Float {
+        var percentileMapping = (userDefaults.dictionary(forKey: Constants.remoteMessagingPercentileMapping) as? [String: Float]) ?? [:]
+
+        if let percentile = percentileMapping[messageID] {
+            return percentile
+        } else {
+            let newPercentile = Float.random(in: 0...1)
+            percentileMapping[messageID] = newPercentile
+            userDefaults.set(percentileMapping, forKey: Constants.remoteMessagingPercentileMapping)
+
+            return newPercentile
+        }
     }
 
 }

--- a/Sources/RemoteMessaging/RemoteMessagingPercentileStoring.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingPercentileStoring.swift
@@ -1,0 +1,37 @@
+//
+//  RemoteMessagingPercentileStoring.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public protocol RemoteMessagingPercentileStoring {
+    func percentile(forMessageId: String) -> Float
+}
+
+public class RemoteMessagingPercentileUserDefaultsStore: RemoteMessagingPercentileStoring {
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+    }
+
+    public func percentile(forMessageId: String) -> Float {
+        return 0.95
+    }
+
+}

--- a/Sources/RemoteMessaging/RemoteMessagingPercentileStoring.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingPercentileStoring.swift
@@ -30,7 +30,7 @@ public class RemoteMessagingPercentileUserDefaultsStore: RemoteMessagingPercenti
 
     private let userDefaults: UserDefaults
 
-    init(userDefaults: UserDefaults) {
+    public init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
     }
 

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapperTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapperTests.swift
@@ -104,41 +104,41 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
         let config = try decodeAndMapJson(fileName: "Resources/remote-messaging-config.json")
         XCTAssertTrue(config.rules.count == 5)
 
-        let rule5 = config.rules.filter { $0.key == 5 }.first
+        let rule5 = config.rules.filter { $0.id == 5 }.first
         XCTAssertNotNil(rule5)
-        XCTAssertTrue(rule5?.value.count == 16)
-        var attribs = rule5?.value.filter { $0 is LocaleMatchingAttribute }
+        XCTAssertTrue(rule5?.attributes.count == 16)
+        var attribs = rule5?.attributes.filter { $0 is LocaleMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
         XCTAssertEqual(attribs?.first as? LocaleMatchingAttribute, LocaleMatchingAttribute(value: ["en-US", "en-GB"], fallback: true))
 
-        let rule6 = config.rules.filter { $0.key == 6 }.first
+        let rule6 = config.rules.filter { $0.id == 6 }.first
         XCTAssertNotNil(rule6)
-        XCTAssertTrue(rule6?.value.count == 1)
-        attribs = rule6?.value.filter { $0 is LocaleMatchingAttribute }
+        XCTAssertTrue(rule6?.attributes.count == 1)
+        attribs = rule6?.attributes.filter { $0 is LocaleMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
         XCTAssertEqual(attribs?.first as? LocaleMatchingAttribute, LocaleMatchingAttribute(value: ["en-GB"], fallback: nil))
 
-        let rule7 = config.rules.filter { $0.key == 7 }.first
+        let rule7 = config.rules.filter { $0.id == 7 }.first
         XCTAssertNotNil(rule7)
-        XCTAssertTrue(rule7?.value.count == 1)
-        attribs = rule7?.value.filter { $0 is WidgetAddedMatchingAttribute }
+        XCTAssertTrue(rule7?.attributes.count == 1)
+        attribs = rule7?.attributes.filter { $0 is WidgetAddedMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
         XCTAssertEqual(attribs?.first as? WidgetAddedMatchingAttribute, WidgetAddedMatchingAttribute(value: false, fallback: nil))
 
-        let rule8 = config.rules.filter { $0.key == 8 }.first
+        let rule8 = config.rules.filter { $0.id == 8 }.first
         XCTAssertNotNil(rule8)
-        XCTAssertTrue(rule8?.value.count == 2)
-        attribs = rule8?.value.filter { $0 is DaysSinceNetPEnabledMatchingAttribute }
+        XCTAssertTrue(rule8?.attributes.count == 2)
+        attribs = rule8?.attributes.filter { $0 is DaysSinceNetPEnabledMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
         XCTAssertEqual(attribs?.first as? DaysSinceNetPEnabledMatchingAttribute, DaysSinceNetPEnabledMatchingAttribute(min: 5, fallback: nil))
 
-        attribs = rule8?.value.filter { $0 is IsNetPWaitlistUserMatchingAttribute }
+        attribs = rule8?.attributes.filter { $0 is IsNetPWaitlistUserMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
         XCTAssertEqual(attribs?.first as? IsNetPWaitlistUserMatchingAttribute, IsNetPWaitlistUserMatchingAttribute(value: true, fallback: nil))
 
-        let rule9 = config.rules.filter { $0.key == 8 }.first
+        let rule9 = config.rules.filter { $0.id == 8 }.first
         XCTAssertNotNil(rule9)
-        XCTAssertTrue(rule9?.value.count == 2)
+        XCTAssertTrue(rule9?.attributes.count == 2)
     }
 
     func testWhenJsonMessagesHaveUnknownTypesThenMessagesNotMappedIntoConfig() throws {
@@ -151,15 +151,15 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
         let config = try decodeAndMapJson(fileName: "Resources/remote-messaging-config-unsupported-items.json")
         XCTAssertTrue(config.rules.count == 2)
 
-        let rule6 = config.rules.filter { $0.key == 6 }.first
+        let rule6 = config.rules.filter { $0.id == 6 }.first
         XCTAssertNotNil(rule6)
-        var attribs = rule6?.value.filter { $0 is UnknownMatchingAttribute }
+        var attribs = rule6?.attributes.filter { $0 is UnknownMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
         XCTAssertEqual(attribs?.first as? UnknownMatchingAttribute, UnknownMatchingAttribute(fallback: true))
 
-        let rule7 = config.rules.filter { $0.key == 7 }.first
+        let rule7 = config.rules.filter { $0.id == 7 }.first
         XCTAssertNotNil(rule7)
-        attribs = rule7?.value.filter { $0 is WidgetAddedMatchingAttribute }
+        attribs = rule7?.attributes.filter { $0 is WidgetAddedMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
         XCTAssertEqual(attribs?.first as? WidgetAddedMatchingAttribute, WidgetAddedMatchingAttribute(value: true, fallback: nil))
     }
@@ -171,11 +171,11 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
         let config = JsonToRemoteConfigModelMapper.mapJson(remoteMessagingConfig: remoteMessagingConfig)
         XCTAssertTrue(config.rules.count == 2)
 
-        let rule6 = config.rules.filter { $0.key == 6 }.first
+        let rule6 = config.rules.filter { $0.id == 6 }.first
         XCTAssertNotNil(rule6)
-        XCTAssertEqual(rule6?.value.filter { $0 is LocaleMatchingAttribute }.count, 1)
-        XCTAssertEqual(rule6?.value.filter { $0 is OSMatchingAttribute }.count, 1)
-        XCTAssertEqual(rule6?.value.filter { $0 is UnknownMatchingAttribute }.count, 1)
+        XCTAssertEqual(rule6?.attributes.filter { $0 is LocaleMatchingAttribute }.count, 1)
+        XCTAssertEqual(rule6?.attributes.filter { $0 is OSMatchingAttribute }.count, 1)
+        XCTAssertEqual(rule6?.attributes.filter { $0 is UnknownMatchingAttribute }.count, 1)
     }
 
     func decodeAndMapJson(fileName: String) throws -> RemoteConfigModel {

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapperTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapperTests.swift
@@ -102,7 +102,7 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
 
     func testWhenValidJsonParsedThenRulesMappedIntoRemoteConfig() throws {
         let config = try decodeAndMapJson(fileName: "Resources/remote-messaging-config.json")
-        XCTAssertTrue(config.rules.count == 4)
+        XCTAssertTrue(config.rules.count == 5)
 
         let rule5 = config.rules.filter { $0.key == 5 }.first
         XCTAssertNotNil(rule5)
@@ -135,6 +135,10 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
         attribs = rule8?.value.filter { $0 is IsNetPWaitlistUserMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
         XCTAssertEqual(attribs?.first as? IsNetPWaitlistUserMatchingAttribute, IsNetPWaitlistUserMatchingAttribute(value: true, fallback: nil))
+
+        let rule9 = config.rules.filter { $0.key == 8 }.first
+        XCTAssertNotNil(rule9)
+        XCTAssertTrue(rule9?.value.count == 2)
     }
 
     func testWhenJsonMessagesHaveUnknownTypesThenMessagesNotMappedIntoConfig() throws {

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapperTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapperTests.swift
@@ -106,6 +106,7 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
 
         let rule5 = config.rules.filter { $0.id == 5 }.first
         XCTAssertNotNil(rule5)
+        XCTAssertNil(rule5?.targetPercentile)
         XCTAssertTrue(rule5?.attributes.count == 16)
         var attribs = rule5?.attributes.filter { $0 is LocaleMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
@@ -113,6 +114,7 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
 
         let rule6 = config.rules.filter { $0.id == 6 }.first
         XCTAssertNotNil(rule6)
+        XCTAssertNil(rule6?.targetPercentile)
         XCTAssertTrue(rule6?.attributes.count == 1)
         attribs = rule6?.attributes.filter { $0 is LocaleMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
@@ -120,6 +122,7 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
 
         let rule7 = config.rules.filter { $0.id == 7 }.first
         XCTAssertNotNil(rule7)
+        XCTAssertNil(rule7?.targetPercentile)
         XCTAssertTrue(rule7?.attributes.count == 1)
         attribs = rule7?.attributes.filter { $0 is WidgetAddedMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
@@ -127,6 +130,7 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
 
         let rule8 = config.rules.filter { $0.id == 8 }.first
         XCTAssertNotNil(rule8)
+        XCTAssertNil(rule8?.targetPercentile)
         XCTAssertTrue(rule8?.attributes.count == 2)
         attribs = rule8?.attributes.filter { $0 is DaysSinceNetPEnabledMatchingAttribute }
         XCTAssertEqual(attribs?.count, 1)
@@ -136,9 +140,11 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
         XCTAssertEqual(attribs?.count, 1)
         XCTAssertEqual(attribs?.first as? IsNetPWaitlistUserMatchingAttribute, IsNetPWaitlistUserMatchingAttribute(value: true, fallback: nil))
 
-        let rule9 = config.rules.filter { $0.id == 8 }.first
+        let rule9 = config.rules.filter { $0.id == 9 }.first
         XCTAssertNotNil(rule9)
-        XCTAssertTrue(rule9?.attributes.count == 2)
+        XCTAssertNotNil(rule9?.targetPercentile)
+        XCTAssertTrue(rule9?.attributes.count == 1)
+        XCTAssertEqual(rule9?.targetPercentile?.before, 0.9)
     }
 
     func testWhenJsonMessagesHaveUnknownTypesThenMessagesNotMappedIntoConfig() throws {

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Mocks/MockRemoteMessagePercentileStore.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Mocks/MockRemoteMessagePercentileStore.swift
@@ -1,6 +1,5 @@
 //
 //  MockRemoteMessagePercentileStore.swift
-//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Mocks/MockRemoteMessagePercentileStore.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Mocks/MockRemoteMessagePercentileStore.swift
@@ -1,0 +1,37 @@
+//
+//  MockRemoteMessagePercentileStore.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import RemoteMessaging
+
+class MockRemoteMessagePercentileStore: RemoteMessagingPercentileStoring {
+
+    var percentileStorage: [String: Float] = [:]
+    var defaultPercentage: Float = 0
+
+    func percentile(forMessageId messageID: String) -> Float {
+        if let percentile = percentileStorage[messageID] {
+            return percentile
+        }
+
+        percentileStorage[messageID] = defaultPercentage
+        return defaultPercentage
+    }
+
+}

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingConfigMatcherTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingConfigMatcherTests.swift
@@ -45,6 +45,7 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                                                            isWidgetInstalled: false,
                                                            isNetPWaitlistUser: false,
                                                            daysSinceNetPEnabled: -1),
+                percentileStore: MockRemoteMessagePercentileStore(),
                 dismissedMessageIds: []
         )
     }
@@ -128,6 +129,7 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                                                            isWidgetInstalled: false,
                                                            isNetPWaitlistUser: false,
                                                            daysSinceNetPEnabled: -1),
+                percentileStore: MockRemoteMessagePercentileStore(),
                 dismissedMessageIds: [])
 
         let remoteConfig = RemoteConfigModel(messages: [
@@ -221,6 +223,7 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                                                            isWidgetInstalled: false,
                                                            isNetPWaitlistUser: false,
                                                            daysSinceNetPEnabled: -1),
+                percentileStore: MockRemoteMessagePercentileStore(),
                 dismissedMessageIds: ["1"])
 
         let remoteConfig = RemoteConfigModel(messages: [
@@ -257,6 +260,7 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                                                            isWidgetInstalled: false,
                                                            isNetPWaitlistUser: false,
                                                            daysSinceNetPEnabled: -1),
+                percentileStore: MockRemoteMessagePercentileStore(),
                 dismissedMessageIds: [])
 
         let remoteConfig = RemoteConfigModel(messages: [

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingConfigMatcherTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingConfigMatcherTests.swift
@@ -278,6 +278,130 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
         XCTAssertNil(matcher.evaluate(remoteConfig: remoteConfig))
     }
 
+    func testWhenDeviceMatchesMessageRules_AndIsPartOfPercentile_ThenReturnMatch() {
+        let percentileStore = MockRemoteMessagePercentileStore()
+        percentileStore.defaultPercentage = 0.1
+
+        matcher = RemoteMessagingConfigMatcher(
+                appAttributeMatcher: AppAttributeMatcher(statisticsStore: MockStatisticsStore(), variantManager: MockVariantManager()),
+                deviceAttributeMatcher: DeviceAttributeMatcher(osVersion: AppVersion.shared.osVersion, locale: "en-US"),
+                userAttributeMatcher: UserAttributeMatcher(statisticsStore: MockStatisticsStore(),
+                                                           variantManager: MockVariantManager(),
+                                                           bookmarksCount: 0,
+                                                           favoritesCount: 0,
+                                                           appTheme: "light",
+                                                           isWidgetInstalled: false,
+                                                           isNetPWaitlistUser: false,
+                                                           daysSinceNetPEnabled: -1),
+                percentileStore: percentileStore,
+                dismissedMessageIds: [])
+
+        let remoteConfig = RemoteConfigModel(messages: [
+            mediumMessage(matchingRules: [1], exclusionRules: [])
+        ], rules: [
+            RemoteConfigRule(
+                id: 1,
+                targetPercentile: RemoteConfigTargetPercentile(before: 0.3),
+                attributes: [OSMatchingAttribute(value: AppVersion.shared.osVersion, fallback: nil)]
+            )
+        ])
+
+        XCTAssertEqual(matcher.evaluate(remoteConfig: remoteConfig), mediumMessage(matchingRules: [1], exclusionRules: []))
+    }
+
+    func testWhenDeviceMatchesMessageRules_AndIsNotPartOfPercentile_ThenReturnNull() {
+        let percentileStore = MockRemoteMessagePercentileStore()
+        percentileStore.defaultPercentage = 0.5
+
+        matcher = RemoteMessagingConfigMatcher(
+                appAttributeMatcher: AppAttributeMatcher(statisticsStore: MockStatisticsStore(), variantManager: MockVariantManager()),
+                deviceAttributeMatcher: DeviceAttributeMatcher(osVersion: AppVersion.shared.osVersion, locale: "en-US"),
+                userAttributeMatcher: UserAttributeMatcher(statisticsStore: MockStatisticsStore(),
+                                                           variantManager: MockVariantManager(),
+                                                           bookmarksCount: 0,
+                                                           favoritesCount: 0,
+                                                           appTheme: "light",
+                                                           isWidgetInstalled: false,
+                                                           isNetPWaitlistUser: false,
+                                                           daysSinceNetPEnabled: -1),
+                percentileStore: percentileStore,
+                dismissedMessageIds: [])
+
+        let remoteConfig = RemoteConfigModel(messages: [
+            mediumMessage(matchingRules: [1], exclusionRules: [])
+        ], rules: [
+            RemoteConfigRule(
+                id: 1,
+                targetPercentile: RemoteConfigTargetPercentile(before: 0.3),
+                attributes: [OSMatchingAttribute(value: AppVersion.shared.osVersion, fallback: nil)]
+            )
+        ])
+
+        XCTAssertNil(matcher.evaluate(remoteConfig: remoteConfig))
+    }
+
+    func testWhenDeviceExcludesMessageRules_AndIsPartOfPercentile_ThenReturnNull() {
+        let percentileStore = MockRemoteMessagePercentileStore()
+        percentileStore.defaultPercentage = 0.3
+
+        matcher = RemoteMessagingConfigMatcher(
+                appAttributeMatcher: AppAttributeMatcher(statisticsStore: MockStatisticsStore(), variantManager: MockVariantManager()),
+                deviceAttributeMatcher: DeviceAttributeMatcher(osVersion: AppVersion.shared.osVersion, locale: "en-US"),
+                userAttributeMatcher: UserAttributeMatcher(statisticsStore: MockStatisticsStore(),
+                                                           variantManager: MockVariantManager(),
+                                                           bookmarksCount: 0,
+                                                           favoritesCount: 0,
+                                                           appTheme: "light",
+                                                           isWidgetInstalled: false,
+                                                           isNetPWaitlistUser: false,
+                                                           daysSinceNetPEnabled: -1),
+                percentileStore: percentileStore,
+                dismissedMessageIds: [])
+
+        let remoteConfig = RemoteConfigModel(messages: [
+            mediumMessage(matchingRules: [], exclusionRules: [1])
+        ], rules: [
+            RemoteConfigRule(
+                id: 1,
+                targetPercentile: RemoteConfigTargetPercentile(before: 0.5),
+                attributes: [OSMatchingAttribute(value: AppVersion.shared.osVersion, fallback: nil)]
+            )
+        ])
+
+        XCTAssertNil(matcher.evaluate(remoteConfig: remoteConfig))
+    }
+
+    func testWhenDeviceExcludesMessageRules_AndIsNotPartOfPercentile_ThenReturnMatch() {
+        let percentileStore = MockRemoteMessagePercentileStore()
+        percentileStore.defaultPercentage = 0.6
+
+        matcher = RemoteMessagingConfigMatcher(
+                appAttributeMatcher: AppAttributeMatcher(statisticsStore: MockStatisticsStore(), variantManager: MockVariantManager()),
+                deviceAttributeMatcher: DeviceAttributeMatcher(osVersion: AppVersion.shared.osVersion, locale: "en-US"),
+                userAttributeMatcher: UserAttributeMatcher(statisticsStore: MockStatisticsStore(),
+                                                           variantManager: MockVariantManager(),
+                                                           bookmarksCount: 0,
+                                                           favoritesCount: 0,
+                                                           appTheme: "light",
+                                                           isWidgetInstalled: false,
+                                                           isNetPWaitlistUser: false,
+                                                           daysSinceNetPEnabled: -1),
+                percentileStore: percentileStore,
+                dismissedMessageIds: [])
+
+        let remoteConfig = RemoteConfigModel(messages: [
+            mediumMessage(matchingRules: [], exclusionRules: [1])
+        ], rules: [
+            RemoteConfigRule(
+                id: 1,
+                targetPercentile: RemoteConfigTargetPercentile(before: 0.5),
+                attributes: [OSMatchingAttribute(value: AppVersion.shared.osVersion, fallback: nil)]
+            )
+        ])
+
+        XCTAssertEqual(matcher.evaluate(remoteConfig: remoteConfig), mediumMessage(matchingRules: [], exclusionRules: [1]))
+    }
+
     func testWhenUnknownRuleFailsThenReturnNull() {
         let remoteConfig = RemoteConfigModel(messages: [
             mediumMessage(matchingRules: [1], exclusionRules: []),

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingConfigProcessorTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingConfigProcessorTests.swift
@@ -38,6 +38,7 @@ class RemoteMessagingConfigProcessorTests: XCTestCase {
                                                        isWidgetInstalled: false,
                                                        isNetPWaitlistUser: false,
                                                        daysSinceNetPEnabled: -1),
+            percentileStore: MockRemoteMessagePercentileStore(),
             dismissedMessageIds: []
         )
 
@@ -66,6 +67,7 @@ class RemoteMessagingConfigProcessorTests: XCTestCase {
                                                            isWidgetInstalled: false,
                                                            isNetPWaitlistUser: false,
                                                            daysSinceNetPEnabled: -1),
+                percentileStore: MockRemoteMessagePercentileStore(),
                 dismissedMessageIds: [])
 
         let processor = RemoteMessagingConfigProcessor(remoteMessagingConfigMatcher: remoteMessagingConfigMatcher)

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingPercentileUserDefaultsStoreTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingPercentileUserDefaultsStoreTests.swift
@@ -51,9 +51,9 @@ class RemoteMessagingPercentileUserDefaultsStoreTests: XCTestCase {
 
     func testWhenFetchingPercentileForMultipleMessages_ThenEachMessageHasIndependentPercentile() {
         let store = RemoteMessagingPercentileUserDefaultsStore(userDefaults: userDefaults)
-        let percentile1 = store.percentile(forMessageId: "message-1")
-        let percentile2 = store.percentile(forMessageId: "message-2")
-        let percentile3 = store.percentile(forMessageId: "message-3")
+        _ = store.percentile(forMessageId: "message-1")
+        _ = store.percentile(forMessageId: "message-2")
+        _ = store.percentile(forMessageId: "message-3")
 
         let percentileDictionary = userDefaults.dictionary(
             forKey: RemoteMessagingPercentileUserDefaultsStore.Constants.remoteMessagingPercentileMapping

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingPercentileUserDefaultsStoreTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingPercentileUserDefaultsStoreTests.swift
@@ -1,0 +1,65 @@
+//
+//  RemoteMessagingPercentileUserDefaultsStoreTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import BrowserServicesKit
+@testable import RemoteMessaging
+
+class RemoteMessagingPercentileUserDefaultsStoreTests: XCTestCase {
+
+    private var userDefaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        userDefaults = UserDefaults(suiteName: #file)
+        userDefaults.removePersistentDomain(forName: #file)
+    }
+
+    func testWhenFetchingPercentileForFirstTime_ThenPercentileIsCreatedAndStored() {
+        let store = RemoteMessagingPercentileUserDefaultsStore(userDefaults: userDefaults)
+        let percentile = store.percentile(forMessageId: "message-1")
+
+        XCTAssert(percentile >= 0.0)
+        XCTAssert(percentile <= 1.0)
+    }
+
+    func testWhenFetchingPercentileMultipleTimes_ThenAllPercentileFetchesReturnSameValue() {
+        let store = RemoteMessagingPercentileUserDefaultsStore(userDefaults: userDefaults)
+        let percentile1 = store.percentile(forMessageId: "message-1")
+        let percentile2 = store.percentile(forMessageId: "message-1")
+        let percentile3 = store.percentile(forMessageId: "message-1")
+
+        XCTAssertEqual(percentile1, percentile2)
+        XCTAssertEqual(percentile2, percentile3)
+    }
+
+    func testWhenFetchingPercentileForMultipleMessages_ThenEachMessageHasIndependentPercentile() {
+        let store = RemoteMessagingPercentileUserDefaultsStore(userDefaults: userDefaults)
+        let percentile1 = store.percentile(forMessageId: "message-1")
+        let percentile2 = store.percentile(forMessageId: "message-2")
+        let percentile3 = store.percentile(forMessageId: "message-3")
+
+        let percentileDictionary = userDefaults.dictionary(
+            forKey: RemoteMessagingPercentileUserDefaultsStore.Constants.remoteMessagingPercentileMapping
+        )
+
+        XCTAssertEqual(percentileDictionary?.count, 3)
+    }
+
+}

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingPercentileUserDefaultsStoreTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/RemoteMessagingPercentileUserDefaultsStoreTests.swift
@@ -1,6 +1,5 @@
 //
 //  RemoteMessagingPercentileUserDefaultsStoreTests.swift
-//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //

--- a/Tests/BrowserServicesKitTests/Resources/remote-messaging-config.json
+++ b/Tests/BrowserServicesKitTests/Resources/remote-messaging-config.json
@@ -244,6 +244,18 @@
           "min": 5
         }
       }
-    }
+    },
+    {
+      "id": 9,
+      "targetPercentile": {
+        "before": 0.9
+      },
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 5,
+          "max": 8
+        },
+      }
+    },
   ]
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1207234800675204/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2824
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2772
What kind of version bump will this require?: Major

**Description**:

This PR adds support for the new `targetPercentile` option in RMF rules. This allows us to specify a percentage of users for whom the rule matches.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
