### PR TITLE
Add support for skipping sending usage pixels for remote messages

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/BrowserServicesKit-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/BrowserServicesKit-Package.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1540"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
@@ -410,6 +410,20 @@
                BlueprintIdentifier = "RemoteMessagingTestsUtils"
                BuildableName = "RemoteMessagingTestsUtils"
                BlueprintName = "RemoteMessagingTestsUtils"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CxxCrashHandler"
+               BuildableName = "CxxCrashHandler"
+               BlueprintName = "CxxCrashHandler"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/SubscriptionTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SubscriptionTests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1540"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/Package.swift
+++ b/Package.swift
@@ -512,6 +512,7 @@ let package = Package(
             resources: [
                 .copy("Resources/remote-messaging-config-example.json"),
                 .copy("Resources/remote-messaging-config-malformed.json"),
+                .copy("Resources/remote-messaging-config-metrics.json"),
                 .copy("Resources/remote-messaging-config-unsupported-items.json"),
                 .copy("Resources/remote-messaging-config.json"),
             ]

--- a/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -93,10 +93,13 @@ struct JsonToRemoteMessageModelMapper {
                 return
             }
 
-            var remoteMessage = RemoteMessageModel(id: message.id,
-                                              content: content,
-                                              matchingRules: message.matchingRules ?? [],
-                                              exclusionRules: message.exclusionRules ?? [])
+            var remoteMessage = RemoteMessageModel(
+                id: message.id,
+                content: content,
+                matchingRules: message.matchingRules ?? [],
+                exclusionRules: message.exclusionRules ?? [],
+                sendPixels: message.sendPixels ?? true
+            )
 
             if let translation = getTranslation(from: message.translations, for: Locale.current) {
                 remoteMessage.localizeContent(translation: translation)

--- a/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -98,7 +98,7 @@ struct JsonToRemoteMessageModelMapper {
                 content: content,
                 matchingRules: message.matchingRules ?? [],
                 exclusionRules: message.exclusionRules ?? [],
-                sendPixels: message.sendPixels ?? true
+                isMetricsEnabled: message.isMetricsEnabled
             )
 
             if let translation = getTranslation(from: message.translations, for: Locale.current) {

--- a/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
+++ b/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
@@ -31,6 +31,7 @@ public enum RemoteMessageResponse {
         let content: JsonContent
         let translations: [String: JsonContentTranslation]?
         let matchingRules, exclusionRules: [Int]?
+        let sendPixels: Bool?
 
         static func == (lhs: JsonRemoteMessage, rhs: JsonRemoteMessage) -> Bool {
             return lhs.id == rhs.id

--- a/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
+++ b/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
@@ -31,10 +31,23 @@ public enum RemoteMessageResponse {
         let content: JsonContent
         let translations: [String: JsonContentTranslation]?
         let matchingRules, exclusionRules: [Int]?
-        let sendPixels: Bool?
+        let metrics: JsonMetrics?
 
         static func == (lhs: JsonRemoteMessage, rhs: JsonRemoteMessage) -> Bool {
             return lhs.id == rhs.id
+        }
+
+        var isMetricsEnabled: Bool {
+            metrics?.state.flatMap(JsonMetrics.MetricsState.init) != .disabled
+        }
+    }
+
+    struct JsonMetrics: Decodable {
+        let state: String?
+
+        enum MetricsState: String, Decodable {
+            case disabled
+            case enabled
         }
     }
 

--- a/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -51,15 +51,6 @@ public struct RemoteMessageModel: Equatable, Codable {
         self.isMetricsEnabled = try container.decodeIfPresent(Bool.self, forKey: .isMetricsEnabled) ?? true
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.id, forKey: .id)
-        try container.encodeIfPresent(self.content, forKey: .content)
-        try container.encode(self.matchingRules, forKey: .matchingRules)
-        try container.encode(self.exclusionRules, forKey: .exclusionRules)
-        try container.encode(self.isMetricsEnabled, forKey: .isMetricsEnabled)
-    }
-
     mutating func localizeContent(translation: RemoteMessageResponse.JsonContentTranslation) {
         guard let content = content else {
             return

--- a/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -24,14 +24,14 @@ public struct RemoteMessageModel: Equatable, Codable {
     public var content: RemoteMessageModelType?
     public let matchingRules: [Int]
     public let exclusionRules: [Int]
-    public let sendPixels: Bool
+    public let isMetricsEnabled: Bool
 
-    public init(id: String, content: RemoteMessageModelType?, matchingRules: [Int], exclusionRules: [Int], sendPixels: Bool) {
+    public init(id: String, content: RemoteMessageModelType?, matchingRules: [Int], exclusionRules: [Int], isMetricsEnabled: Bool) {
         self.id = id
         self.content = content
         self.matchingRules = matchingRules
         self.exclusionRules = exclusionRules
-        self.sendPixels = sendPixels
+        self.isMetricsEnabled = isMetricsEnabled
     }
 
     enum CodingKeys: CodingKey {
@@ -39,7 +39,7 @@ public struct RemoteMessageModel: Equatable, Codable {
         case content
         case matchingRules
         case exclusionRules
-        case sendPixels
+        case isMetricsEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -48,7 +48,7 @@ public struct RemoteMessageModel: Equatable, Codable {
         self.content = try container.decodeIfPresent(RemoteMessageModelType.self, forKey: .content)
         self.matchingRules = try container.decode([Int].self, forKey: .matchingRules)
         self.exclusionRules = try container.decode([Int].self, forKey: .exclusionRules)
-        self.sendPixels = try container.decodeIfPresent(Bool.self, forKey: .sendPixels) ?? true
+        self.isMetricsEnabled = try container.decodeIfPresent(Bool.self, forKey: .isMetricsEnabled) ?? true
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -57,7 +57,7 @@ public struct RemoteMessageModel: Equatable, Codable {
         try container.encodeIfPresent(self.content, forKey: .content)
         try container.encode(self.matchingRules, forKey: .matchingRules)
         try container.encode(self.exclusionRules, forKey: .exclusionRules)
-        try container.encode(self.sendPixels, forKey: .sendPixels)
+        try container.encode(self.isMetricsEnabled, forKey: .isMetricsEnabled)
     }
 
     mutating func localizeContent(translation: RemoteMessageResponse.JsonContentTranslation) {

--- a/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -24,28 +24,40 @@ public struct RemoteMessageModel: Equatable, Codable {
     public var content: RemoteMessageModelType?
     public let matchingRules: [Int]
     public let exclusionRules: [Int]
+    public let sendPixels: Bool
 
-    public init(id: String, content: RemoteMessageModelType?, matchingRules: [Int], exclusionRules: [Int]) {
+    public init(id: String, content: RemoteMessageModelType?, matchingRules: [Int], exclusionRules: [Int], sendPixels: Bool) {
         self.id = id
         self.content = content
         self.matchingRules = matchingRules
         self.exclusionRules = exclusionRules
+        self.sendPixels = sendPixels
     }
 
-    public static func == (lhs: RemoteMessageModel, rhs: RemoteMessageModel) -> Bool {
-        if lhs.id != rhs.id {
-            return false
-        }
-        if lhs.content != rhs.content {
-            return false
-        }
-        if lhs.matchingRules != rhs.matchingRules {
-            return false
-        }
-        if lhs.exclusionRules != rhs.exclusionRules {
-            return false
-        }
-        return true
+    enum CodingKeys: CodingKey {
+        case id
+        case content
+        case matchingRules
+        case exclusionRules
+        case sendPixels
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.content = try container.decodeIfPresent(RemoteMessageModelType.self, forKey: .content)
+        self.matchingRules = try container.decode([Int].self, forKey: .matchingRules)
+        self.exclusionRules = try container.decode([Int].self, forKey: .exclusionRules)
+        self.sendPixels = try container.decodeIfPresent(Bool.self, forKey: .sendPixels) ?? true
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encodeIfPresent(self.content, forKey: .content)
+        try container.encode(self.matchingRules, forKey: .matchingRules)
+        try container.encode(self.exclusionRules, forKey: .exclusionRules)
+        try container.encode(self.sendPixels, forKey: .sendPixels)
     }
 
     mutating func localizeContent(translation: RemoteMessageResponse.JsonContentTranslation) {

--- a/Sources/RemoteMessaging/RemoteMessagingStore.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingStore.swift
@@ -226,7 +226,13 @@ extension RemoteMessagingStore {
                     continue
                 }
 
-                scheduledRemoteMessage = RemoteMessageModel(id: id, content: remoteMessage.content, matchingRules: [], exclusionRules: [])
+                scheduledRemoteMessage = RemoteMessageModel(
+                    id: id,
+                    content: remoteMessage.content,
+                    matchingRules: [],
+                    exclusionRules: [],
+                    sendPixels: remoteMessage.sendPixels
+                )
                 break
             }
         }
@@ -255,7 +261,13 @@ extension RemoteMessagingStore {
                     continue
                 }
 
-                remoteMessage = RemoteMessageModel(id: id, content: remoteMessageMapped.content, matchingRules: [], exclusionRules: [])
+                remoteMessage = RemoteMessageModel(
+                    id: id,
+                    content: remoteMessageMapped.content,
+                    matchingRules: [],
+                    exclusionRules: [],
+                    sendPixels: remoteMessageMapped.sendPixels
+                )
                 break
             }
         }

--- a/Sources/RemoteMessaging/RemoteMessagingStore.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingStore.swift
@@ -231,7 +231,7 @@ extension RemoteMessagingStore {
                     content: remoteMessage.content,
                     matchingRules: [],
                     exclusionRules: [],
-                    sendPixels: remoteMessage.sendPixels
+                    isMetricsEnabled: remoteMessage.isMetricsEnabled
                 )
                 break
             }
@@ -266,7 +266,7 @@ extension RemoteMessagingStore {
                     content: remoteMessageMapped.content,
                     matchingRules: [],
                     exclusionRules: [],
-                    sendPixels: remoteMessageMapped.sendPixels
+                    isMetricsEnabled: remoteMessageMapped.isMetricsEnabled
                 )
                 break
             }

--- a/Tests/RemoteMessagingTests/Mappers/JsonToRemoteConfigModelMapperTests.swift
+++ b/Tests/RemoteMessagingTests/Mappers/JsonToRemoteConfigModelMapperTests.swift
@@ -31,7 +31,8 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
                 content: .bigSingleAction(titleText: "title", descriptionText: "description", placeholder: .announce,
                                           primaryActionText: "Ok", primaryAction: .url(value: "https://duckduckgo.com")),
                 matchingRules: [],
-                exclusionRules: [])
+                exclusionRules: [],
+                isMetricsEnabled: true)
         )
 
         XCTAssertEqual(config.messages[1], RemoteMessageModel(
@@ -39,21 +40,24 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
                 content: .bigSingleAction(titleText: "Kedvenc hozzáadása", descriptionText: "Kedvenc eltávolítása", placeholder: .ddgAnnounce,
                                           primaryActionText: "Ok", primaryAction: .url(value: "https://duckduckgo.com")),
                 matchingRules: [],
-                exclusionRules: [])
+                exclusionRules: [],
+                isMetricsEnabled: true)
         )
 
         XCTAssertEqual(config.messages[2], RemoteMessageModel(
                 id: "26780792-49fe-4e25-ae27-aa6a2e6f013b",
                 content: .small(titleText: "Here goes a title", descriptionText: "description"),
                 matchingRules: [5, 6],
-                exclusionRules: [7, 8, 9])
+                exclusionRules: [7, 8, 9],
+                isMetricsEnabled: true)
         )
 
         XCTAssertEqual(config.messages[3], RemoteMessageModel(
                 id: "c3549d64-b388-41d8-9649-33e6e2674e8e",
                 content: .medium(titleText: "Here goes a title", descriptionText: "description", placeholder: .criticalUpdate),
                 matchingRules: [],
-                exclusionRules: [])
+                exclusionRules: [],
+                isMetricsEnabled: true)
         )
 
         XCTAssertEqual(config.messages[4], RemoteMessageModel(
@@ -62,7 +66,8 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
                                        primaryActionText: "Ok", primaryAction: .appStore,
                                        secondaryActionText: "Cancel", secondaryAction: .dismiss),
                 matchingRules: [],
-                exclusionRules: [])
+                exclusionRules: [],
+                isMetricsEnabled: true)
         )
 
         XCTAssertEqual(config.messages[5], RemoteMessageModel(
@@ -72,7 +77,8 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
                                                                                   title: "Share Title"),
                                    secondaryActionText: "Cancel", secondaryAction: .dismiss),
             matchingRules: [],
-            exclusionRules: [])
+            exclusionRules: [],
+            isMetricsEnabled: true)
         )
 
         XCTAssertEqual(config.messages[6], RemoteMessageModel(
@@ -80,7 +86,8 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
             content: .promoSingleAction(titleText: "Promo Title", descriptionText: "Promo Description", placeholder: .newForMacAndWindows,
                                         actionText: "Promo Action", action: .dismiss),
             matchingRules: [],
-            exclusionRules: [])
+            exclusionRules: [],
+            isMetricsEnabled: true)
         )
 
         XCTAssertEqual(config.messages[7], RemoteMessageModel(
@@ -93,7 +100,8 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
                 action: .survey(value: "https://duckduckgo.com/survey")
             ),
             matchingRules: [8],
-            exclusionRules: [])
+            exclusionRules: [],
+            isMetricsEnabled: true)
         )
 
     }
