### PR TITLE
Remove Privacy Pro from device once expired account is deleted

### DIFF
--- a/Sources/Subscription/API/APIService.swift
+++ b/Sources/Subscription/API/APIService.swift
@@ -58,7 +58,7 @@ public struct DefaultAPIService: APIService {
             let (data, urlResponse) = try await session.data(for: request)
 
             printDebugInfo(method: method, endpoint: endpoint, data: data, response: urlResponse)
-            
+
             guard let httpResponse = urlResponse as? HTTPURLResponse else { return .failure(.unknownServerError) }
 
             if (200..<300).contains(httpResponse.statusCode) {

--- a/Sources/Subscription/Managers/AccountManager.swift
+++ b/Sources/Subscription/Managers/AccountManager.swift
@@ -46,7 +46,7 @@ public protocol AccountManager {
 
     typealias AccountDetails = (email: String?, externalID: String)
     func fetchAccountDetails(with accessToken: String) async -> Result<AccountDetails, Error>
-    func refreshSubscriptionAndEntitlements() async
+
     @discardableResult func checkForEntitlements(wait waitTime: Double, retry retryCount: Int) async -> Bool
 }
 
@@ -329,24 +329,6 @@ public final class DefaultAccountManager: AccountManager {
             os_log(.error, log: .subscription, "[AccountManager] fetchAccountDetails error: %{public}@", error.localizedDescription)
             return .failure(error)
         }
-    }
-
-    public func refreshSubscriptionAndEntitlements() async {
-        os_log(.info, log: .subscription, "[AccountManager] refreshSubscriptionAndEntitlements")
-
-        guard let token = accessToken else {
-            subscriptionEndpointService.signOut()
-            entitlementsCache.reset()
-            return
-        }
-
-        if case .success(let subscription) = await subscriptionEndpointService.getSubscription(accessToken: token, cachePolicy: .reloadIgnoringLocalCacheData) {
-            if !subscription.isActive {
-                signOut()
-            }
-        }
-
-        await fetchEntitlements(cachePolicy: .reloadIgnoringLocalCacheData)
     }
 
     @discardableResult

--- a/Sources/Subscription/Managers/SubscriptionManager.swift
+++ b/Sources/Subscription/Managers/SubscriptionManager.swift
@@ -28,7 +28,7 @@ public protocol SubscriptionManager {
     var canPurchase: Bool { get }
     @available(macOS 12.0, iOS 15.0, *) func storePurchaseManager() -> StorePurchaseManager
     func loadInitialData()
-    func updateSubscriptionStatus(completion: @escaping (_ isActive: Bool) -> Void)
+    func refreshCachedSubscriptionAndEntitlements(completion: @escaping (_ isSubscriptionActive: Bool) -> Void)
     func url(for type: SubscriptionURL) -> URL
 }
 
@@ -118,7 +118,7 @@ public final class DefaultSubscriptionManager: SubscriptionManager {
         }
     }
 
-    public func updateSubscriptionStatus(completion: @escaping (_ isActive: Bool) -> Void) {
+    public func refreshCachedSubscriptionAndEntitlements(completion: @escaping (_ isSubscriptionActive: Bool) -> Void) {
         Task {
             guard let token = accountManager.accessToken else { return }
 

--- a/Sources/SubscriptionTestingUtilities/AccountManagerMock.swift
+++ b/Sources/SubscriptionTestingUtilities/AccountManagerMock.swift
@@ -83,10 +83,6 @@ public final class AccountManagerMock: AccountManager {
         }
     }
 
-    public func refreshSubscriptionAndEntitlements() async {
-
-    }
-
     public func checkForEntitlements(wait waitTime: Double, retry retryCount: Int) async -> Bool {
         return true
     }

--- a/Sources/SubscriptionTestingUtilities/SubscriptionManagerMock.swift
+++ b/Sources/SubscriptionTestingUtilities/SubscriptionManagerMock.swift
@@ -34,7 +34,7 @@ public final class SubscriptionManagerMock: SubscriptionManager {
 
     }
 
-    public func updateSubscriptionStatus(completion: @escaping (Bool) -> Void) {
+    public func refreshCachedSubscriptionAndEntitlements(completion: @escaping (Bool) -> Void) {
         completion(true)
     }
 


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/1200019156869587/1207492658883345/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3009
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2922
What kind of version bump will this require?: Major

**Description**:
When fetching subscription info a 401 response means that the token is no longer valid. As a result we should sign out the user.

**Steps to test this PR**:
_See task_

**OS Testing**:

* [ ] iOS
* [ ] macOS

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
