### PR TITLE
Remove unused VPN session utilities

### DIFF
--- a/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
+++ b/Sources/NetworkProtection/Session/ConnectionSessionUtilities.swift
@@ -23,60 +23,6 @@ import NetworkExtension
 ///
 public class ConnectionSessionUtilities {
 
-    /// Ideally we should remove these for iOS too.
-    ///
-    /// This has been deprecated in macOS to avoid making multiple calls to
-    /// `NEPacketTunnelProviderManager.loadAllFromPreferences` since it causes notification
-    /// degradation issues over time.  Also, I tried removing this for both platforms, but iOS doesn't have
-    /// good ways to pass the tunnel controller where we need the session.
-    ///
-    /// Ref: https://app.asana.com/0/1203137811378537/1206513608690551/f
-    ///
-    @available(macOS, deprecated: 10.0, message: "Use NetworkProtectionTunnelController.activeSession instead.")
-    public static func activeSession(networkExtensionBundleID: String) async throws -> NETunnelProviderSession? {
-        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-
-        guard let manager = managers.first(where: {
-            ($0.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier == networkExtensionBundleID
-        }) else {
-            // No active connection, this is acceptable
-            return nil
-        }
-
-        guard let session = manager.connection as? NETunnelProviderSession else {
-            // The active connection is not running, so there's no session, this is acceptable
-            return nil
-        }
-
-        return session
-    }
-
-    /// Ideally we should remove these for iOS too.
-    ///
-    /// This has been deprecated in macOS to avoid making multiple calls to
-    /// `NEPacketTunnelProviderManager.loadAllFromPreferences` since it causes notification
-    /// degradation issues over time.  Also, I tried removing this for both platforms, but iOS doesn't have
-    /// good ways to pass the tunnel controller where we need the session.
-    ///
-    /// Ref: https://app.asana.com/0/1203137811378537/1206513608690551/f
-    ///
-    @available(macOS, deprecated: 10.0, message: "Use NetworkProtectionTunnelController.activeSession instead.")
-    public static func activeSession() async throws -> NETunnelProviderSession? {
-        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-
-        guard let manager = managers.first else {
-            // No active connection, this is acceptable
-            return nil
-        }
-
-        guard let session = manager.connection as? NETunnelProviderSession else {
-            // The active connection is not running, so there's no session, this is acceptable
-            return nil
-        }
-
-        return session
-    }
-
     /// Retrieves a session from a `NEVPNStatusDidChange` notification.
     ///
     public static func session(from notification: Notification) -> NETunnelProviderSession? {
@@ -87,6 +33,7 @@ public class ConnectionSessionUtilities {
 
         return session
     }
+
 }
 
 public extension NETunnelProviderSession {

--- a/Sources/NetworkProtectionTestUtils/Controllers/MockTunnelController.swift
+++ b/Sources/NetworkProtectionTestUtils/Controllers/MockTunnelController.swift
@@ -17,9 +17,11 @@
 //
 
 import Foundation
+import NetworkExtension
 import NetworkProtection
 
-public final class MockTunnelController: TunnelController {
+public final class MockTunnelController: TunnelController, TunnelSessionProvider {
+
     public init() {}
 
     public var didCallStart = false
@@ -35,4 +37,9 @@ public final class MockTunnelController: TunnelController {
     public var isConnected: Bool {
         true
     }
+
+    public func activeSession() async -> NETunnelProviderSession? {
+        return nil
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/72649045549333/1207151621945908/f
iOS PR: TODO
macOS PR: TODO
What kind of version bump will this require?: Major

**Description**:

This PR removes connection utilities that haven't been used on macOS for a while, but were still used on iOS. These are now unused on iOS as well, so they're being removed.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
