### PR TITLE
Update autofill to 12.0.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "10aeff1ec7f533d1705233a9b14f9393a699b1c0",
-        "version" : "11.0.2"
+        "revision" : "2b81745565db09eee8c1cd44d38eefa1011a9f0a",
+        "version" : "12.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .library(name: "PixelKitTestingUtilities", targets: ["PixelKitTestingUtilities"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "11.0.2"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "12.0.1"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.3.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "2.1.2"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207634174804399/1207634174804399
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.1


## Description
Updates Autofill to version [12.0.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.1).

### Autofill 12.0.1 release notes
## What's Changed
* generation: ensure password gen feature flag is respected by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/583

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/12.0.0...12.0.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).