### PR TITLE
Add onForExistingUsers autofill subfeature

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -74,6 +74,7 @@ public enum AutofillSubfeature: String, PrivacySubfeature {
     case autofillPasswordGeneration
     case onByDefault
     case deduplicateLoginsOnImport
+    case onForExistingUsers
 }
 
 public enum DBPSubfeature: String, Equatable, PrivacySubfeature {


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1142021229838617/1207886016598226/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3182
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3071
What kind of version bump will this require?: Major

**Description**:
Adds a PrivacyFeature case for rolling out enabling autofill for existing users

**Steps to test this PR**:
1. See iOS PR/

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
