### PR TITLE
Add a debug menu action to reset Remote Messages on macOS

### DIFF
--- a/Sources/RemoteMessaging/RemoteMessagingStore.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingStore.swift
@@ -379,6 +379,7 @@ extension RemoteMessagingStore {
                 os_log("Failed to reset remote messages", log: log, type: .error)
             }
         }
+        notificationCenter.post(name: Notifications.remoteMessagesDidChange, object: nil)
     }
 }
 

--- a/Sources/RemoteMessaging/RemoteMessagingStore.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingStore.swift
@@ -360,6 +360,26 @@ extension RemoteMessagingStore {
             }
         }
     }
+
+    public func resetRemoteMessages() {
+        guard remoteMessagingAvailabilityProvider.isRemoteMessagingAvailable else {
+            return
+        }
+
+        let context = database.makeContext(concurrencyType: .privateQueueConcurrencyType, name: Constants.privateContextName)
+        context.performAndWait {
+            context.deleteAll(entityDescriptions: [
+                RemoteMessageManagedObject.entity(in: context),
+                RemoteMessagingConfigManagedObject.entity(in: context)
+            ])
+
+            do {
+                try context.save()
+            } catch {
+                os_log("Failed to reset remote messages", log: log, type: .error)
+            }
+        }
+    }
 }
 
 // MARK: - RemoteMessageManagedObject Private Interface

--- a/Sources/RemoteMessaging/RemoteMessagingStoring.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingStoring.swift
@@ -18,7 +18,11 @@
 
 import Foundation
 
-public protocol RemoteMessagingStoring {
+public protocol RemoteMessagingStoringDebuggingSupport {
+    func resetRemoteMessages()
+}
+
+public protocol RemoteMessagingStoring: RemoteMessagingStoringDebuggingSupport {
 
     func saveProcessedResult(_ processorResult: RemoteMessagingConfigProcessor.ProcessorResult)
     func fetchRemoteMessagingConfig() -> RemoteMessagingConfig?

--- a/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
+++ b/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
@@ -92,4 +92,6 @@ public class MockRemoteMessagingStore: RemoteMessagingStoring {
     public func updateRemoteMessage(withID id: String, asShown shown: Bool) {
         updateRemoteMessageCalls += 1
     }
+
+    public func resetRemoteMessages() {}
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199230911884351/1207797025533577/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3076
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2972
What kind of version bump will this require?: Minor

**Description**:
This change adds API to reset Remote Messages by deleting all records in the database.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Make sure that CI is green.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
