### PR TITLE
Improve prerequisite checks for VPN start

### DIFF
--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -222,12 +222,18 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             selectedServer = registeredServer
             return (selectedServer, selectedServer.expirationDate)
         case .failure(let error):
-            if isSubscriptionEnabled, case .accessDenied = error {
-                errorEvents?.fire(.vpnAccessRevoked)
-                throw NetworkProtectionError.vpnAccessRevoked
+            handle(clientError: error)
+
+            switch error {
+            case .accessDenied, .invalidAuthToken:
+                if isSubscriptionEnabled {
+                    errorEvents?.fire(.vpnAccessRevoked)
+                    throw NetworkProtectionError.vpnAccessRevoked
+                }
+            default:
+                break
             }
 
-            handle(clientError: error)
             throw error
         }
     }

--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -223,17 +223,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             return (selectedServer, selectedServer.expirationDate)
         case .failure(let error):
             handle(clientError: error)
-
-            switch error {
-            case .accessDenied, .invalidAuthToken:
-                if isSubscriptionEnabled {
-                    errorEvents?.fire(.vpnAccessRevoked)
-                    throw NetworkProtectionError.vpnAccessRevoked
-                }
-            default:
-                break
-            }
-
+            try handleAccessRevoked(error)
             throw error
         }
     }
@@ -324,5 +314,17 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
         }
 #endif
         errorEvents?.fire(clientError.networkProtectionError)
+    }
+
+    private func handleAccessRevoked(_ error: NetworkProtectionClientError) throws {
+        switch error {
+        case .accessDenied, .invalidAuthToken:
+            if isSubscriptionEnabled {
+                errorEvents?.fire(.vpnAccessRevoked)
+                throw NetworkProtectionError.vpnAccessRevoked
+            }
+        default:
+            break
+        }
     }
 }

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1469,9 +1469,25 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     // MARK: - Connection Tester
 
