### PR TITLE
Improve CrashLogMessageExtractor memory safety

### DIFF
--- a/Sources/Common/Extensions/StringExtension.swift
+++ b/Sources/Common/Extensions/StringExtension.swift
@@ -30,7 +30,7 @@ extension RegEx {
     // from https://stackoverflow.com/a/25717506/73479
     static let hostName = regex("^(((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)*[A-Za-z0-9-]{2,63})$", .caseInsensitive)
 
-    static let email = regex(#"[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*@[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)+"#)
+    static let email = regex(#"[^\s]+@[^\s]+\.[^\s]+"#)
 }
 
 // Use this instead of NSLocalizedString for strings that are not supposed to be translated
@@ -99,7 +99,8 @@ public extension String {
 
     // clean-up file paths and email addresses
     func sanitized() -> String {
-        var message = self
+        // clean-up emails
+        var message = self.replacing(RegEx.email, with: "<removed>")
 
         // find all the substring ranges looking like a file path
         let pathRanges = message.rangesOfFilePaths()
@@ -131,9 +132,6 @@ public extension String {
                 }
             }
         }
-
-        // clean-up emails
-        message = message.replacing(RegEx.email, with: "<removed>")
 
         return message
     }

--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -55,6 +55,12 @@ public final class CrashCollection {
         }, didFindCrashReports: didFindCrashReports)
     }
 
