### PR TITLE
fix WKBackForwardListItem deallocated from background thread

### DIFF
--- a/Sources/Navigation/NavigationAction.swift
+++ b/Sources/Navigation/NavigationAction.swift
@@ -300,14 +300,6 @@ extension NavigationPreferences: CustomDebugStringConvertible {
 
 extension HistoryItemIdentity: CustomDebugStringConvertible {
     public var debugDescription: String {
-        "\(object)".replacingOccurrences(of: "WKBackForwardListItem: ", with: "").dropping(suffix: ">")
-        + {
-            guard let backForwardListItem = object as? WKBackForwardListItem else { return "" }
-            var url = " " + backForwardListItem.url.absoluteString
-            if backForwardListItem.initialURL != backForwardListItem.url {
-                url += " (initial: \(backForwardListItem.initialURL.absoluteString))"
-            }
-            return url
-        }() + ">"
+        "<\(identifier) url: \(url?.absoluteString ?? "") title: \(title ?? "<nil>")>"
     }
 }

--- a/Sources/Navigation/NavigationType.swift
+++ b/Sources/Navigation/NavigationType.swift
@@ -166,25 +166,29 @@ public protocol WebViewNavigationAction {
     var isUserInitiated: Bool? { get }
 }
 
-public struct HistoryItemIdentity: Hashable {
-    let object: any AnyObject & Hashable
+public class HistoryItemIdentity: Hashable {
+    let identifier: ObjectIdentifier
+    let title: String?
+    let url: URL?
 
-    public init(_ object: any AnyObject & Hashable) {
-        self.object = object
+    public init(backForwardListItem: WKBackForwardListItem) {
+        self.identifier = ObjectIdentifier(backForwardListItem)
+        self.title = backForwardListItem.title
+        self.url = backForwardListItem.url
     }
 
     public static func == (lhs: HistoryItemIdentity, rhs: HistoryItemIdentity) -> Bool {
-        lhs.object === rhs.object
+        lhs.identifier == rhs.identifier
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(object)
+        hasher.combine(identifier)
     }
 }
 
 extension WKBackForwardListItem {
 
-    public var identity: HistoryItemIdentity { HistoryItemIdentity(self) }
+    public var identity: HistoryItemIdentity { HistoryItemIdentity(backForwardListItem: self) }
 
 }
 

--- a/Sources/Navigation/NavigationType.swift
+++ b/Sources/Navigation/NavigationType.swift
@@ -166,7 +166,7 @@ public protocol WebViewNavigationAction {
     var isUserInitiated: Bool? { get }
 }
 
-public class HistoryItemIdentity: Hashable {
+public struct HistoryItemIdentity: Hashable {
     let identifier: ObjectIdentifier
     let title: String?
     let url: URL?


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1207299387361575/f
iOS PR: not affected
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2769
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
- fixes WKBackForwardListItem being deallocated from background thread (`Navigation.NavigationAction.fromHistoryItemIdentity`)

**Steps to test this PR**:
1. Validate common sanity
2. Validate Navigation framework tests pass