-    private enum ConnectionTesterError: Error {
+    private enum ConnectionTesterError: CustomNSError {
         case couldNotRetrieveInterfaceNameFromAdapter
         case testerFailedToStart(internalError: Error)
+
+        var errorCode: Int {
+            switch self {
+            case .couldNotRetrieveInterfaceNameFromAdapter: return 0
+            case .testerFailedToStart: return 1
+            }
+        }
+
+        var errorUserInfo: [String : Any] {
+            switch self {
+            case .couldNotRetrieveInterfaceNameFromAdapter:
+                return [:]
+            case .testerFailedToStart(let internalError):
+                return [NSUnderlyingErrorKey: internalError as NSError]
+            }
+        }
     }
 
     private func startConnectionTester(testImmediately: Bool) async throws {

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -569,6 +569,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     @MainActor
     open override func startTunnel(options: [String: NSObject]? = nil) async throws {
 
+        // It's important to have this as soon as possible since it helps setup PixelKit
+        prepareToConnect(using: tunnelProviderProtocol)
+
         let startupOptions = StartupOptions(options: options ?? [:])
         os_log("Starting tunnel with options: %{public}s", log: .networkProtection, startupOptions.description)
 
@@ -598,7 +601,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         do {
             providerEvents.fire(.tunnelStartAttempt(.begin))
-            prepareToConnect(using: tunnelProviderProtocol)
             connectionStatus = .connecting
             resetIssueStateOnTunnelStart(startupOptions)
 

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -516,6 +516,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             try tokenStore.store(newAuthToken)
         case .useExisting:
+            guard try tokenStore.fetchToken() != nil else {
+                throw TunnelError.startingTunnelWithoutAuthToken
+            }
             break
         case .reset:
             // This case should in theory not be possible, but it's ideal to have this in place
@@ -564,69 +567,66 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     // MARK: - Tunnel Start
 
-    open override func startTunnel(options: [String: NSObject]?, completionHandler: @escaping (Error?) -> Void) {
-        Task { @MainActor in
-            providerEvents.fire(.tunnelStartAttempt(.begin))
-            prepareToConnect(using: tunnelProviderProtocol)
+    @MainActor
+    open override func startTunnel(options: [String : NSObject]? = nil) async throws {
 
-            connectionStatus = .connecting
+        let startupOptions = StartupOptions(options: options ?? [:])
+        os_log("Starting tunnel with options: %{public}s", log: .networkProtection, startupOptions.description)
 
-            let startupOptions = StartupOptions(options: options ?? [:])
-            os_log("Starting tunnel with options: %{public}s", log: .networkProtection, startupOptions.description)
-
-            resetIssueStateOnTunnelStart(startupOptions)
-
-            let internalCompletionHandler = { [weak self, providerEvents] (error: Error?) in
-                guard let error else {
-                    completionHandler(nil)
-                    providerEvents.fire(.tunnelStartAttempt(.success))
-                    return
-                }
-
-                let handler = {
-                    let errorDescription = (error as? LocalizedError)?.localizedDescription ?? String(describing: error)
-
-                    os_log("Tunnel startup error: %{public}@", type: .error, errorDescription)
-                    self?.controllerErrorStore.lastErrorMessage = errorDescription
-                    self?.connectionStatus = .disconnected
-                    self?.knownFailureStore.lastKnownFailure = KnownFailure(error)
-
-                    providerEvents.fire(.tunnelStartAttempt(.failure(error)))
-                    completionHandler(error)
-                }
-
-                if startupOptions.startupMethod == .automaticOnDemand {
-                    Task {
-                        // We add a 10 seconds delay when the VPN is started by
-                        // on-demand and there's an error, to avoid frenetic ON/OFF
-                        // cycling.
-                        try? await Task.sleep(interval: .seconds(10))
-                        handler()
-                    }
-                } else {
-                    handler()
-                }
-            }
-
-            startTunnel(options: startupOptions, completionHandler: internalCompletionHandler)
-        }
-    }
-
-    private func startTunnel(options: StartupOptions, completionHandler: @escaping (Error?) -> Void) {
         do {
-            try runDebugSimulations(options: options)
-            try load(options: options)
+            try load(options: startupOptions)
             try loadVendorOptions(from: tunnelProviderProtocol)
         } catch {
-            completionHandler(error)
-            return
+            if startupOptions.startupMethod == .automaticOnDemand {
+                // If the VPN was started by on-demand without the basic prerequisites for
+                // it to work we skip firing pixels.  This should only be possible if the
+                // manual start attempt that preceded failed, or if the subscription has
+                // expired.  In either case it should be enough to record the manual failures
+                // for these prerequisited to avoid flooding our metrics.
+                try? await Task.sleep(interval: .seconds(15))
+            } else {
+                // If the VPN was started manually without the basic prerequisited we always
+                // want to know as this should not be possible.
+                providerEvents.fire(.tunnelStartAttempt(.begin))
+                providerEvents.fire(.tunnelStartAttempt(.failure(error)))
+            }
+
+            os_log("🔴 Stopping VPN due to no auth token: %{public}s", log: .networkProtection)
+            await attemptShutdown()
+
+            throw error
         }
 
-        let onDemand = options.startupMethod == .automaticOnDemand
+        do {
+            providerEvents.fire(.tunnelStartAttempt(.begin))
+            prepareToConnect(using: tunnelProviderProtocol)
+            connectionStatus = .connecting
+            resetIssueStateOnTunnelStart(startupOptions)
 
-        os_log("Starting tunnel %{public}@", log: .networkProtection, options.startupMethod.debugDescription)
-        startTunnel(onDemand: onDemand,
-                    completionHandler: completionHandler)
+            try runDebugSimulations(options: startupOptions)
+            try await startTunnel(onDemand: startupOptions.startupMethod == .automaticOnDemand)
+
+            providerEvents.fire(.tunnelStartAttempt(.success))
+        } catch {
+            if startupOptions.startupMethod == .automaticOnDemand {
+                // We add a 10 seconds delay when the VPN is started by
+                // on-demand and there's an error, to avoid frenetic ON/OFF
+                // cycling.
+                try? await Task.sleep(interval: .seconds(15))
+            }
+
+            let errorDescription = (error as? LocalizedError)?.localizedDescription ?? String(describing: error)
+
+            os_log("Tunnel startup error: %{public}@", type: .error, errorDescription)
+            self.controllerErrorStore.lastErrorMessage = errorDescription
+            self.connectionStatus = .disconnected
+            self.knownFailureStore.lastKnownFailure = KnownFailure(error)
+
+            providerEvents.fire(.tunnelStartAttempt(.failure(error)))
+
+            os_log("🔴 Stopping VPN due to error: %{public}s", log: .networkProtection, error.localizedDescription)
+            throw error
+        }
     }
 
     var currentServerSelectionMethod: NetworkProtectionServerSelectionMethod {
@@ -651,60 +651,60 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         return serverSelectionMethod
     }
 
-    private func startTunnel(onDemand: Bool, completionHandler: @escaping (Error?) -> Void) {
-        Task {
-            do {
-                os_log("🔵 Generating tunnel config", log: .networkProtection, type: .info)
-                os_log("🔵 Excluded ranges are: %{public}@", log: .networkProtection, type: .info, String(describing: settings.excludedRanges))
-                os_log("🔵 Server selection method: %{public}@", log: .networkProtection, type: .info, currentServerSelectionMethod.debugDescription)
-                let tunnelConfiguration = try await generateTunnelConfiguration(serverSelectionMethod: currentServerSelectionMethod,
-                                                                                includedRoutes: includedRoutes ?? [],
-                                                                                excludedRoutes: settings.excludedRanges,
-                                                                                regenerateKey: true)
-                startTunnel(with: tunnelConfiguration, onDemand: onDemand, completionHandler: completionHandler)
-                os_log("🔵 Done generating tunnel config", log: .networkProtection, type: .info)
-            } catch {
-                os_log("🔵 Error starting tunnel: %{public}@", log: .networkProtection, type: .info, error.localizedDescription)
+    private func startTunnel(onDemand: Bool) async throws {
+        do {
+            os_log("🔵 Generating tunnel config", log: .networkProtection, type: .info)
+            os_log("🔵 Excluded ranges are: %{public}@", log: .networkProtection, type: .info, String(describing: settings.excludedRanges))
+            os_log("🔵 Server selection method: %{public}@", log: .networkProtection, type: .info, currentServerSelectionMethod.debugDescription)
+            let tunnelConfiguration = try await generateTunnelConfiguration(serverSelectionMethod: currentServerSelectionMethod,
+                                                                            includedRoutes: includedRoutes ?? [],
+                                                                            excludedRoutes: settings.excludedRanges,
+                                                                            regenerateKey: true)
+            try await startTunnel(with: tunnelConfiguration, onDemand: onDemand)
+            os_log("🔵 Done generating tunnel config", log: .networkProtection, type: .info)
+        } catch {
+            os_log("🔵 Error starting tunnel: %{public}@", log: .networkProtection, type: .info, error.localizedDescription)
 
-                controllerErrorStore.lastErrorMessage = error.localizedDescription
+            controllerErrorStore.lastErrorMessage = error.localizedDescription
 
-                completionHandler(error)
-            }
+            throw error
         }
     }
 
-    private func startTunnel(with tunnelConfiguration: TunnelConfiguration, onDemand: Bool, completionHandler: @escaping (Error?) -> Void) {
+    private func startTunnel(with tunnelConfiguration: TunnelConfiguration, onDemand: Bool) async throws {
 
-        adapter.start(tunnelConfiguration: tunnelConfiguration) { [weak self] error in
-            if let error {
-                os_log("🔵 Starting tunnel failed with %{public}@", log: .networkProtection, type: .error, error.localizedDescription)
-                self?.debugEvents?.fire(error.networkProtectionError)
-                completionHandler(error)
-                return
-            }
-
-            Task { @MainActor [weak self] in
-                // It's important to call this completion handler before running the tester
-                // as if we don't, the tester will just fail.  It seems like the connection
-                // won't fully work until the completion handler is called.
-                completionHandler(nil)
-
-                guard let self else { return }
-
-                do {
-                    let startReason: AdapterStartReason = onDemand ? .onDemand : .manual
-                    try await self.handleAdapterStarted(startReason: startReason)
-
-                    // Enable Connect on Demand when manually enabling the tunnel on iOS 17.0+.
-#if os(iOS)
-                    if #available(iOS 17.0, *), startReason == .manual {
-                        try? await updateConnectOnDemand(enabled: true)
-                        os_log("Enabled Connect on Demand due to user-initiated startup", log: .networkProtection, type: .info)
-                    }
-#endif
-                } catch {
-                    self.cancelTunnelWithError(error)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            adapter.start(tunnelConfiguration: tunnelConfiguration) { [weak self] error in
+                if let error {
+                    os_log("🔵 Starting tunnel failed with %{public}@", log: .networkProtection, type: .error, error.localizedDescription)
+                    self?.debugEvents?.fire(error.networkProtectionError)
+                    continuation.resume(throwing: error)
                     return
+                }
+
+                Task { @MainActor [weak self] in
+                    // It's important to call this completion handler before running the tester
+                    // as if we don't, the tester will just fail.  It seems like the connection
+                    // won't fully work until the completion handler is called.
+                    continuation.resume()
+
+                    guard let self else { return }
+
+                    do {
+                        let startReason: AdapterStartReason = onDemand ? .onDemand : .manual
+                        try await self.handleAdapterStarted(startReason: startReason)
+
+                        // Enable Connect on Demand when manually enabling the tunnel on iOS 17.0+.
+#if os(iOS)
+                        if #available(iOS 17.0, *), startReason == .manual {
+                            try? await updateConnectOnDemand(enabled: true)
+                            os_log("Enabled Connect on Demand due to user-initiated startup", log: .networkProtection, type: .info)
+                        }
+#endif
+                    } catch {
+                        self.cancelTunnelWithError(error)
+                        return
+                    }
                 }
             }
         }
@@ -1052,9 +1052,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             handleSendTestNotification(completionHandler: completionHandler)
         case .disableConnectOnDemandAndShutDown:
             Task { [weak self] in
-                await self?.attemptShutdown {
-                    completionHandler?(nil)
-                }
+                await self?.attemptShutdown()
+                completionHandler?(nil)
             }
         case .removeVPNConfiguration:
             // Since the VPN configuration is being removed we may as well reset all state
@@ -1428,13 +1427,12 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     // Attempt to shut down the tunnel
     // On iOS 16 and below, as a workaround, we rekey to force a 403 error so that the tunnel fails to restart
     @MainActor
-    private func attemptShutdown(completion: (() -> Void)? = nil) async {
+    private func attemptShutdown() async {
         if #available(iOS 17, *) {
             handleShutDown()
         } else {
             try? await rekey()
         }
-        completion?()
     }
 
     @MainActor

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -519,7 +519,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             guard try tokenStore.fetchToken() != nil else {
                 throw TunnelError.startingTunnelWithoutAuthToken
             }
-            break
         case .reset:
             // This case should in theory not be possible, but it's ideal to have this in place
             // in case an error in the controller on the client side allows it.
@@ -568,7 +567,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     // MARK: - Tunnel Start
 
     @MainActor
-    open override func startTunnel(options: [String : NSObject]? = nil) async throws {
+    open override func startTunnel(options: [String: NSObject]? = nil) async throws {
 
         let startupOptions = StartupOptions(options: options ?? [:])
         os_log("Starting tunnel with options: %{public}s", log: .networkProtection, startupOptions.description)

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1480,7 +1480,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             }
         }
 
-        var errorUserInfo: [String : Any] {
+        var errorUserInfo: [String: Any] {
             switch self {
             case .couldNotRetrieveInterfaceNameFromAdapter:
                 return [:]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206580121312550/1207613628544128/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2970
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2882
What kind of version bump will this require?: Patch

## Description

**Goals:**
- Validate tunnel start prerequisites and, when they aren't met:
   - Prevent pixel noise; and
   - Prevent network calls to our backend.
- Also clean up the code a bit so that we no longer use completion callbacks for the tunnel start logic.
- Add underlying error information to our wake failure pixels.

## Testing

See the platform specific PRs for testing instructions.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
