### PR TITLE
Fast egress server draining

### DIFF
--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionError.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionError.swift
@@ -35,6 +35,8 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
     case failedToParseServerListResponse(Error)
     case failedToFetchLocationList(Error)
     case failedToParseLocationListResponse(Error)
+    case failedToFetchServerStatus(Error)
+    case failedToParseServerStatusResponse(Error)
     case failedToEncodeRegisterKeyRequest
     case failedToFetchRegisteredServers(Error?)
     case failedToParseRegisteredServersResponse(Error)
@@ -94,6 +96,8 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
         case .failedToParseRedeemResponse: return 111
         case .invalidAuthToken: return 112
         case .serverListInconsistency: return 113
+        case .failedToFetchServerStatus: return 114
+        case .failedToParseServerStatusResponse: return 115
             // 200+ - Keychain errors
         case .failedToCastKeychainValueToData: return 300
         case .keychainReadError: return 201
@@ -156,7 +160,9 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
                 .failedToParseRegisteredServersResponse(let error),
                 .failedToParseRedeemResponse(let error),
                 .wireGuardSetNetworkSettings(let error),
-                .unhandledError(_, _, let error):
+                .unhandledError(_, _, let error),
+                .failedToFetchServerStatus(let error),
+                .failedToParseServerStatusResponse(let error):
             return [
                 NSUnderlyingErrorKey: error
             ]

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionServerStatusMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionServerStatusMonitor.swift
@@ -35,7 +35,7 @@ public actor NetworkProtectionServerStatusMonitor {
         }
     }
 
