### PR TITLE
Keep Remote Messages in database if they were shown

### DIFF
--- a/Sources/RemoteMessaging/CoreData/RemoteMessageUtils.swift
+++ b/Sources/RemoteMessaging/CoreData/RemoteMessageUtils.swift
@@ -1,0 +1,47 @@
+//
+//  RemoteMessageUtils.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import CoreData
+
+struct RemoteMessageUtils {
+    static func fetchRemoteMessage(with id: String, in context: NSManagedObjectContext) -> RemoteMessageManagedObject? {
+        let fetchRequest: NSFetchRequest<RemoteMessageManagedObject> = RemoteMessageManagedObject.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(RemoteMessageManagedObject.id), id)
+        fetchRequest.fetchLimit = 1
+
+        return try? context.fetch(fetchRequest).first
+    }
+
+    static func fetchScheduledRemoteMessage(in context: NSManagedObjectContext) -> RemoteMessageManagedObject? {
+        let fetchRequest: NSFetchRequest<RemoteMessageManagedObject> = RemoteMessageManagedObject.fetchRequest()
+        fetchRequest.predicate = NSPredicate(
+            format: "%K == %i",
+            #keyPath(RemoteMessageManagedObject.status),
+            RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue
+        )
+        fetchRequest.fetchLimit = 1
+
+        return try? context.fetch(fetchRequest).first
+    }
+
+    static func fetchAllRemoteMessages(in context: NSManagedObjectContext) -> [RemoteMessageManagedObject] {
+        let fetchRequest = RemoteMessageManagedObject.fetchRequest()
+        return (try? context.fetch(fetchRequest)) ?? []
+    }
+}

--- a/Sources/RemoteMessaging/CoreData/RemoteMessageUtils.swift
+++ b/Sources/RemoteMessaging/CoreData/RemoteMessageUtils.swift
@@ -1,6 +1,5 @@
 //
 //  RemoteMessageUtils.swift
-//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //

