### PR TITLE
Add attribute for checking for deprecated Mac remote message interaction

### DIFF
--- a/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -43,6 +43,7 @@ private enum AttributesKey: String, CaseIterable {
     case pproPurchasePlatform
     case pproSubscriptionStatus
     case interactedWithMessage
+    case interactedWithDeprecatedMacRemoteMessage
     case installedMacAppStore
     case pinnedTabs
     case customHomePage
@@ -74,6 +75,9 @@ private enum AttributesKey: String, CaseIterable {
         case .pproPurchasePlatform: return PrivacyProPurchasePlatformMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .pproSubscriptionStatus: return PrivacyProSubscriptionStatusMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .interactedWithMessage: return InteractedWithMessageMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
+        case .interactedWithDeprecatedMacRemoteMessage: return InteractedWithDeprecatedMacRemoteMessageMatchingAttribute(
+            jsonMatchingAttribute: jsonMatchingAttribute
+        )
         case .installedMacAppStore: return IsInstalledMacAppStoreMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .pinnedTabs: return PinnedTabsMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .customHomePage: return CustomHomePageMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)

--- a/Sources/RemoteMessaging/Matchers/UserAttributeMatcher.swift
+++ b/Sources/RemoteMessaging/Matchers/UserAttributeMatcher.swift
@@ -94,6 +94,7 @@ public struct DesktopUserAttributeMatcher: AttributeMatching {
     private let hasCustomHomePage: Bool
     private let isDuckPlayerOnboarded: Bool
     private let isDuckPlayerEnabled: Bool
+    private let dismissedDeprecatedMacRemoteMessageIds: [String]
 
     private let commonUserAttributeMatcher: CommonUserAttributeMatcher
 
@@ -116,12 +117,14 @@ public struct DesktopUserAttributeMatcher: AttributeMatching {
                 pinnedTabsCount: Int,
                 hasCustomHomePage: Bool,
                 isDuckPlayerOnboarded: Bool,
-                isDuckPlayerEnabled: Bool
+                isDuckPlayerEnabled: Bool,
+                dismissedDeprecatedMacRemoteMessageIds: [String]
     ) {
         self.pinnedTabsCount = pinnedTabsCount
         self.hasCustomHomePage = hasCustomHomePage
         self.isDuckPlayerOnboarded = isDuckPlayerOnboarded
         self.isDuckPlayerEnabled = isDuckPlayerEnabled
+        self.dismissedDeprecatedMacRemoteMessageIds = dismissedDeprecatedMacRemoteMessageIds
 
         commonUserAttributeMatcher = .init(
             statisticsStore: statisticsStore,
@@ -153,6 +156,14 @@ public struct DesktopUserAttributeMatcher: AttributeMatching {
             return matchingAttribute.evaluate(for: isDuckPlayerOnboarded)
         case let matchingAttribute as DuckPlayerEnabledMatchingAttribute:
             return matchingAttribute.evaluate(for: isDuckPlayerEnabled)
+        case let matchingAttribute as InteractedWithDeprecatedMacRemoteMessageMatchingAttribute:
+            if dismissedDeprecatedMacRemoteMessageIds.contains(where: { messageId in
+                StringArrayMatchingAttribute(matchingAttribute.value).matches(value: messageId) == .match
+            }) {
+                return .match
+            } else {
+                return .fail
+            }
         default:
             return commonUserAttributeMatcher.evaluate(matchingAttribute: matchingAttribute)
         }

--- a/Sources/RemoteMessaging/Model/MatchingAttributes.swift
+++ b/Sources/RemoteMessaging/Model/MatchingAttributes.swift
@@ -159,6 +159,11 @@ struct InteractedWithMessageMatchingAttribute: SingleValueMatching {
     var fallback: Bool?
 }
 
+struct InteractedWithDeprecatedMacRemoteMessageMatchingAttribute: SingleValueMatching {
+    var value: [String]? = []
+    var fallback: Bool?
+}
+
 struct IsInstalledMacAppStoreMatchingAttribute: SingleValueMatching {
     var value: Bool?
     var fallback: Bool?

--- a/Tests/RemoteMessagingTests/Matchers/DesktopUserAttributeMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/Matchers/DesktopUserAttributeMatcherTests.swift
@@ -51,7 +51,7 @@ class DesktopUserAttributeMatcherTests: XCTestCase {
         emailManagerStorage.mockToken = "token"
 
         emailManager = EmailManager(storage: emailManagerStorage)
-        setUpUserAttributeMatcher()
+        setUpUserAttributeMatcher(dismissedDeprecatedMacRemoteMessageIds: ["dismissed-message"])
     }
 
     override func tearDownWithError() throws {
@@ -133,9 +133,37 @@ class DesktopUserAttributeMatcherTests: XCTestCase {
                        .fail)
     }
 
+    // MARK: - DeprecatedMacRemoteMessage
+
+    func testWhenNoDismissedMessageIdsAreProvidedThenReturnFail() throws {
+        XCTAssertEqual(matcher.evaluate(
+            matchingAttribute: InteractedWithDeprecatedMacRemoteMessageMatchingAttribute(value: [], fallback: nil)
+        ), .fail)
+    }
+
+    func testWhenNoDismissedMessageIdsMatchThenReturnFail() throws {
+        XCTAssertEqual(matcher.evaluate(
+            matchingAttribute: InteractedWithDeprecatedMacRemoteMessageMatchingAttribute(value: ["unrelated-message"], fallback: nil)
+        ), .fail)
+    }
+
+    func testWhenOneDismissedMessageIdMatchesThenReturnMatch() throws {
+        XCTAssertEqual(matcher.evaluate(
+            matchingAttribute: InteractedWithDeprecatedMacRemoteMessageMatchingAttribute(value: ["dismissed-message"], fallback: nil)
+        ), .match)
+    }
+
+    func testWhenTwoDismissedMessageIdsMatchThenReturnMatch() throws {
+        XCTAssertEqual(matcher.evaluate(
+            matchingAttribute: InteractedWithDeprecatedMacRemoteMessageMatchingAttribute(value: [
+                "dismissed-message", "unrelated-message"
+            ], fallback: nil)
+        ), .match)
+    }
+
     // MARK: -
 
-    private func setUpUserAttributeMatcher(dismissedMessageIds: [String] = []) {
+    private func setUpUserAttributeMatcher(dismissedMessageIds: [String] = [], dismissedDeprecatedMacRemoteMessageIds: [String] = []) {
         matcher = DesktopUserAttributeMatcher(
             statisticsStore: mockStatisticsStore,
             variantManager: manager,
@@ -156,7 +184,8 @@ class DesktopUserAttributeMatcherTests: XCTestCase {
             pinnedTabsCount: 3,
             hasCustomHomePage: true,
             isDuckPlayerOnboarded: true,
-            isDuckPlayerEnabled: false
+            isDuckPlayerEnabled: false,
+            dismissedDeprecatedMacRemoteMessageIds: dismissedDeprecatedMacRemoteMessageIds
         )
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199333091098016/1207851439577905/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3107
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2995
What kind of version bump will this require?: Major

**Optional**:

Tech Design URL:
CC:

**Description**:

This PR adds a new attribute which can check whether a user interacted with a given remote message via the deprecated messaging system on macOS.

This new attribute is a clone of the `interactedWithMessage` attribute, except we provide a different array. I considered simply appending the deprecated message IDs to the array we pass to `interactedWithMessage`, but would prefer to keep the arrays distinct in case of reused IDs between the two.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check that tests pass and verify the correct behaviour

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