+    /// Start `MXDiagnostic` (App Store) crash processing with callbacks called when crash data is found
+    /// - Parameters:
+    ///   - process: callback preprocessing `MXDiagnosticPayload` Array and returning processed JSON Data Array to be uploaded
+    ///   - didFindCrashReports: callback called after payload preprocessing is finished.
+    ///     Provides processed JSON data to be presented to the user and Pixel parameters to fire a crash Pixel.
+    ///     `uploadReports` callback is used when the user accepts uploading the crash report and starts crash upload to the server.
     public func start(process: @escaping ([MXDiagnosticPayload]) -> [Data], didFindCrashReports: @escaping (_ pixelParameters: [[String: String]], _ payloads: [Data], _ uploadReports: @escaping () -> Void) -> Void) {
         let first = isFirstCrash
         isFirstCrash = false
@@ -89,6 +95,12 @@ public final class CrashCollection {
         MXMetricManager.shared.add(crashHandler)
     }
 
+    /// Start `MXDiagnostic` (App Store) crash processing with `didFindCrashReports` callback called when crash data is found and processed.
+    /// This method collects additional NSException/C++ exception data (message and stack trace) saved by `CrashLogMessageExtractor` and attaches it to payloads.
+    /// - Parameters:
+    ///   - didFindCrashReports: callback called after payload preprocessing is finished.
+    ///     Provides processed JSON data to be presented to the user and Pixel parameters to fire a crash Pixel.
+    ///     `uploadReports` callback is used when the user accepts uploading the crash report and starts crash upload to the server.
     public func startAttachingCrashLogMessages(didFindCrashReports: @escaping (_ pixelParameters: [[String: String]], _ payloads: [Data], _ uploadReports: @escaping () -> Void) -> Void) {
         start(process: { payloads in
             payloads.compactMap { payload in
@@ -98,6 +110,9 @@ public final class CrashCollection {
                 if #available(macOS 14.0, iOS 17.0, *) {
                     pid = payload.crashDiagnostics?.first?.metaData.pid
                 }
+                // The `MXDiagnostic` payload may not include `crashDiagnostics`, but may instead contain `cpuExceptionDiagnostics`,
+                // `diskWriteExceptionDiagnostics`, or `hangDiagnostics`.
+                // For now, we are ignoring these.
                 if var crashDiagnostics = dict["crashDiagnostics"] as? [[AnyHashable: Any]], !crashDiagnostics.isEmpty {
                     var crashDiagnosticsDict = crashDiagnostics[0]
                     var diagnosticMetaDataDict = crashDiagnosticsDict["diagnosticMetaData"] as? [AnyHashable: Any] ?? [:]
@@ -106,16 +121,44 @@ public final class CrashCollection {
                     var exceptionMessage = (objCexceptionReason["composedMessage"] as? String)?.sanitized()
                     var stackTrace: [String]?
 
-                    // append crash log message if loaded
+                    // Look up for NSException/C++ exception diagnostics data (name, reason, `userInfo` dictionary, stack trace)
+                    // by searching for the related crash diagnostics file using the provided crash event timestamp and/or the crashed process PID.
+                    // The stored data was sanitized to remove any potential filename or email occurrences.
                     if let diagnostic = try? CrashLogMessageExtractor().crashDiagnostic(for: payload.timeStampBegin, pid: pid)?.diagnosticData(), !diagnostic.isEmpty {
+                        // append the loaded crash diagnostics message if the `MXDiagnostic` already contains one
                         if let existingMessage = exceptionMessage, !existingMessage.isEmpty {
                             exceptionMessage = existingMessage + "\n\n---\n\n" + diagnostic.message
                         } else {
+                            // set the loaded diagnostics message in place of the original `MXDiagnostic` exceptionMessage if none exists
                             exceptionMessage = diagnostic.message
                         }
                         stackTrace = diagnostic.stackTrace
                     }
 
+                    /** Rebuild the original `MXDiagnostic` JSON with appended crash diagnostics:
+                    ```
+                     {
+                       "crashDiagnostics": [
+                         {
+                           "callStackTree": { ... },
+                           "diagnosticMetaData": {
+                             "appVersion": "1.95.0",
+                             "objectiveCexceptionReason": {
+                               "composedMessage": "NSTableViewException: Row index 9223372036854775807 out of row range (numberOfRows: 0)",
+                               "stackTrace": [
+                                 "0   CoreFoundation                      0x00000001930072ec __exceptionPreprocess + 176",
+                                 "1   libobjc.A.dylib                     0x0000000192aee788 objc_exception_throw + 60",
+                                 "2   AppKit                              0x00000001968dc20c -[NSTableRowData _availableRowViewWhileUpdatingAtRow:] + 0,",
+                                 ...
+                               ]
+                             },
+                             ...
+                           }
+                         }
+                       ],
+                       "timeStampBegin": "2024-07-05 14:10:00",
+                     }
+                    ``` */
                     objCexceptionReason["composedMessage"] = exceptionMessage
                     objCexceptionReason["stackTrace"] = stackTrace
                     diagnosticMetaDataDict["objectiveCexceptionReason"] = objCexceptionReason

--- a/Sources/Crashes/CrashLogMessageExtractor.swift
+++ b/Sources/Crashes/CrashLogMessageExtractor.swift
@@ -107,7 +107,7 @@ public struct CrashLogMessageExtractor {
     fileprivate static var nextCppTerminateHandler: (() -> Void)!
     fileprivate static var diagnosticsDirectory: URL!
 
-    public static func setUp() {
+    public static func setUp(swapCxaThrow: Bool = true) {
         prepareDiagnosticsDirectory()
 
         // Set unhandled NSException handler
@@ -116,7 +116,9 @@ public struct CrashLogMessageExtractor {
         // Set unhandled C++ exception handler
         nextCppTerminateHandler = SetCxxExceptionTerminateHandler(handleTerminateOnCxxException)
         // Swap C++ `throw` to collect stack trace when throw happens
-        CxaThrowSwapper.swapCxaThrow(with: captureStackTrace)
+        if swapCxaThrow {
+            CxaThrowSwapper.swapCxaThrow(with: captureStackTrace)
+        }
     }
 
     /// create App Support/Diagnostics folder

--- a/Sources/Crashes/CrashLogMessageExtractor.swift
+++ b/Sources/Crashes/CrashLogMessageExtractor.swift
@@ -48,6 +48,7 @@ import Foundation
 /// `applicationSupportDir/Diagnostics/2024-05-20T12:11:33Z-%pid%.log`
 public struct CrashLogMessageExtractor {
 
+    /// Structure representing an NSException/C++ diagnostic data file stored in the `Application Support/Diagnostics` directory.
     public struct CrashDiagnostic {
 
         // ""2024-05-22T08:17:23Z59070.log"
@@ -57,6 +58,8 @@ public struct CrashLogMessageExtractor {
         public let timestamp: Date
         public let pid: pid_t
 
+        /// Failable constructor parsing the provided file name to extract crash timestamp and pid from the provided NSException/C++ diagnostic data file URL.
+        /// - Returns: `nil` if the provided file name doesn’t match the `2024-05-20T12:11:33Z-%pid%.log` format.
         init?(url: URL) {
             let fileName = url.lastPathComponent
 
@@ -77,6 +80,7 @@ public struct CrashLogMessageExtractor {
             self.pid = pid
         }
 
+        /// JSON-codable NSException/C++ diagnostic data container.
         public struct DiagnosticData: Codable {
             public let message: String
             public let stackTrace: [String]
@@ -91,6 +95,7 @@ public struct CrashLogMessageExtractor {
             }
         }
 
+        /// Try reading diagnostic data from the diagnostics file URL.
         public func diagnosticData() throws -> DiagnosticData {
             do {
                 let data = try Data(contentsOf: url)
@@ -107,6 +112,23 @@ public struct CrashLogMessageExtractor {
     fileprivate static var nextCppTerminateHandler: (() -> Void)!
     fileprivate static var diagnosticsDirectory: URL!
 
+    /// Install uncaught NSException and C++ exception handlers.
+    /// - Parameters:
+    ///   - swapCxaThrow: whether the `__cxa_throw` hook should be installed.
+    /// - Note:
+    ///   `__cxa_throw` is a method called under the hood when `throw MyCppException();` is executed.
+    ///   It unwinds the stack to look for a `catch` handler to handle the thrown exception. If the handler can’t
+    ///   be found, `std::terminate` is called, which crashes the app.
+    ///
+    ///   We use the `__cxa_throw` hook (or call it _swizzle_) to record the stack trace of the original place
+    ///   where the exception was thrown and write it to the current NSThread dictionary.
+    ///
+    ///   If the exception causes app termination, we check the NSThread dictionary for the recorded stack trace
+    ///   in our custom `std::terminate` handler that we install using `std::set_terminate` and save
+    ///   the exception message and the stack trace to the _Diagnostics_ directory.
+    ///
+    ///   After the custom `std::terminate` or `NSUncaughtExceptionHandler` is done, we call the
+    ///   original exception handler, which causes the app termination.
     public static func setUp(swapCxaThrow: Bool = true) {
         prepareDiagnosticsDirectory()
 
@@ -148,6 +170,9 @@ public struct CrashLogMessageExtractor {
         self.diagnosticsDirectory = diagnosticsDirectory ?? Self.diagnosticsDirectory ?? self.fileManager.diagnosticsDirectory
     }
 
+    /// Write exception diagnostics as JSON data, including the exception name, reason, and `userInfo` dictionary,
+    /// to `applicationSupportDir/Diagnostics/2024-05-20T12:11:33Z-%pid%.log`.
+    /// - Note: Data sanitization is applied to clean up any potential filename or email occurrences.
     func writeDiagnostic(for exception: NSException) throws {
         // collect exception diagnostics data
         let message = (

--- a/Sources/Crashes/CxaThrowSwapper.swift
+++ b/Sources/Crashes/CxaThrowSwapper.swift
@@ -77,12 +77,14 @@ public struct CxaThrowSwapper {
     public static var log: OSLog = .disabled
 
     fileprivate static var cxaThrowHandler: CxaThrowType?
-    /// Swap C++ `throw` to collect stack trace when throw happens
+    /// Swap `__cxa_throw` (the method called when C++ `throw MyCppException();` is executed) to collect the stack trace when the throw occurs.
+    /// The original exception stack trace is stored in the current NSThread dictionary and used later in the `std::terminate` handler if the exception
+    /// is not caught.
     public static func swapCxaThrow(with handler: CxaThrowType) {
         dispatchPrecondition(condition: .onQueue(.main))
         if cxaThrowHandler == nil {
             // iterate through mach headers loaded in memory and hook `__cxa_throw` method by overwriting its address.
-            // when this function is first registered it is called for once for each image that is currently part of the process.
+            // When this function is first registered, it is called once for each image that is currently part of the process.
             _dyld_register_func_for_add_image(processMachHeader)
         }
         cxaThrowHandler = handler
@@ -119,6 +121,7 @@ private func _processMachHeader(_ header: UnsafePointer<mach_header_64>?, slide:
     let headerInfo = try Dl_info(header)
     os_log(.debug, log: CxaThrowSwapper.log, "processing image %s (%s), slide: %02X", String(cString: headerInfo.dli_fname), header.debugDescription, slide)
 
+    // Lookup for the needed Mach-O loader commands and segments.
     guard let imageMap = ImageMap(header: header, slide: slide) else { throw ProcessingError.imageMap }
 
     try processSegment(imageMap.dataSegment)
@@ -132,17 +135,33 @@ private func _processMachHeader(_ header: UnsafePointer<mach_header_64>?, slide:
 
             try section.pointee.indirectSymbolBindings(slide: slide)?.withTemporaryUnprotectedMemory { indirectSymbolBindings in
                 guard let indirectSymbolIndices = section.pointee.indirectSymbolIndices(indirectSymtab: imageMap.indirectSymtab) else { return }
+                // Iterate symbols in the section of the __DATA or __DATA_CONST segments.
                 for i in 0..<section.pointee.count where indirectSymbolIndices.indices.contains(i) && indirectSymbolBindings.indices.contains(i) {
                     let symtabIndex = indirectSymbolIndices[i]
                     guard !indicesToSkip.contains(symtabIndex),
                           let symbolName = imageMap.symbolName(at: Int(symtabIndex)),
+                          // There were crashes when the String(cString:) constructor was used for some C string pointers,
+                          // which was probably caused by the `0`-terminating character lookup getting out of the `strtab` buffer bounds.
+                          // This implementation matches the original KSCrash code using strcmp (bytewise compare); it doesn’t copy
+                          // the original C String buffer and stops at the first non-matching byte.
+                          // - First, we make sure the string is not empty and is longer than 1 byte.
                           symbolName[0] != 0, symbolName[1] != 0,
+                          // Then we skip the first "_" character and compare.
                           strcmp(symbolName.advanced(by: 1), "__cxa_throw") == 0 else { continue }
 
                     let sectionInfo = try Dl_info(section)
                     os_log(.debug, log: CxaThrowSwapper.log, "found %s: %s", String(cString: symbolName), indirectSymbolBindings[i].debugDescription)
 
+                    // Now that the `__cxa_throw` symbol index is found, the magique begins:
+                    // - We store the original function pointer from the section’s indirect symbol bindings table in the
+                    //   `cxxOriginalThrowFunctions` dictionary by the base address of the section.
+                    // - Since the `__cxa_throw` method is compiler-generated, it is present in each Mach-O binary loaded by the app.
+                    //   That’s why we may need to hook it several times.
                     cxxOriginalThrowFunctions[UnsafeRawPointer(sectionInfo.dli_fbase)] = indirectSymbolBindings[i]
+                    // - Now we overwrite the function pointer directly in the section memory with our custom handler,
+                    //   so the next time `throw Exception();` is called, it will call our handler first. Then
+                    //   we will find the original `__cxa_throw` method using the base address of the section that is
+                    //   passed as the `tinfo` parameter into our custom handler.
                     indirectSymbolBindings[i] = unsafeBitCast(cxaThrowHandler as CxaThrowType, to: UnsafeRawPointer.self)
 
                     break

--- a/Sources/Crashes/Mach-O/Dl_info+dladdr.swift
+++ b/Sources/Crashes/Mach-O/Dl_info+dladdr.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 
+/// Extension for `Dl_info` to initialize the structure from a pointer using `dladdr`.
+/// - Throws: `Error`: If `dladdr` fails to retrieve information, an error is thrown with a description from `dlerror()`.
 extension Dl_info {
 
     struct Error: LocalizedError {

--- a/Sources/Crashes/Mach-O/UnsafeBufferPointer+unprotected.swift
+++ b/Sources/Crashes/Mach-O/UnsafeBufferPointer+unprotected.swift
@@ -30,6 +30,10 @@ extension UnsafeBufferPointer {
         }
     }
 
+    /// Temporarily removes memory protection from the buffer (if needed) and calls the callback with the readable/writable memory buffer.
+    /// Memory protection is restored to the original state afterwards.
+    /// - Returns: Generic callback result.
+    /// - Throws: `MemoryProtectionFailure` error if the memory protection change fails.
     func withTemporaryUnprotectedMemory<Result>(_ body: (_ pointer: UnsafeMutableBufferPointer<Self.Element>) throws -> Result) throws -> Result {
         let protection = try vm_region_basic_info_data_64_t(self.baseAddress!).protection
         let mutableBuffer = UnsafeMutableBufferPointer(mutating: self)

--- a/Sources/Crashes/Mach-O/mach_header+helpers.swift
+++ b/Sources/Crashes/Mach-O/mach_header+helpers.swift
@@ -23,6 +23,7 @@ import MachO
     #error("This code is only compatible with 64-bit architecture. Adjust the Mach Header definitions (like segment_command_64, LC_SEGMENT_64 and others) for current platform")
 #endif
 
+/// Helper to iterate through Mach-O loader commands.
 extension UnsafePointer where Pointee == mach_header_64 {
 
     struct LoadCommands: Sequence {

--- a/Sources/Crashes/Mach-O/section+helpers.swift
+++ b/Sources/Crashes/Mach-O/section+helpers.swift
@@ -29,13 +29,15 @@ extension section_64 {
         Int(self.size / UInt64(MemoryLayout<UnsafeMutableRawPointer?>.size))
     }
 
-    func indirectSymbolIndices(indirectSymtab: UnsafePointer<UInt32>) -> UnsafeBufferPointer<UInt32> {
-        UnsafeBufferPointer(start: indirectSymtab.advanced(by: Int(self.reserved1)), count: self.count)
+    func indirectSymbolIndices(indirectSymtab: UnsafeBufferPointer<UInt32>) -> UnsafeBufferPointer<UInt32>? {
+        let count = min(self.count, indirectSymtab.count - Int(self.reserved1))
+        guard count > 0 else { return nil }
+        return UnsafeBufferPointer(start: indirectSymtab.baseAddress!.advanced(by: Int(self.reserved1)), count: count)
     }
 
-    func indirectSymbolBindings(slide: Int) -> UnsafeBufferPointer<UnsafeRawPointer> {
-        UnsafeRawBufferPointer(start: UnsafeRawPointer(bitPattern: UInt(self.addr))!.advanced(by: slide),
-                               count: Int(self.size)).assumingMemoryBound(to: UnsafeRawPointer.self)
+    func indirectSymbolBindings(slide: Int) -> UnsafeBufferPointer<UnsafeRawPointer>? {
+        guard let ptr = UnsafeRawPointer(bitPattern: UInt(self.addr) + UInt(slide)) else { return nil }
+        return UnsafeRawBufferPointer(start: ptr, count: Int(self.size)).assumingMemoryBound(to: UnsafeRawPointer.self)
     }
 
 }

--- a/Sources/Crashes/Mach-O/vm_region_basic_info_data_64_t+ptr.swift
+++ b/Sources/Crashes/Mach-O/vm_region_basic_info_data_64_t+ptr.swift
@@ -29,6 +29,8 @@ struct KernError: Error, RawRepresentable {
 
 extension vm_region_basic_info_data_64_t {
 
+    /// Initializes `vm_region_basic_info_data_64_t` from a pointer, retrieving memory region information.
+    /// - Throws: `KernError` if the operation fails.
     init(_ ptr: UnsafeRawPointer) throws {
         var size: vm_size_t = 0
         var address = vm_address_t(bitPattern: ptr)

--- a/Tests/CommonTests/Extensions/StringExtensionTests.swift
+++ b/Tests/CommonTests/Extensions/StringExtensionTests.swift
@@ -143,6 +143,10 @@ final class StringExtensionTests: XCTestCase {
         Solution: please the file something.h has to be alone without others include, it has to be present in release letter,
         in order to be included in /var/log/xyz/test. automatically parse /the/file/name
         Other Note: send me an email at admin@duckduckgo.com!
+        Also u can use these addresses: test-one@example.com
+        test_two@example.com, test+three@example.com
+        ,test@example-one.com
+        test@example_one.com.
         The file something. must contain the somethinge.h and not the ecpfmbsd.h because it doesn't contain C operative c in /var/filename.c.
         """.sanitized(), """
         In file included from <removed>,
@@ -150,7 +154,11 @@ final class StringExtensionTests: XCTestCase {
         from test.c: 29:
         Solution: please the file <removed> has to be alone without others include, it has to be present in release letter,
         in order to be included in <removed>. automatically parse <removed>
-        Other Note: send me an email at <removed>!
+        Other Note: send me an email at <removed>
+        Also u can use these addresses: <removed>
+        <removed> <removed>
+        <removed>
+        <removed>
         The file something. must contain the <removed> and not the <removed> because it doesn't contain C operative c in filename.c.
         """)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1207878606354585/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3133
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3011
What kind of version bump will this require?: Minor

**Description**:
- Move memory protection modifier `withTemporaryUnprotectedMemory` earlier, matching https://github.com/kstenerud/KSCrash/blob/master/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c
- Add symbol tables/string table regions boundary checks for safer memory access
- Add `swapCxaThrow` parameter to `CrashLogMessageExtractor.setUp` to allow disabling `__cxa_throw` swapping

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. pass `swapCxaThrow: false` to CrashLogMessageExtractor.setUp
2. detach debugger
3. simulate c++ crash
4. run from debugger
5. validate uploaded reports is generated (without the exception stack trace)
6. Simulate NSException and validate the stack trace is there

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
