### PR TITLE
Add RMF `messageShown` attribute

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
       - name: SwiftLint
         uses: docker://norionomura/swiftlint:0.54.0_swift-5.9.0
         with:
-          args: swiftlint --reporter github-actions-logging --strict
+          args: swiftlint --reporter github-actions-logging --strict --quiet
 
   unit-tests:
 

--- a/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -49,6 +49,7 @@ private enum AttributesKey: String, CaseIterable {
     case customHomePage
     case duckPlayerOnboarded
     case duckPlayerEnabled
+    case messageShown
 
     func matchingAttribute(jsonMatchingAttribute: AnyDecodable) -> MatchingAttribute {
         switch self {
@@ -83,6 +84,7 @@ private enum AttributesKey: String, CaseIterable {
         case .customHomePage: return CustomHomePageMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .duckPlayerOnboarded: return DuckPlayerOnboardedMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .duckPlayerEnabled: return DuckPlayerEnabledMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
+        case .messageShown: return MessageShownMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         }
     }
 }

--- a/Sources/RemoteMessaging/Matchers/UserAttributeMatcher.swift
+++ b/Sources/RemoteMessaging/Matchers/UserAttributeMatcher.swift
@@ -56,7 +56,8 @@ public struct MobileUserAttributeMatcher: AttributeMatching {
                 isPrivacyProSubscriptionExpired: Bool,
                 isDuckPlayerOnboarded: Bool,
                 isDuckPlayerEnabled: Bool,
-                dismissedMessageIds: [String]
+                dismissedMessageIds: [String],
+                shownMessageIds: [String]
     ) {
         self.isWidgetInstalled = isWidgetInstalled
 
@@ -78,7 +79,8 @@ public struct MobileUserAttributeMatcher: AttributeMatching {
             isPrivacyProSubscriptionExpired: isPrivacyProSubscriptionExpired,
             isDuckPlayerOnboarded: isDuckPlayerOnboarded,
             isDuckPlayerEnabled: isDuckPlayerEnabled,
-            dismissedMessageIds: dismissedMessageIds
+            dismissedMessageIds: dismissedMessageIds,
+            shownMessageIds: shownMessageIds
         )
     }
 
@@ -116,6 +118,7 @@ public struct DesktopUserAttributeMatcher: AttributeMatching {
                 isPrivacyProSubscriptionExpiring: Bool,
                 isPrivacyProSubscriptionExpired: Bool,
                 dismissedMessageIds: [String],
+                shownMessageIds: [String],
                 pinnedTabsCount: Int,
                 hasCustomHomePage: Bool,
                 isDuckPlayerOnboarded: Bool,
@@ -144,7 +147,8 @@ public struct DesktopUserAttributeMatcher: AttributeMatching {
             isPrivacyProSubscriptionExpired: isPrivacyProSubscriptionExpired,
             isDuckPlayerOnboarded: isDuckPlayerOnboarded,
             isDuckPlayerEnabled: isDuckPlayerEnabled,
-            dismissedMessageIds: dismissedMessageIds
+            dismissedMessageIds: dismissedMessageIds,
+            shownMessageIds: shownMessageIds
         )
     }
 
@@ -194,6 +198,7 @@ public struct CommonUserAttributeMatcher: AttributeMatching {
     private let isDuckPlayerOnboarded: Bool
     private let isDuckPlayerEnabled: Bool
     private let dismissedMessageIds: [String]
+    private let shownMessageIds: [String]
 
     public init(statisticsStore: StatisticsStore,
                 variantManager: VariantManager,
@@ -212,7 +217,8 @@ public struct CommonUserAttributeMatcher: AttributeMatching {
                 isPrivacyProSubscriptionExpired: Bool,
                 isDuckPlayerOnboarded: Bool,
                 isDuckPlayerEnabled: Bool,
-                dismissedMessageIds: [String]
+                dismissedMessageIds: [String],
+                shownMessageIds: [String]
     ) {
         self.statisticsStore = statisticsStore
         self.variantManager = variantManager
@@ -232,6 +238,7 @@ public struct CommonUserAttributeMatcher: AttributeMatching {
         self.isDuckPlayerOnboarded = isDuckPlayerOnboarded
         self.isDuckPlayerEnabled = isDuckPlayerEnabled
         self.dismissedMessageIds = dismissedMessageIds
+        self.shownMessageIds = shownMessageIds
     }
 
     public func evaluate(matchingAttribute: MatchingAttribute) -> EvaluationResult? {
@@ -282,6 +289,14 @@ public struct CommonUserAttributeMatcher: AttributeMatching {
             return matchingAttribute.evaluate(for: isDuckPlayerEnabled)
         case let matchingAttribute as InteractedWithMessageMatchingAttribute:
             if dismissedMessageIds.contains(where: { messageId in
+                StringArrayMatchingAttribute(matchingAttribute.value).matches(value: messageId) == .match
+            }) {
+                return .match
+            } else {
+                return .fail
+            }
+        case let matchingAttribute as MessageShownMatchingAttribute:
+            if shownMessageIds.contains(where: { messageId in
                 StringArrayMatchingAttribute(matchingAttribute.value).matches(value: messageId) == .match
             }) {
                 return .match

--- a/Sources/RemoteMessaging/Model/MatchingAttributes.swift
+++ b/Sources/RemoteMessaging/Model/MatchingAttributes.swift
@@ -191,6 +191,11 @@ struct DuckPlayerEnabledMatchingAttribute: SingleValueMatching {
     var fallback: Bool?
 }
 
+struct MessageShownMatchingAttribute: SingleValueMatching {
+    var value: [String]? = []
+    var fallback: Bool?
+}
+
 struct UnknownMatchingAttribute: MatchingAttribute, Equatable {
     var fallback: Bool?
 

--- a/Sources/RemoteMessaging/RemoteMessagingStoring.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingStoring.swift
@@ -29,6 +29,7 @@ public protocol RemoteMessagingStoring: RemoteMessagingStoringDebuggingSupport {
     func fetchScheduledRemoteMessage() -> RemoteMessageModel?
     func fetchRemoteMessage(withID id: String) -> RemoteMessageModel?
     func hasShownRemoteMessage(withID id: String) -> Bool
+    func fetchShownRemoteMessageIDs() -> [String]
     func hasDismissedRemoteMessage(withID id: String) -> Bool
     func dismissRemoteMessage(withID id: String)
     func fetchDismissedRemoteMessageIDs() -> [String]

--- a/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
+++ b/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
@@ -26,6 +26,7 @@ public class MockRemoteMessagingStore: RemoteMessagingStoring {
     public var fetchScheduledRemoteMessageCalls = 0
     public var fetchRemoteMessageCalls = 0
     public var hasShownRemoteMessageCalls = 0
+    public var fetchShownRemoteMessageIDsCalls = 0
     public var hasDismissedRemoteMessageCalls = 0
     public var dismissRemoteMessageCalls = 0
     public var fetchDismissedRemoteMessageIDsCalls = 0
@@ -73,6 +74,11 @@ public class MockRemoteMessagingStore: RemoteMessagingStoring {
     public func hasShownRemoteMessage(withID id: String) -> Bool {
         hasShownRemoteMessageCalls += 1
         return shownRemoteMessagesIDs.contains(id)
+    }
+
+    public func fetchShownRemoteMessageIDs() -> [String] {
+        fetchShownRemoteMessageIDsCalls += 1
+        return shownRemoteMessagesIDs
     }
 
     public func hasDismissedRemoteMessage(withID id: String) -> Bool {

--- a/Tests/RemoteMessagingTests/Matchers/CommonUserAttributeMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/Matchers/CommonUserAttributeMatcherTests.swift
@@ -328,8 +328,6 @@ class CommonUserAttributeMatcherTests: XCTestCase {
         ), .fail)
     }
 
-    // TODO
-
     private func setUpUserAttributeMatcher(dismissedMessageIds: [String] = [], shownMessageIds: [String] = []) {
         matcher = CommonUserAttributeMatcher(
             statisticsStore: mockStatisticsStore,

--- a/Tests/RemoteMessagingTests/Matchers/CommonUserAttributeMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/Matchers/CommonUserAttributeMatcherTests.swift
@@ -295,7 +295,42 @@ class CommonUserAttributeMatcherTests: XCTestCase {
         ), .fail)
     }
 
-    private func setUpUserAttributeMatcher(dismissedMessageIds: [String] = []) {
+    func testWhenOneShownMessageIdMatchesThenReturnMatch() throws {
+        setUpUserAttributeMatcher(shownMessageIds: ["1"])
+        XCTAssertEqual(matcher.evaluate(
+            matchingAttribute: MessageShownMatchingAttribute(value: ["1", "2", "3"], fallback: nil)
+        ), .match)
+    }
+
+    func testWhenAllShownMessageIdsMatchThenReturnMatch() throws {
+        setUpUserAttributeMatcher(shownMessageIds: ["1", "2", "3"])
+        XCTAssertEqual(matcher.evaluate(
+            matchingAttribute: MessageShownMatchingAttribute(value: ["1", "2", "3"], fallback: nil)
+        ), .match)
+    }
+
+    func testWhenNoShownMessageIdsMatchThenReturnFail() throws {
+        setUpUserAttributeMatcher(shownMessageIds: ["1", "2", "3"])
+        XCTAssertEqual(matcher.evaluate(
+            matchingAttribute: MessageShownMatchingAttribute(value: ["4", "5"], fallback: nil)
+        ), .fail)
+    }
+
+    func testWhenHaveShownMessageIdsAndMatchAttributeIsEmptyThenReturnFail() throws {
+        setUpUserAttributeMatcher(shownMessageIds: ["1", "2", "3"])
+        XCTAssertEqual(matcher.evaluate(matchingAttribute: MessageShownMatchingAttribute(value: [], fallback: nil)), .fail)
+    }
+
+    func testWhenHaveNoShownMessageIdsAndMatchAttributeIsNotEmptyThenReturnFail() throws {
+        setUpUserAttributeMatcher(shownMessageIds: [])
+        XCTAssertEqual(matcher.evaluate(
+            matchingAttribute: MessageShownMatchingAttribute(value: ["1", "2"], fallback: nil)
+        ), .fail)
+    }
+
+    // TODO
+
+    private func setUpUserAttributeMatcher(dismissedMessageIds: [String] = [], shownMessageIds: [String] = []) {
         matcher = CommonUserAttributeMatcher(
             statisticsStore: mockStatisticsStore,
             variantManager: manager,
@@ -314,7 +349,8 @@ class CommonUserAttributeMatcherTests: XCTestCase {
             isPrivacyProSubscriptionExpired: false,
             isDuckPlayerOnboarded: false,
             isDuckPlayerEnabled: false,
-            dismissedMessageIds: dismissedMessageIds
+            dismissedMessageIds: dismissedMessageIds,
+            shownMessageIds: shownMessageIds
         )
     }
 }

--- a/Tests/RemoteMessagingTests/Matchers/DesktopUserAttributeMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/Matchers/DesktopUserAttributeMatcherTests.swift
@@ -181,6 +181,7 @@ class DesktopUserAttributeMatcherTests: XCTestCase {
             isPrivacyProSubscriptionExpiring: false,
             isPrivacyProSubscriptionExpired: false,
             dismissedMessageIds: dismissedMessageIds,
+            shownMessageIds: [],
             pinnedTabsCount: 3,
             hasCustomHomePage: true,
             isDuckPlayerOnboarded: true,

--- a/Tests/RemoteMessagingTests/Matchers/MobileUserAttributeMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/Matchers/MobileUserAttributeMatcherTests.swift
@@ -92,7 +92,8 @@ class MobileUserAttributeMatcherTests: XCTestCase {
             isPrivacyProSubscriptionExpired: false,
             isDuckPlayerOnboarded: false,
             isDuckPlayerEnabled: false,
-            dismissedMessageIds: dismissedMessageIds
+            dismissedMessageIds: dismissedMessageIds,
+            shownMessageIds: []
         )
     }
 }

--- a/Tests/RemoteMessagingTests/RemoteMessagingConfigMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingConfigMatcherTests.swift
@@ -56,7 +56,8 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: MockRemoteMessagePercentileStore(),
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),
@@ -153,7 +154,8 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: MockRemoteMessagePercentileStore(),
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),
@@ -260,7 +262,8 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: MockRemoteMessagePercentileStore(),
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),
@@ -310,7 +313,8 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: MockRemoteMessagePercentileStore(),
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),
@@ -356,7 +360,8 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: percentileStore,
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),
@@ -400,7 +405,8 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: percentileStore,
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),
@@ -444,7 +450,8 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: percentileStore,
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),
@@ -488,7 +495,8 @@ class RemoteMessagingConfigMatcherTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: percentileStore,
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),

--- a/Tests/RemoteMessagingTests/RemoteMessagingConfigProcessorTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingConfigProcessorTests.swift
@@ -47,7 +47,8 @@ class RemoteMessagingConfigProcessorTests: XCTestCase {
                 isPrivacyProSubscriptionExpired: false,
                 isDuckPlayerOnboarded: false,
                 isDuckPlayerEnabled: false,
-                dismissedMessageIds: []
+                dismissedMessageIds: [],
+                shownMessageIds: []
             ),
             percentileStore: MockRemoteMessagePercentileStore(),
             surveyActionMapper: MockRemoteMessageSurveyActionMapper(),
@@ -89,7 +90,8 @@ class RemoteMessagingConfigProcessorTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: MockRemoteMessagePercentileStore(),
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),

--- a/Tests/RemoteMessagingTests/RemoteMessagingProcessingTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingProcessingTests.swift
@@ -83,7 +83,8 @@ class RemoteMessagingProcessingTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: MockRemoteMessagePercentileStore(),
                 surveyActionMapper: MockRemoteMessageSurveyActionMapper(),

--- a/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -213,7 +213,7 @@ class RemoteMessagingStoreTests: XCTestCase {
     }
 
     func testConfigUpdateWhenMessageWasNotShownThenItIsRemovedFromDatabase() throws {
-        let _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
 
         let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
         context.performAndWait {

--- a/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -118,6 +118,14 @@ class RemoteMessagingStoreTests: XCTestCase {
         XCTAssertFalse(store.hasShownRemoteMessage(withID: remoteMessage.id))
     }
 
+    func testFetchShownRemoteMessageIds() throws {
+        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
+        XCTAssertEqual(store.fetchShownRemoteMessageIDs(), [])
+
+        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+        XCTAssertEqual(store.fetchShownRemoteMessageIDs(), [remoteMessage.id])
+    }
+
     func testWhenDismissRemoteMessageThenFetchedMessageHasDismissedState() throws {
         let remoteMessage = try saveProcessedResultFetchRemoteMessage()
 
@@ -205,7 +213,7 @@ class RemoteMessagingStoreTests: XCTestCase {
     }
 
     func testConfigUpdateWhenMessageWasNotShownThenItIsRemovedFromDatabase() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+        let _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
 
         let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
         context.performAndWait {
@@ -431,7 +439,8 @@ class RemoteMessagingStoreTests: XCTestCase {
                     isPrivacyProSubscriptionExpired: false,
                     isDuckPlayerOnboarded: false,
                     isDuckPlayerEnabled: false,
-                    dismissedMessageIds: []
+                    dismissedMessageIds: [],
+                    shownMessageIds: []
                 ),
                 percentileStore: RemoteMessagingPercentileUserDefaultsStore(keyValueStore: self.defaults),
                 surveyActionMapper: MockRemoteMessagingSurveyActionMapper(),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1199333091098016/1207959177057413/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3176
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3062
What kind of version bump will this require?: Major

**Description**:

This PR adds support for the RMF `messageShown` attribute, which will match against messages which have simply been displayed to the user, without any interaction required.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
