### PR TITLE
VPN uninstall not stopping agent in App Store build

### DIFF
--- a/Sources/NetworkProtection/ExtensionMessage/ExtensionRequest.swift
+++ b/Sources/NetworkProtection/ExtensionMessage/ExtensionRequest.swift
@@ -25,6 +25,7 @@ public enum VPNCommand: Codable {
     case sendTestNotification
     case uninstallVPN
     case disableConnectOnDemandAndShutDown
+    case quitAgent
 }
 
 public enum ExtensionRequest: Codable {

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1062,6 +1062,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         case .uninstallVPN:
             // Since the VPN configuration is being removed we may as well reset all state
             handleResetAllState(completionHandler: completionHandler)
+        case .quitAgent:
+            // No-op since this is intended for the agent app
+            break
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1207659744300515/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2999
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2911

What kind of version bump will this require?: Major/Minor/Patch

## Description

Fixes stopping the VPN agent after uninstalling the VPN in App Store builds.

## Testing

See platform specific PRs for instructions.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
