### PR TITLE
Update autofill to 12.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "2b81745565db09eee8c1cd44d38eefa1011a9f0a",
-        "version" : "12.0.1"
+        "revision" : "9fea1c6762db726328b14bb9ebfd6508849eae28",
+        "version" : "12.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         .library(name: "PixelKitTestingUtilities", targets: ["PixelKitTestingUtilities"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "12.0.1"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "12.1.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.3.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "2.1.2"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207920274236438/1207920274236438
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.1.0


## Description
Updates Autofill to version [12.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.1.0).

### Autofill 12.1.0 release notes
## What's Changed
* [Form] Skip autofilling select input if it was changed already by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/580
* scanner: discard Form instances with no classified inputs by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/574
* [Credentials] Autofill when elements are in shadow by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/592
* Update password-related json files (2024-07-19) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/607
* [Scanner] Don't stop scanner fully on max forms by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/617
* tests: remove spurious logging from unit tests by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/575
* Add credit card test form failure by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/588

## New Contributors
* @dbajpeyi made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/580

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/12.0.1...12.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).