### PR TITLE
Silence tunnel startup noise with no access token available

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -594,7 +594,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             if (try? tokenStore.fetchToken()) == nil {
                 providerEvents.fire(.tunnelStartWithoutAccessToken)
-                try? await Task.sleep(interval: .seconds(15))
                 throw TunnelError.startingTunnelWithoutAuthToken
             }
         } catch {

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -37,7 +37,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         case tunnelStopAttempt(_ step: TunnelStopAttemptStep)
         case tunnelUpdateAttempt(_ step: TunnelUpdateAttemptStep)
         case tunnelWakeAttempt(_ step: TunnelWakeAttemptStep)
-        case tunnelStartWithoutAccessToken
+        case tunnelStartOnDemandWithoutAccessToken
         case reportTunnelFailure(result: NetworkProtectionTunnelFailureMonitor.Result)
         case reportLatency(result: NetworkProtectionLatencyMonitor.Result)
         case rekeyAttempt(_ step: RekeyAttemptStep)
@@ -593,7 +593,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             try loadVendorOptions(from: tunnelProviderProtocol)
 
             if (try? tokenStore.fetchToken()) == nil {
-                providerEvents.fire(.tunnelStartWithoutAccessToken)
                 throw TunnelError.startingTunnelWithoutAuthToken
             }
         } catch {
@@ -603,6 +602,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 // manual start attempt that preceded failed, or if the subscription has
                 // expired.  In either case it should be enough to record the manual failures
                 // for these prerequisited to avoid flooding our metrics.
+                providerEvents.fire(.tunnelStartOnDemandWithoutAccessToken)
                 try? await Task.sleep(interval: .seconds(15))
             } else {
                 // If the VPN was started manually without the basic prerequisites we always


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203137811378537/1207585882006688/f
iOS PR: https://github.com/duckduckgo/iOS/pull/2993
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2906
What kind of version bump will this require?: Major

**Description**:

This PR adds a guard statement into the VPN startup process, which checks for the presence of an access token. If no token is found, we send a new pixel, and then stop the startup process after a short delay.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