--- a/Sources/RemoteMessaging/RemoteMessagingStore.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingStore.swift
@@ -89,8 +89,9 @@ public final class RemoteMessagingStore: RemoteMessagingStoring {
             if let remoteMessage = processorResult.message {
                 addOrUpdate(remoteMessage: remoteMessage, in: context)
             } else {
-                markScheduledMessagesAsDoneAndDeleteNeverShownMessages(in: context)
+                markScheduledMessagesAsDone(in: context)
             }
+            deleteNotShownDoneMessages(in: context)
 
             do {
                 try context.save()
@@ -111,7 +112,8 @@ public final class RemoteMessagingStore: RemoteMessagingStoring {
 
         context.performAndWait {
             invalidateRemoteMessagingConfigs(in: context)
-            markScheduledMessagesAsDoneAndDeleteNeverShownMessages(in: context)
+            markScheduledMessagesAsDone(in: context)
+            deleteNotShownDoneMessages(in: context)
 
             do {
                 try context.save()
@@ -417,12 +419,6 @@ extension RemoteMessagingStore {
                 remoteMessageManagedObject.shown = false
             }
         }
-        deleteNotShownDoneMessages(in: context)
-    }
-
-    private func markScheduledMessagesAsDoneAndDeleteNeverShownMessages(in context: NSManagedObjectContext) {
-        markScheduledMessagesAsDone(in: context)
-        deleteNotShownDoneMessages(in: context)
     }
 
     private func updateRemoteMessage(withID id: String, toStatus status: RemoteMessageStatus, in context: NSManagedObjectContext) {

--- a/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -82,8 +82,8 @@ class RemoteMessagingStoreTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
-    func saveProcessedResultFetchRemoteMessage() throws -> RemoteMessageModel {
-        let processorResult = try processorResult()
+    func saveProcessedResultFetchRemoteMessage(for configJSON: String? = nil) throws -> RemoteMessageModel {
+        let processorResult = try processorResult(for: configJSON)
         // 1. saveProcessedResult()
         store.saveProcessedResult(processorResult)
 
@@ -140,6 +140,124 @@ class RemoteMessagingStoreTests: XCTestCase {
         let dismissedRemoteMessageIds = store.fetchDismissedRemoteMessageIDs()
         XCTAssertEqual(dismissedRemoteMessageIds.count, 1)
         XCTAssertEqual(dismissedRemoteMessageIds.first, remoteMessage.id)
+    }
+
+    func testConfigUpdateWhenMessageWasShownAndNotInteractedWithThenItIsNotRemovedFromDatabase() throws {
+        let remoteMessage = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+
+        let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+        context.performAndWait {
+            let messages = RemoteMessageUtils.fetchAllRemoteMessages(in: context)
+            XCTAssertEqual(messages.count, 1)
+            let firstMessage = messages.first!
+            XCTAssertTrue(firstMessage.shown)
+            XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
+        }
+
+        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
+
+        context.performAndWait {
+            context.refreshAllObjects()
+            let messages = RemoteMessageUtils.fetchAllRemoteMessages(in: context)
+            XCTAssertEqual(messages.count, 2)
+
+            let firstMessage = messages.first(where: { $0.id == "1" })!
+            XCTAssertTrue(firstMessage.shown)
+            XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.done.rawValue)
+
+            let secondMessage = messages.first(where: { $0.id == "2" })!
+            XCTAssertFalse(secondMessage.shown)
+            XCTAssertEqual(secondMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
+        }
+    }
+
+    func testConfigUpdateWhenMessageWasInteractedWithThenItIsNotRemovedFromDatabase() throws {
+        let remoteMessage = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+        store.dismissRemoteMessage(withID: remoteMessage.id)
+
+        let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+        context.performAndWait {
+            let messages = RemoteMessageUtils.fetchAllRemoteMessages(in: context)
+            XCTAssertEqual(messages.count, 1)
+
+            let firstMessage = messages.first!
+            XCTAssertTrue(firstMessage.shown)
+            XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.dismissed.rawValue)
+        }
+
+        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
+
+        context.performAndWait {
+            context.refreshAllObjects()
+            let messages = RemoteMessageUtils.fetchAllRemoteMessages(in: context)
+            XCTAssertEqual(messages.count, 2)
+
+            let firstMessage = messages.first(where: { $0.id == "1" })!
+            XCTAssertTrue(firstMessage.shown)
+            XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.dismissed.rawValue)
+
+            let secondMessage = messages.first(where: { $0.id == "2" })!
+            XCTAssertFalse(secondMessage.shown)
+            XCTAssertEqual(secondMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
+        }
+    }
+
+    func testConfigUpdateWhenMessageWasNotShownThenItIsRemovedFromDatabase() throws {
+        let remoteMessage = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+
+        let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+        context.performAndWait {
+            let messages = RemoteMessageUtils.fetchAllRemoteMessages(in: context)
+            XCTAssertEqual(messages.count, 1)
+
+            let firstMessage = messages.first!
+            XCTAssertFalse(firstMessage.shown)
+            XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
+        }
+
+        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
+
+        context.performAndWait {
+            context.refreshAllObjects()
+            let messages = RemoteMessageUtils.fetchAllRemoteMessages(in: context)
+            XCTAssertEqual(messages.count, 1)
+
+            let secondMessage = messages.first!
+            XCTAssertEqual(secondMessage.id, "2")
+            XCTAssertFalse(secondMessage.shown)
+            XCTAssertEqual(secondMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
+        }
+    }
+
+    func testConfigUpdateWhenShownAndNotInteractedWithMessageIsReintroducedInNewConfigThenItIsMarkedAsScheduled() throws {
+        let remoteMessage = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+
+        let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+        context.performAndWait {
+            let messages = RemoteMessageUtils.fetchAllRemoteMessages(in: context)
+            XCTAssertEqual(messages.count, 1)
+
+            let firstMessage = messages.first!
+            XCTAssertTrue(firstMessage.shown)
+            XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
+        }
+
+        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
+        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 3, messageID: 1))
+
+        context.performAndWait {
+            context.refreshAllObjects()
+            let messages = RemoteMessageUtils.fetchAllRemoteMessages(in: context)
+            XCTAssertEqual(messages.count, 1)
+
+            let firstMessage = messages.first!
+            XCTAssertEqual(firstMessage.id, "1")
+            XCTAssertTrue(firstMessage.shown) // shown status is preserved
+            XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
+        }
     }
 
     // MARK: - Feature Flag
@@ -274,8 +392,25 @@ class RemoteMessagingStoreTests: XCTestCase {
         return remoteMessagingConfig
     }
 
-    func processorResult() throws -> RemoteMessagingConfigProcessor.ProcessorResult {
-        let jsonRemoteMessagingConfig = try decodeJson(fileName: "remote-messaging-config-example.json")
+    func decodeJson(from jsonString: String) throws -> RemoteMessageResponse.JsonRemoteMessagingConfig {
+        let validJson = jsonString.data(using: .utf8)!
+        let remoteMessagingConfig = try JSONDecoder().decode(RemoteMessageResponse.JsonRemoteMessagingConfig.self, from: validJson)
+        XCTAssertNotNil(remoteMessagingConfig)
+
+        return remoteMessagingConfig
+    }
+
+    func processorResult(for configJSON: String? = nil) throws -> RemoteMessagingConfigProcessor.ProcessorResult {
+        let jsonRemoteMessagingConfig = try {
+            guard let configJSON else {
+                return try decodeJson(fileName: "remote-messaging-config-example.json")
+            }
+            return try decodeJson(from: configJSON)
+        }()
+        return try processorResult(for: jsonRemoteMessagingConfig)
+    }
+
+    func processorResult(for jsonRemoteMessagingConfig: RemoteMessageResponse.JsonRemoteMessagingConfig) throws -> RemoteMessagingConfigProcessor.ProcessorResult {
         let remoteMessagingConfigMatcher = RemoteMessagingConfigMatcher(
                 appAttributeMatcher: MobileAppAttributeMatcher(statisticsStore: MockStatisticsStore(), variantManager: MockVariantManager()),
                 userAttributeMatcher: MobileUserAttributeMatcher(
@@ -312,6 +447,22 @@ class RemoteMessagingStoreTests: XCTestCase {
             XCTFail("Processor result message is nil")
             return RemoteMessagingConfigProcessor.ProcessorResult(version: 0, message: nil)
         }
+    }
+
+    func minimalConfig(version: Int, messageID: Int) -> String {
+        """
+        {
+          "version": \(version),
+          "messages": [
+            {
+              "id": "\(messageID)",
+              "content": { "messageType": "small", "titleText": "title", "descriptionText": "description" },
+              "matchingRules": [], "exclusionRules": []
+            }
+          ],
+          "rules": []
+        }
+        """
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1207619243206445/1207864976004819/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3136
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3012
What kind of version bump will this require?: Major

**Description**:
Update RemoteMessagingStore to keep track of messages that have ever been shown to the user,
also if the user didn't interact with them (by dismissing or clicking any buttons).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
See platform PRs for steps to test.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
