### PR TITLE
VPN no longer binds to a fixed listening port

### DIFF
--- a/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
+++ b/Sources/NetworkProtection/NetworkProtectionDeviceManager.swift
@@ -332,7 +332,6 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
                                       addresses: [addressRange],
                                       includedRoutes: includedRoutes,
                                       excludedRoutes: excludedRoutes,
-                                      listenPort: 51821,
                                       dns: dns)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1207825471514017/f

iOS PR: Will integrate this to iOS main once released.  iOS doesn't need this with urgency.
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2992

What kind of version bump will this require?: Patch

## Description

We were specifying a listening port for WireGuard, which is not a good idea for a VPN client both for technical and security reasons.

## Testing

Test using the macOS PR.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
