### PR TITLE
fix crash in NavigationResponse.response.url!

### DIFF
--- a/Sources/Navigation/NavigationResponse.swift
+++ b/Sources/Navigation/NavigationResponse.swift
@@ -50,7 +50,7 @@ public struct NavigationResponse {
 public extension NavigationResponse {
 
     var url: URL {
-        response.url!
+        response.url ?? .empty
     }
 
     var httpResponse: HTTPURLResponse? {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201048563534612/1207643411973941/f
Sentry URL: https://errors.duckduckgo.com/organizations/ddg/issues/32792/?project=6&query=is%3Aunresolved+app_version%3A1.92.0&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=6
iOS PR: not affected
macOS PR: 
What kind of version bump will this require?: Patch

**Description**:
- Replaces nil url in `NavigationResponse` with empty URL

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. validate sanity related to the crash report

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