@@ -223,6 +231,43 @@ class JsonToRemoteConfigModelMapperTests: XCTestCase {
         XCTAssertEqual(rule6?.attributes.filter { $0 is LocaleMatchingAttribute }.count, 1)
         XCTAssertEqual(rule6?.attributes.filter { $0 is OSMatchingAttribute }.count, 1)
         XCTAssertEqual(rule6?.attributes.filter { $0 is UnknownMatchingAttribute }.count, 1)
+    }
+
+    func testThatMetricsAreEnabledWhenStatedInJSONOrMissing() throws {
+        let config = try decodeAndMapJson(fileName: "remote-messaging-config-metrics.json")
+        XCTAssertEqual(config.messages.count, 4)
+
+        XCTAssertEqual(config.messages[0], RemoteMessageModel(
+                id: "1",
+                content: .small(titleText: "title", descriptionText: "description"),
+                matchingRules: [],
+                exclusionRules: [],
+                isMetricsEnabled: true)
+        )
+
+        XCTAssertEqual(config.messages[1], RemoteMessageModel(
+                id: "2",
+                content: .small(titleText: "title", descriptionText: "description"),
+                matchingRules: [],
+                exclusionRules: [],
+                isMetricsEnabled: true)
+        )
+
+        XCTAssertEqual(config.messages[2], RemoteMessageModel(
+                id: "3",
+                content: .small(titleText: "title", descriptionText: "description"),
+                matchingRules: [],
+                exclusionRules: [],
+                isMetricsEnabled: false)
+        )
+
+        XCTAssertEqual(config.messages[3], RemoteMessageModel(
+                id: "4",
+                content: .small(titleText: "title", descriptionText: "description"),
+                matchingRules: [],
+                exclusionRules: [],
+                isMetricsEnabled: true)
+        )
     }
 
     func decodeAndMapJson(fileName: String) throws -> RemoteConfigModel {

--- a/Tests/RemoteMessagingTests/RemoteMessagingConfigMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingConfigMatcherTests.swift
@@ -515,9 +515,10 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
 
     func mediumMessage(id: String = "1", matchingRules: [Int], exclusionRules: [Int]) -> RemoteMessageModel {
         return RemoteMessageModel(id: id,
-                             content: .medium(titleText: "title", descriptionText: "description", placeholder: .announce),
-                             matchingRules: matchingRules,
-                             exclusionRules: exclusionRules
+                                  content: .medium(titleText: "title", descriptionText: "description", placeholder: .announce),
+                                  matchingRules: matchingRules,
+                                  exclusionRules: exclusionRules,
+                                  isMetricsEnabled: true
         )
     }
 }

