### PR TITLE
Update the Privacy Pro status attribute matcher

### DIFF
--- a/Sources/RemoteMessaging/Matchers/UserAttributeMatcher.swift
+++ b/Sources/RemoteMessaging/Matchers/UserAttributeMatcher.swift
@@ -160,19 +160,19 @@ public struct UserAttributeMatcher: AttributeMatcher {
         case let matchingAttribute as PrivacyProPurchasePlatformMatchingAttribute:
             return StringArrayMatchingAttribute(matchingAttribute.value).matches(value: privacyProPurchasePlatform ?? "")
         case let matchingAttribute as PrivacyProSubscriptionStatusMatchingAttribute:
-            guard let value = matchingAttribute.value else {
-                return .fail
+            let mappedStatuses = matchingAttribute.value.compactMap { status in
+                return PrivacyProSubscriptionStatus(rawValue: status)
             }
 
-            guard let status = PrivacyProSubscriptionStatus(rawValue: value) else {
-                return .fail
+            for status in mappedStatuses {
+                switch status {
+                case .active: if isPrivacyProSubscriptionActive { return .match }
+                case .expiring: if isPrivacyProSubscriptionExpiring { return .match }
+                case .expired: if isPrivacyProSubscriptionExpired { return .match }
+                }
             }
 
-            switch status {
-            case .active: return isPrivacyProSubscriptionActive ? .match : .fail
-            case .expiring: return isPrivacyProSubscriptionExpiring ? .match : .fail
-            case .expired: return isPrivacyProSubscriptionExpired ? .match : .fail
-            }
+            return .fail
         case let matchingAttribute as InteractedWithMessageMatchingAttribute:
             if dismissedMessageIds.contains(where: { messageId in
                 StringArrayMatchingAttribute(matchingAttribute.value).matches(value: messageId) == .match

--- a/Sources/RemoteMessaging/Model/MatchingAttributes.swift
+++ b/Sources/RemoteMessaging/Model/MatchingAttributes.swift
@@ -799,13 +799,14 @@ struct PrivacyProPurchasePlatformMatchingAttribute: MatchingAttribute, Equatable
 }
 
 struct PrivacyProSubscriptionStatusMatchingAttribute: MatchingAttribute, Equatable {
-    var value: String?
+    var value: [String] = []
     var fallback: Bool?
 
     init(jsonMatchingAttribute: AnyDecodable) {
-        guard let jsonMatchingAttribute = jsonMatchingAttribute.value as? [String: Any] else { return }
-
-        if let value = jsonMatchingAttribute[RuleAttributes.value] as? String {
+        guard let jsonMatchingAttribute = jsonMatchingAttribute.value as? [String: Any] else {
+            return
+        }
+        if let value = jsonMatchingAttribute[RuleAttributes.value] as? [String] {
             self.value = value
         }
         if let fallback = jsonMatchingAttribute[RuleAttributes.fallback] as? Bool {
@@ -813,7 +814,7 @@ struct PrivacyProSubscriptionStatusMatchingAttribute: MatchingAttribute, Equatab
         }
     }
 
-    init(value: String?, fallback: Bool?) {
+    init(value: [String], fallback: Bool?) {
         self.value = value
         self.fallback = fallback
     }

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapperTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Mappers/JsonToRemoteConfigModelMapperTests.swift
@@ -168,7 +168,7 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
 
         attribs = rule8?.attributes.filter { $0 is PrivacyProSubscriptionStatusMatchingAttribute }
         XCTAssertEqual(attribs?.first as? PrivacyProSubscriptionStatusMatchingAttribute, PrivacyProSubscriptionStatusMatchingAttribute(
-            value: "active", fallback: nil
+            value: ["active", "expiring"], fallback: nil
         ))
 
         let rule9 = config.rules.filter { $0.id == 9 }.first

--- a/Tests/BrowserServicesKitTests/RemoteMessaging/Matchers/UserAttributeMatcherTests.swift
+++ b/Tests/BrowserServicesKitTests/RemoteMessaging/Matchers/UserAttributeMatcherTests.swift
@@ -250,35 +250,47 @@ class UserAttributeMatcherTests: XCTestCase {
 
     func testWhenPrivacyProSubscriptionStatusMatchesThenReturnMatch() throws {
         XCTAssertEqual(userAttributeMatcher.evaluate(
-            matchingAttribute: PrivacyProSubscriptionStatusMatchingAttribute(value: "active", fallback: nil)
+            matchingAttribute: PrivacyProSubscriptionStatusMatchingAttribute(value: ["active"], fallback: nil)
+        ), .match)
+    }
+
+    func testWhenPrivacyProSubscriptionStatusHasMultipleAttributesAndOneMatchesThenReturnMatch() throws {
+        XCTAssertEqual(userAttributeMatcher.evaluate(
+            matchingAttribute: PrivacyProSubscriptionStatusMatchingAttribute(value: ["active", "expiring", "expired"], fallback: nil)
         ), .match)
     }
 
     func testWhenPrivacyProSubscriptionStatusDoesNotMatchThenReturnFail() throws {
         XCTAssertEqual(userAttributeMatcher.evaluate(
-            matchingAttribute: PrivacyProSubscriptionStatusMatchingAttribute(value: "expiring", fallback: nil)
+            matchingAttribute: PrivacyProSubscriptionStatusMatchingAttribute(value: ["expiring"], fallback: nil)
         ), .fail)
     }
 
     func testWhenPrivacyProSubscriptionStatusHasUnsupportedStatusThenReturnFail() throws {
         XCTAssertEqual(userAttributeMatcher.evaluate(
-            matchingAttribute: PrivacyProSubscriptionStatusMatchingAttribute(value: "unsupported_status", fallback: nil)
+            matchingAttribute: PrivacyProSubscriptionStatusMatchingAttribute(value: ["unsupported_status"], fallback: nil)
         ), .fail)
     }
 
     func testWhenOneDismissedMessageIdMatchesThenReturnMatch() throws {
         setUpUserAttributeMatcher(dismissedMessageIds: ["1"])
-        XCTAssertEqual(userAttributeMatcher.evaluate(matchingAttribute: InteractedWithMessageMatchingAttribute(value: ["1", "2", "3"], fallback: nil)), .match)
+        XCTAssertEqual(userAttributeMatcher.evaluate(
+            matchingAttribute: InteractedWithMessageMatchingAttribute(value: ["1", "2", "3"], fallback: nil)
+        ), .match)
     }
 
     func testWhenAllDismissedMessageIdsMatchThenReturnMatch() throws {
         setUpUserAttributeMatcher(dismissedMessageIds: ["1", "2", "3"])
-        XCTAssertEqual(userAttributeMatcher.evaluate(matchingAttribute: InteractedWithMessageMatchingAttribute(value: ["1", "2", "3"], fallback: nil)), .match)
+        XCTAssertEqual(userAttributeMatcher.evaluate(
+            matchingAttribute: InteractedWithMessageMatchingAttribute(value: ["1", "2", "3"], fallback: nil)
+        ), .match)
     }
 
     func testWhenNoDismissedMessageIdsMatchThenReturnFail() throws {
         setUpUserAttributeMatcher(dismissedMessageIds: ["1", "2", "3"])
-        XCTAssertEqual(userAttributeMatcher.evaluate(matchingAttribute: InteractedWithMessageMatchingAttribute(value: ["4", "5"], fallback: nil)), .fail)
+        XCTAssertEqual(userAttributeMatcher.evaluate(
+            matchingAttribute: InteractedWithMessageMatchingAttribute(value: ["4", "5"], fallback: nil)
+        ), .fail)
     }
 
     func testWhenHaveDismissedMessageIdsAndMatchAttributeIsEmptyThenReturnFail() throws {
@@ -288,7 +300,9 @@ class UserAttributeMatcherTests: XCTestCase {
 
     func testWhenHaveNoDismissedMessageIdsAndMatchAttributeIsNotEmptyThenReturnFail() throws {
         setUpUserAttributeMatcher(dismissedMessageIds: [])
-        XCTAssertEqual(userAttributeMatcher.evaluate(matchingAttribute: InteractedWithMessageMatchingAttribute(value: ["1", "2"], fallback: nil)), .fail)
+        XCTAssertEqual(userAttributeMatcher.evaluate(
+            matchingAttribute: InteractedWithMessageMatchingAttribute(value: ["1", "2"], fallback: nil)
+        ), .fail)
     }
 
     private func setUpUserAttributeMatcher(dismissedMessageIds: [String] = []) {

--- a/Tests/BrowserServicesKitTests/Resources/remote-messaging-config.json
+++ b/Tests/BrowserServicesKitTests/Resources/remote-messaging-config.json
@@ -270,7 +270,7 @@
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": "active"
+          "value": ["active", "expiring"]
         },
         "pproDaysSinceSubscribed": {
             "min": 5,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199333091098016/1207731341550989/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3033
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2940
What kind of version bump will this require?: Patch (technically the public API has not changed)

**Description**:

This PR updates the Privacy Pro status attribute to match an array instead of a string.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check that tests pass

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
