### PR TITLE
move async WKWebView.evaluateJavaScript to BSK

### DIFF
--- a/Sources/Common/Extensions/WKWebViewExtension.swift
+++ b/Sources/Common/Extensions/WKWebViewExtension.swift
@@ -1,0 +1,48 @@
+//
+//  WKWebViewExtension.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import WebKit
+
+public extension WKWebView {
+
+    /// Calling this method is equivalent to calling `evaluateJavaScript:inFrame:inContentWorld:completionHandler:` with:
+    /// - A `frame` value of `nil` to represent the main frame
+    /// - A `contentWorld` value of `WKContentWorld.pageWorld`
+    @MainActor func evaluateJavaScript<T>(_ script: String) async throws -> T? {
+        try await withUnsafeThrowingContinuation { c in
+            evaluateJavaScript(script) { result, error in
+                if let error {
+                    c.resume(with: .failure(error))
+                } else {
+                    c.resume(with: .success(result as? T))
+                }
+            }
+        }
+    }
+
+    // This is meant to cause the `Ambiguous use` error, because async `evaluateJavaScript(_) -> Any`
+    // call will crash when its result is `nil`.
+    // Use typed `try await evaluateJavaScript(script) as Void?` (or other type you need),
+    // or even better `try await evaluateJavaScript(script, in: nil, in: .page|.defaultClient) -> Any?` (available in macOS 12/iOS 15)
+    @available(*, deprecated, message: "Use `try await evaluateJavaScript(script) as Void?` instead.")
+    @MainActor func evaluateJavaScript(_ script: String) async throws {
+        assertionFailure("Use `try await evaluateJavaScript(script) as Void?` instead of `try await evaluateJavaScript(script)` as it will crash in runtime")
+        try await evaluateJavaScript(script) as Void?
+    }
+
+}

--- a/Sources/PrivacyDashboard/BrokenSiteReporting/ReferrerInfo.swift
+++ b/Sources/PrivacyDashboard/BrokenSiteReporting/ReferrerInfo.swift
@@ -16,22 +16,24 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
 import WebKit
 
 extension WKWebView {
+
+    @MainActor
+    var referrer: String? {
+        get async {
+            try? await self.evaluateJavaScript("document.referrer")
+        }
+    }
+
     @MainActor
     public var isCurrentSiteReferredFromDuckDuckGo: Bool {
         get async {
-            do {
-                if let result = try await self.evaluateJavaScript("document.referrer") as? String {
-                    return result.contains("duckduckgo.com")
-                }
-            } catch {
-                return false
-            }
-
-            return false
+            await referrer?.contains("duckduckgo.com") ?? false
         }
     }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201037661562251/1207644259876245/f
iOS PR: not affected
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2902
What kind of version bump will this require?: Minor

**Description**:
- Moved `WKWebView.evaluateJavaScript(_) -> T? async` implementation from macOS code base
- Added ambiguous `WKWebView.evaluateJavaScript(_) -> Void async` implementation to prevent from using the problematic method

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate code compilation fails for code like `let result = webView.evaluateJavaScript("document.outerHTML")`
2. Validate this code doesn‘t crash (it does when the added extension is commented out:
```
let webView = WKWebView()
webView.evaluateJavaScript("document.outerHTML")
```
