### PR TITLE
Properly encode broken site reports

### DIFF
--- a/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -69,7 +69,7 @@ public struct BrokenSiteReport {
         case navigation
     }
 
-    public static let allowedQueryReservedCharacters = CharacterSet(charactersIn: ",")
+    public static let allowedQueryReservedCharacters = CharacterSet.urlQueryParameterAllowed
 
     let siteUrl: URL
     let category: String
@@ -270,8 +270,7 @@ public struct BrokenSiteReport {
             return "\(error.code) - \(error.domain):\(error.localizedDescription)"
         }
         let jsonString = try? String(data: JSONSerialization.data(withJSONObject: errorDescriptions), encoding: .utf8)!
-        let encodedString = jsonString?.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed)
-        return encodedString ?? ""
+        return jsonString ?? ""
     }
 
 }


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203790657351911/1207052048359801/f
iOS PR: TBD
macOS PR: TBD