--- a/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -93,7 +93,7 @@ class RemoteMessagingStoreTests: XCTestCase {
         XCTAssertEqual(config?.version, processorResult.version)
         guard let remoteMessage = store.fetchScheduledRemoteMessage() else {
             XCTFail("No remote message found")
-            return RemoteMessageModel(id: "", content: nil, matchingRules: [], exclusionRules: [])
+            return RemoteMessageModel(id: "", content: nil, matchingRules: [], exclusionRules: [], isMetricsEnabled: true)
         }
 
         XCTAssertNotNil(remoteMessage)

--- a/Tests/RemoteMessagingTests/Resources/remote-messaging-config-metrics.json
+++ b/Tests/RemoteMessagingTests/Resources/remote-messaging-config-metrics.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "messages": [
+    {
+      "id": "1",
+      "content": {
+        "messageType": "small",
+        "titleText": "title",
+        "descriptionText": "description"
+      }
+    },
+    {
+      "id": "2",
+      "content": {
+        "messageType": "small",
+        "titleText": "title",
+        "descriptionText": "description"
+      },
+      "metrics": {
+        "state": "enabled"
+      }
+    },
+    {
+      "id": "3",
+      "content": {
+        "messageType": "small",
+        "titleText": "title",
+        "descriptionText": "description"
+      },
+      "metrics": {
+        "state": "disabled"
+      }
+    },
+    {
+      "id": "4",
+      "content": {
+        "messageType": "small",
+        "titleText": "title",
+        "descriptionText": "description"
+      },
+      "metrics": {
+        "state": "unsupported-value"
+      }
+    }
+  ],
+  "rules": []
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201621708115095/1207841204698435/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3106
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2994
What kind of version bump will this require?: Major

**Description**:
This change allows to skip sending usage pixels for a given remote message if that's stated in the RMF config.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
For both iOS and macOS apps:
1. Replace config URL in RemoteMessagingClient.swift with `https://www.jsonblob.com/api/1263462242434539520`. This config contains 4 messages: 1, 2, and 4 send pixels, and 3 has pixels disabled.
2. Run the app from Xcode. If on macOS, set internal user state and restart the app before proceeding.
3. Launch the app again and observe the logs (Pixel logs are enabled by default on both apps).
4. Verify that shown and shown unique pixel is fired for message 1
5. Dismiss message 1
6. Verify that message dismissed pixel was sent for message 1
7. Restart the app.
8. Verify steps 4-6 for message 2
9. Restart the app
10. Verify that no pixels are sent for message 3
11. Restart the app
12. Verify steps 4-6 for message 4
13. You can reset remote messages (to restart config parsing) on macOS via Main Menu -> Debug -> Reset Data -> Reset Remote Messages, or on iOS via Debug Menu -> Remote Messages -> Delete All.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