-    private static let monitoringInterval: TimeInterval = .seconds(30) // .minutes(5)
+    private static let monitoringInterval: TimeInterval = .minutes(5)
 
     private var task: Task<Never, Error>? {
         willSet {
@@ -55,7 +55,7 @@ public actor NetworkProtectionServerStatusMonitor {
     init(networkClient: NetworkProtectionClient, tokenStore: NetworkProtectionTokenStore) {
         self.networkClient = networkClient
         self.tokenStore = tokenStore
-        
+
         os_log("[+] %{public}@", log: .networkProtectionMemoryLog, type: .debug, String(describing: self))
     }
 

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionServerStatusMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionServerStatusMonitor.swift
@@ -68,7 +68,7 @@ public actor NetworkProtectionServerStatusMonitor {
     // MARK: - Start/Stop monitoring
 
     public func start(serverName: String, callback: @escaping (ServerStatusResult) async throws -> Void) {
-        os_log("⚫️ Starting server status monitor with server %{public}s", log: .networkProtectionServerStatusMonitorLog, serverName)
+        os_log("⚫️ Starting server status monitor for %{public}s", log: .networkProtectionServerStatusMonitorLog, serverName)
 
         task = Task.periodic(interval: Self.monitoringInterval) {
             let result = await self.checkServerStatus(for: serverName)
@@ -79,11 +79,16 @@ public actor NetworkProtectionServerStatusMonitor {
                     os_log("⚫️ Beginning server migration away from %{public}s", log: .networkProtectionServerStatusMonitorLog, serverName)
                     do {
                         try await callback(.serverMigrationRequested)
+                        os_log("⚫️ Completed server migration away from %{public}s", log: .networkProtectionServerStatusMonitorLog, serverName)
                     } catch {
+                        os_log("⚫️ Failed server migration away from %{public}s, error: %{public}s",
+                               log: .networkProtectionServerStatusMonitorLog,
+                               serverName,
+                               error.localizedDescription)
                         // TODO: Send migration failure pixel
                     }
                 } else {
-                    os_log("⚫️ Not migrating server away from %{public}s", log: .networkProtectionServerStatusMonitorLog, serverName)
+                    os_log("⚫️ No migration requested for %{public}s", log: .networkProtectionServerStatusMonitorLog, serverName)
                 }
             case .failure(let error):
                 os_log("⚫️ Error retrieving server status: %{public}@", log: .networkProtectionServerStatusMonitorLog, error.localizedDescription)

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionServerStatusMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionServerStatusMonitor.swift
@@ -89,7 +89,7 @@ public actor NetworkProtectionServerStatusMonitor {
     }
 
     public func stop() {
-        os_log("⚫️ Stopping server status monitor", log: .networkProtectionEntitlementMonitorLog)
+        os_log("⚫️ Stopping server status monitor", log: .networkProtectionServerStatusMonitorLog)
 
         task?.cancel()
         task = nil

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionServerStatusMonitor.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionServerStatusMonitor.swift
@@ -1,0 +1,102 @@
+//
+//  NetworkProtectionServerStatusMonitor.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Network
+import Common
+import Combine
+
+public actor NetworkProtectionServerStatusMonitor {
+
+    public enum ServerStatusResult {
+        case serverMigrationRequested
+        case error(Error)
+    }
+
+    private static let monitoringInterval: TimeInterval = .minutes(5)
+
+    private var task: Task<Never, Error>? {
+        willSet {
+            task?.cancel()
+        }
+    }
+
+    var isStarted: Bool {
+        task?.isCancelled == false
+    }
+
+    private let networkClient: NetworkProtectionClient
+    private let tokenStore: NetworkProtectionTokenStore
+
+    // MARK: - Init & deinit
+
+    init(networkClient: NetworkProtectionClient, tokenStore: NetworkProtectionTokenStore) {
+        self.networkClient = networkClient
+        self.tokenStore = tokenStore
+        
+        os_log("[+] %{public}@", log: .networkProtectionMemoryLog, type: .debug, String(describing: self))
+    }
+
+    deinit {
+        task?.cancel()
+
+        os_log("[-] %{public}@", log: .networkProtectionMemoryLog, type: .debug, String(describing: self))
+    }
+
+    // MARK: - Start/Stop monitoring
+
+    public func start(serverName: String, callback: @escaping (ServerStatusResult) -> Void) {
+        os_log("⚫️ Starting server status monitor", log: .networkProtectionServerStatusMonitorLog)
+
+        task = Task.periodic(interval: Self.monitoringInterval) {
+            let result = await self.checkServerStatus(for: serverName)
+
+            switch result {
+            case .success(let serverStatus):
+                if serverStatus.shouldMigrate {
+                    os_log("⚫️ Beginning server migration", log: .networkProtectionServerStatusMonitorLog)
+                    callback(.serverMigrationRequested)
+                } else {
+                    os_log("⚫️ Not migrating server", log: .networkProtectionServerStatusMonitorLog)
+                }
+            case .failure(let error):
+                os_log("⚫️ Error retrieving server status: %{public}@", log: .networkProtectionServerStatusMonitorLog, error.localizedDescription)
+                callback(.error(error))
+            }
+        }
+    }
+
+    public func stop() {
+        os_log("⚫️ Stopping server status monitor", log: .networkProtectionEntitlementMonitorLog)
+
+        task?.cancel()
+        task = nil
+    }
+
+    // MARK: - Server Status Check
+
+    private func checkServerStatus(for serverName: String) async -> Result<NetworkProtectionServerStatus, NetworkProtectionClientError> {
+        guard let accessToken = try? tokenStore.fetchToken() else {
+            assertionFailure("Failed to check server status due to lack of access token")
+            return .failure(.invalidAuthToken)
+        }
+
+        return await networkClient.getServerStatus(authToken: accessToken, serverName: serverName)
+    }
+
+}

--- a/Sources/NetworkProtection/Logging/Logging.swift
+++ b/Sources/NetworkProtection/Logging/Logging.swift
@@ -29,6 +29,11 @@ extension OSLog {
         Logging.networkProtectionBandwidthAnalysisLoggingEnabled ? Logging.networkProtectionBandwidthAnalysis : .disabled
     }
 
+    public static var networkProtectionServerStatusMonitorLog: OSLog {
+        Logging.networkProtectionServerStatusMonitorLoggingEnabled ? Logging.networkProtectionServerStatusMonitor : .disabled
+    }
+
+
     public static var networkProtectionLatencyMonitorLog: OSLog {
         Logging.networkProtectionLatencyMonitorLoggingEnabled ? Logging.networkProtectionLatencyMonitor : .disabled
     }
@@ -87,6 +92,9 @@ struct Logging {
 
     fileprivate static let networkProtectionBandwidthAnalysisLoggingEnabled = true
     fileprivate static let networkProtectionBandwidthAnalysis: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Bandwidth Analysis")
+
+    fileprivate static let networkProtectionServerStatusMonitorLoggingEnabled = true
+    fileprivate static let networkProtectionServerStatusMonitor: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Server Status Monitor")
 
     fileprivate static let networkProtectionLatencyMonitorLoggingEnabled = true
     fileprivate static let networkProtectionLatencyMonitor: OSLog = OSLog(subsystem: subsystem, category: "Network Protection: Latency Monitor")

--- a/Sources/NetworkProtection/Logging/Logging.swift
+++ b/Sources/NetworkProtection/Logging/Logging.swift
@@ -33,7 +33,6 @@ extension OSLog {
         Logging.networkProtectionServerStatusMonitorLoggingEnabled ? Logging.networkProtectionServerStatusMonitor : .disabled
     }
 
-
     public static var networkProtectionLatencyMonitorLog: OSLog {
         Logging.networkProtectionLatencyMonitorLoggingEnabled ? Logging.networkProtectionLatencyMonitor : .disabled
     }

--- a/Sources/NetworkProtection/Models/NetworkProtectionServerStatus.swift
+++ b/Sources/NetworkProtection/Models/NetworkProtectionServerStatus.swift
@@ -1,0 +1,23 @@
+//
+//  NetworkProtectionServerStatus.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct NetworkProtectionServerStatus: Codable, Equatable, Sendable {
+    public let shouldMigrate: Bool
+}

--- a/Sources/NetworkProtection/Networking/NetworkProtectionClient.swift
+++ b/Sources/NetworkProtection/Networking/NetworkProtectionClient.swift
@@ -21,8 +21,8 @@ import Foundation
 protocol NetworkProtectionClient {
     func getLocations(authToken: String) async -> Result<[NetworkProtectionLocation], NetworkProtectionClientError>
     func getServers(authToken: String) async -> Result<[NetworkProtectionServer], NetworkProtectionClientError>
-    func register(authToken: String,
-                  requestBody: RegisterKeyRequestBody) async -> Result<[NetworkProtectionServer], NetworkProtectionClientError>
+    func getServerStatus(authToken: String, serverName: String) async -> Result<NetworkProtectionServerStatus, NetworkProtectionClientError>
+    func register(authToken: String, requestBody: RegisterKeyRequestBody) async -> Result<[NetworkProtectionServer], NetworkProtectionClientError>
 }
 
 public enum NetworkProtectionClientError: CustomNSError, NetworkProtectionErrorConvertible {
@@ -30,6 +30,8 @@ public enum NetworkProtectionClientError: CustomNSError, NetworkProtectionErrorC
     case failedToParseLocationListResponse(Error)
     case failedToFetchServerList(Error)
     case failedToParseServerListResponse(Error)
+    case failedToFetchServerStatus(Error)
+    case failedToParseServerStatusResponse(Error)
     case failedToEncodeRegisterKeyRequest
     case failedToFetchRegisteredServers(Error)
     case failedToParseRegisteredServersResponse(Error)
@@ -47,6 +49,8 @@ public enum NetworkProtectionClientError: CustomNSError, NetworkProtectionErrorC
         case .failedToParseLocationListResponse(let error): return .failedToParseLocationListResponse(error)
         case .failedToFetchServerList(let error): return .failedToFetchServerList(error)
         case .failedToParseServerListResponse(let error): return .failedToParseServerListResponse(error)
+        case .failedToFetchServerStatus(let error): return .failedToFetchServerStatus(error)
+        case .failedToParseServerStatusResponse(let error): return .failedToParseServerStatusResponse(error)
         case .failedToEncodeRegisterKeyRequest: return .failedToEncodeRegisterKeyRequest
         case .failedToFetchRegisteredServers(let error): return .failedToFetchRegisteredServers(error)
         case .failedToParseRegisteredServersResponse(let error): return .failedToParseRegisteredServersResponse(error)
@@ -76,6 +80,8 @@ public enum NetworkProtectionClientError: CustomNSError, NetworkProtectionErrorC
         case .failedToParseRedeemResponse: return 11
         case .invalidAuthToken: return 12
         case .accessDenied: return 13
+        case .failedToFetchServerStatus: return 14
+        case .failedToParseServerStatusResponse: return 15
         }
     }
 
@@ -88,7 +94,9 @@ public enum NetworkProtectionClientError: CustomNSError, NetworkProtectionErrorC
                 .failedToFetchRegisteredServers(let error),
                 .failedToParseRegisteredServersResponse(let error),
                 .failedToRedeemInviteCode(let error),
-                .failedToParseRedeemResponse(let error):
+                .failedToParseRedeemResponse(let error),
+                .failedToFetchServerStatus(let error),
+                .failedToParseServerStatusResponse(let error):
             return [NSUnderlyingErrorKey: error as NSError]
         case .failedToEncodeRegisterKeyRequest,
                 .failedToEncodeRedeemRequest,
@@ -186,6 +194,10 @@ final class NetworkProtectionBackendClient: NetworkProtectionClient {
 
     var registerKeyURL: URL {
         endpointURL.appending("/register")
+    }
+
+    func serverStatusURL(serverName: String) -> URL {
+        endpointURL.appending("/servers/\(serverName)/status")
     }
 
     private let decoder: JSONDecoder = {
@@ -298,6 +310,49 @@ final class NetworkProtectionBackendClient: NetworkProtectionClient {
             return .success(decodedServers)
         } catch {
             return .failure(NetworkProtectionClientError.failedToParseServerListResponse(error))
+        }
+    }
+
+    public enum GetServerStatusError: CustomNSError {
+        case noResponse
+        case unexpectedStatus(status: Int)
+
+        var errorCode: Int {
+            switch self {
+            case .noResponse:
+                return 0
+            case .unexpectedStatus(let status):
+                // Adding a large number so that we can get a somewhat reasonable status code
+                return 100000 + status
+            }
+        }
+    }
+
+    func getServerStatus(authToken: String, serverName: String) async -> Result<NetworkProtectionServerStatus, NetworkProtectionClientError> {
+        var request = URLRequest(url: serverStatusURL(serverName: serverName))
+        request.setValue("bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        let downloadedData: Data
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let response = response as? HTTPURLResponse else {
+                throw GetServerStatusError.noResponse
+            }
+            switch response.statusCode {
+            case 200: downloadedData = data
+            case 401: return .failure(.invalidAuthToken)
+            default:
+                throw GetServerStatusError.unexpectedStatus(status: response.statusCode)
+            }
+        } catch {
+            return .failure(NetworkProtectionClientError.failedToFetchServerList(error))
+        }
+
+        do {
+            let serverStatus = try decoder.decode(NetworkProtectionServerStatus.self, from: downloadedData)
+            return .success(serverStatus)
+        } catch {
+            return .failure(NetworkProtectionClientError.failedToParseServerStatusResponse(error))
         }
     }
 

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -340,6 +340,10 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     public lazy var latencyMonitor = NetworkProtectionLatencyMonitor()
     public lazy var entitlementMonitor = NetworkProtectionEntitlementMonitor()
+    public lazy var serverStatusMonitor = NetworkProtectionServerStatusMonitor(
+        networkClient: NetworkProtectionBackendClient(isSubscriptionEnabled: true),
+        tokenStore: NetworkProtectionKeychainTokenStore()
+    )
 
     private var lastTestFailed = false
     private let bandwidthAnalyzer = NetworkProtectionConnectionBandwidthAnalyzer()

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1397,12 +1397,14 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         await serverStatusMonitor.start(serverName: serverName) { status in
             if status.shouldMigrate {
-                self.providerEvents.fire(.serverMigrationAttempt(.begin))
-                do {
-                    try await self.updateTunnelConfiguration(reassert: false, regenerateKey: true)
-                    self.providerEvents.fire(.serverMigrationAttempt(.success))
-                } catch {
-                    self.providerEvents.fire(.serverMigrationAttempt(.failure(error)))
+                Task {
+                    self.providerEvents.fire(.serverMigrationAttempt(.begin))
+                    do {
+                        try await self.updateTunnelConfiguration(reassert: true, regenerateKey: true)
+                        self.providerEvents.fire(.serverMigrationAttempt(.success))
+                    } catch {
+                        self.providerEvents.fire(.serverMigrationAttempt(.failure(error)))
+                    }
                 }
             }
         }

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1508,6 +1508,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         await tunnelFailureMonitor.stop()
         await latencyMonitor.stop()
         await entitlementMonitor.stop()
+        await serverStatusMonitor.stop()
     }
 
     public override func wake() {

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1393,7 +1393,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         await serverStatusMonitor.start(serverName: serverName) { status in
             if status.shouldMigrate {
-                try await self.updateTunnelConfiguration(reassert: false, regenerateKey: true)
+                try await self.updateTunnelConfiguration(reassert: true, regenerateKey: true)
             }
         }
     }

--- a/Sources/NetworkProtectionTestUtils/Networking/MockNetworkProtectionClient.swift
+++ b/Sources/NetworkProtectionTestUtils/Networking/MockNetworkProtectionClient.swift
@@ -34,6 +34,16 @@ public final class MockNetworkProtectionClient: NetworkProtectionClient {
         return stubGetLocations
     }
 
+    public var spyGetServerStatusAuthToken: String?
+    public var spyGetServerStatusServerName: String?
+    public var stubServerStatus: Result<NetworkProtection.NetworkProtectionServerStatus, NetworkProtection.NetworkProtectionClientError> = .success(
+        .init(shouldMigrate: true)
+    )
+    public func getServerStatus(authToken: String, serverName: String) async -> Result<NetworkProtection.NetworkProtectionServerStatus, NetworkProtection.NetworkProtectionClientError> {
+        spyGetServerStatusAuthToken = authToken
+        spyGetServerStatusServerName = serverName
+        return stubServerStatus
+    }
     public var spyRedeemInviteCode: String?
     public var spyRedeemAccessToken: String?
     public var stubRedeem: Result<String, NetworkProtection.NetworkProtectionClientError> = .success("")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203137811378537/1207555842602667/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2945
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2858
What kind of version bump will this require?: Major

**Description**:

This PR adds support for fast egress server draining. It works as follows:

1. Every 5 minutes, the client makes a call to the server status endpoint for the server it is connected to
2. If the response indicates that the server wants clients to transfer to another server, we will force a tunnel configuration update
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
