### PR TITLE
fix index out-of-bounds in startAttachingCrashLogMessages

### DIFF
--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -120,7 +120,11 @@ public final class CrashCollection {
                 objCexceptionReason["stackTrace"] = stackTrace
                 diagnosticMetaDataDict["objectiveCexceptionReason"] = objCexceptionReason
                 crashDiagnosticsDict["diagnosticMetaData"] = diagnosticMetaDataDict
-                crashDiagnostics[0] = crashDiagnosticsDict
+                if crashDiagnostics.isEmpty {
+                    crashDiagnostics = [crashDiagnosticsDict]
+                } else {
+                    crashDiagnostics[0] = crashDiagnosticsDict
+                }
                 dict["crashDiagnostics"] = crashDiagnostics
 
                 guard JSONSerialization.isValidJSONObject(dict) else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207877553454228/f
iOS PR: 
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3006
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
- Fixes Out-of-bounds exception when no records in `crashDiagnostics` array 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Simulate a crash in App Store target with debugger detached
2. Set a breakpoint at `CrashCollection.swift:122` and remove items from `crashDiagnostics` array (using LLDB: `po crashDiagnostics.removeAll()`)
3. validate the code is not crashing when adding a record to the array

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
