### PR TITLE
allow to install early user scripts before

### DIFF
--- a/Sources/BrowserServicesKit/ContentScopeScript/UserContentController.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/UserContentController.swift
@@ -113,11 +113,13 @@ final public class UserContentController: WKUserContentController {
     private let scriptMessageHandler = PermanentScriptMessageHandler()
 
     @MainActor
-    public init<Pub, Content>(assetsPublisher: Pub, privacyConfigurationManager: PrivacyConfigurationManaging)
+    public init<Pub, Content>(assetsPublisher: Pub, privacyConfigurationManager: PrivacyConfigurationManaging, earlyAccessHandlers: [UserScript] = [])
     where Pub: Publisher, Content: UserContentControllerNewContent, Pub.Output == Content, Pub.Failure == Never {
 
         self.privacyConfigurationManager = privacyConfigurationManager
         super.init()
+
+        installUserScripts([], handlers: earlyAccessHandlers)
 
         assetsPublisherCancellable = assetsPublisher.sink { [weak self, selfDescr=self.debugDescription] content in
             os_log(.debug, log: .contentBlocking, "\(selfDescr): 📚 received content blocking assets")


### PR DESCRIPTION
…loaded

<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1204186595873227/1207965393294683/f
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Minor

**Optional**: 

Tech Design URL:
CC:

**Description**: allow to install user script before content blocking rules have been loaded

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
