### PR TITLE
Attach params to PPro pixels

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -49,6 +49,7 @@ public enum PrivacyFeature: String {
     case brokenSiteReportExperiment
     case toggleReports
     case remoteMessaging
+    case additionalCampaignPixelParams
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414235014887631/1207759380490241/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3092
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2990
What kind of version bump will this require?: Major

**Optional**:

Tech Design URL: https://app.asana.com/0/481882893211075/1207760245011173/f
CC:

**Description**:

Attach a randomized subset of parameters to certain PPro pixels.

**Steps to test this PR**:
1. Use https://www.jsonblob.com/api/1263251505917321216 for the remote config
1. Use https://www.jsonblob.com/api/1263231573443862528 for the remote message test
2. Make sure that pixels are fired with randomized subset of params, and that the params are calculated correctly

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
