### PR TITLE
Update C-S-S version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "branch" : "pr-releases/pr-992",
-        "revision" : "9e36dc0a90fa98e43f0564b52be7682e8a6daee4"
+        "revision" : "d0d4f28bbe2fd44cbc5db5f109bb8453699308a3",
+        "version" : "6.1.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "9c65477457126ab7ad963a32b7f85ce08e6bd1a7",
-        "version" : "6.0.0"
+        "branch" : "pr-releases/pr-992",
+        "revision" : "9e36dc0a90fa98e43f0564b52be7682e8a6daee4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "2.1.2"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", branch: "pr-releases/pr-992"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "6.1.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "4.2.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "2.1.2"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "6.0.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", branch: "pr-releases/pr-992"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "4.2.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1204167627774280/1207810982214900/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/3078
macOS PR:  https://github.com/duckduckgo/macos-browser/pull/2957

What kind of version bump will this require?: Minor

**Description**:
Update C-S-S to correctly send DuckPlayer pixel