### PR TITLE
Add bookmarks to top hits suggestions on iOS

### DIFF
--- a/Sources/Suggestions/Suggestion.swift
+++ b/Sources/Suggestions/Suggestion.swift
@@ -70,10 +70,17 @@ extension Suggestion {
 
     init?(bookmark: Bookmark) {
         guard let urlObject = URL(string: bookmark.url) else { return nil }
+        #if os(macOS)
         self = .bookmark(title: bookmark.title,
                          url: urlObject,
                          isFavorite: bookmark.isFavorite,
                          allowedInTopHits: bookmark.isFavorite)
+        #else
+        self = .bookmark(title: bookmark.title,
+                         url: urlObject,
+                         isFavorite: bookmark.isFavorite,
+                         allowedInTopHits: true)
+        #endif
     }
 
     init(historyEntry: HistorySuggestion) {


### PR DESCRIPTION

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1207251449708624/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2835
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2754
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

Bookmarks are added to top hits on iOS, but the behaviour is unchanged on macOS.

**Steps to test this PR**:

***iOS***
1. On iOS launch the app (use the `md` variant by editing the scheme > run > check environment variable VARIANT is md and enabled
1. Add some bookmarks
2. Start typing in the address bar
3. The bookmarks should appear in the top hits section (ie at the top of the suggestions list)
1. Check that launching the app clean with no variant still works as expected. 

***macOS***
1. Launch the app and confirm that suggestions works as it did previously.  ie Bookmarks should not be in top hits unless they have been visited several times. 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
