### PR TITLE
VPN now recovers from WireGuard closing utun

### DIFF
--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionError.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionError.swift
@@ -61,6 +61,7 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
     case wireGuardDnsResolution
     case wireGuardSetNetworkSettings(Error)
     case startWireGuardBackend(Int32)
+    case setWireguardConfig(errorCode: Int64)
 
     // Auth errors
     case noAuthTokenFound
@@ -110,6 +111,7 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
         case .wireGuardDnsResolution: return 302
         case .wireGuardSetNetworkSettings: return 303
         case .startWireGuardBackend: return 304
+        case .setWireguardConfig: return 305
             // 400+ Auth errors
         case .noAuthTokenFound: return 400
             // 500+ Subscription errors
@@ -140,7 +142,6 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
                 .wireGuardCannotLocateTunnelFileDescriptor,
                 .wireGuardInvalidState,
                 .wireGuardDnsResolution,
-                .startWireGuardBackend,
                 .noAuthTokenFound,
                 .vpnAccessRevoked:
             return [:]
@@ -166,6 +167,10 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
             return [
                 NSUnderlyingErrorKey: error
             ]
+        case .startWireGuardBackend(let code):
+            return [NSUnderlyingErrorKey: NSError(domain: "WireGuardAdapter", code: Int(code))]
+        case .setWireguardConfig(let code):
+            return [NSUnderlyingErrorKey: NSError(domain: "WireGuardAdapter", code: Int(code))]
         }
     }
 

--- a/Sources/NetworkProtection/Diagnostics/NetworkProtectionError.swift
+++ b/Sources/NetworkProtection/Diagnostics/NetworkProtectionError.swift
@@ -23,6 +23,7 @@ protocol NetworkProtectionErrorConvertible {
 }
 
 public enum NetworkProtectionError: LocalizedError, CustomNSError {
+
     // Tunnel configuration errors
     case noServerRegistrationInfo
     case couldNotSelectClosestServer
@@ -60,8 +61,8 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
     case wireGuardInvalidState(reason: String)
     case wireGuardDnsResolution
     case wireGuardSetNetworkSettings(Error)
-    case startWireGuardBackend(Int32)
-    case setWireguardConfig(errorCode: Int64)
+    case startWireGuardBackend(Error)
+    case setWireguardConfig(Error)
 
     // Auth errors
     case noAuthTokenFound
@@ -161,16 +162,14 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
                 .failedToParseRegisteredServersResponse(let error),
                 .failedToParseRedeemResponse(let error),
                 .wireGuardSetNetworkSettings(let error),
+                .startWireGuardBackend(let error),
+                .setWireguardConfig(let error),
                 .unhandledError(_, _, let error),
                 .failedToFetchServerStatus(let error),
                 .failedToParseServerStatusResponse(let error):
             return [
                 NSUnderlyingErrorKey: error
             ]
-        case .startWireGuardBackend(let code):
-            return [NSUnderlyingErrorKey: NSError(domain: "WireGuardAdapter", code: Int(code))]
-        case .setWireguardConfig(let code):
-            return [NSUnderlyingErrorKey: NSError(domain: "WireGuardAdapter", code: Int(code))]
         }
     }
 

--- a/Sources/NetworkProtection/Diagnostics/WireGuardAdapterError+NetworkProtectionErrorConvertible.swift
+++ b/Sources/NetworkProtection/Diagnostics/WireGuardAdapterError+NetworkProtectionErrorConvertible.swift
@@ -31,6 +31,8 @@ extension WireGuardAdapterError: NetworkProtectionErrorConvertible {
             return .wireGuardSetNetworkSettings(error)
         case .startWireGuardBackend(let code):
             return .startWireGuardBackend(code)
+        case .setWireguardConfig(let errorCode):
+            return .setWireguardConfig(errorCode: errorCode)
         }
     }
 }

--- a/Sources/NetworkProtection/Diagnostics/WireGuardAdapterError+NetworkProtectionErrorConvertible.swift
+++ b/Sources/NetworkProtection/Diagnostics/WireGuardAdapterError+NetworkProtectionErrorConvertible.swift
@@ -29,10 +29,10 @@ extension WireGuardAdapterError: NetworkProtectionErrorConvertible {
             return .wireGuardDnsResolution
         case .setNetworkSettings(let error):
             return .wireGuardSetNetworkSettings(error)
-        case .startWireGuardBackend(let code):
-            return .startWireGuardBackend(code)
-        case .setWireguardConfig(let errorCode):
-            return .setWireguardConfig(errorCode: errorCode)
+        case .startWireGuardBackend(let error):
+            return .startWireGuardBackend(error)
+        case .setWireguardConfig(let error):
+            return .setWireguardConfig(error)
         }
     }
 }

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -139,7 +139,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     // MARK: - WireGuard
 
-    private lazy var adapter: WireGuardAdapter = {
+    func makeAdapter(with packetTunnelProvider: PacketTunnelProvider) -> WireGuardAdapter {
         WireGuardAdapter(with: self) { logLevel, message in
             if logLevel == .error {
                 os_log("🔴 Received error from adapter: %{public}@", log: .networkProtection, type: .error, message)
@@ -147,7 +147,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 os_log("Received message from adapter: %{public}@", log: .networkProtection, message)
             }
         }
-    }()
+    }
+
+    private lazy var adapter = makeAdapter(with: self)
 
     // MARK: - Timers Support
 
@@ -897,9 +899,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             await stopMonitors()
         }
 
-        do {
-            let tunnelConfiguration: TunnelConfiguration
+        var tunnelConfiguration: TunnelConfiguration?
 
+        do {
             switch updateMethod {
             case .selectServer(let serverSelectionMethod):
                 tunnelConfiguration = try await generateTunnelConfiguration(serverSelectionMethod: serverSelectionMethod,
@@ -912,7 +914,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 tunnelConfiguration = newTunnelConfiguration
             }
 
-            try await updateAdapterConfiguration(tunnelConfiguration: tunnelConfiguration, reassert: reassert)
+            try await updateAdapterConfiguration(tunnelConfiguration: tunnelConfiguration!, reassert: reassert)
 
             if reassert {
                 try await handleAdapterStarted(startReason: .reconnected)
@@ -921,12 +923,21 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             providerEvents.fire(.tunnelUpdateAttempt(.success))
         } catch {
             providerEvents.fire(.tunnelUpdateAttempt(.failure(error)))
+
+            switch error {
+            case WireGuardAdapterError.setWireguardConfig:
+                await cancelTunnel(with: error)
+            default:
+                break
+            }
+
             throw error
         }
     }
 
     @MainActor
     private func updateAdapterConfiguration(tunnelConfiguration: TunnelConfiguration, reassert: Bool) async throws {
+
         try await withCheckedThrowingContinuation { [weak self] (continuation: CheckedContinuation<Void, Error>) in
             guard let self = self else {
                 continuation.resume()
@@ -934,8 +945,10 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             }
 
             self.adapter.update(tunnelConfiguration: tunnelConfiguration, reassert: reassert) { [weak self] error in
+
                 if let error = error {
                     self?.debugEvents?.fire(error.networkProtectionError)
+
                     continuation.resume(throwing: error)
                     return
                 }
@@ -1689,6 +1702,9 @@ extension WireGuardAdapterError: LocalizedError, CustomDebugStringConvertible {
 
         case .startWireGuardBackend(let errorCode):
             return "Starting tunnel failed with wgTurnOn returning: \(errorCode)"
+
+        case .setWireguardConfig(let errorCode):
+            return "Update tunnel failed with wgSetConfig returning: \(errorCode)"
 
         case .invalidState:
             return "Starting tunnel failed with invalid error"

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -139,7 +139,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     // MARK: - WireGuard
 
-    func makeAdapter(with packetTunnelProvider: PacketTunnelProvider) -> WireGuardAdapter {
+    private lazy var adapter: WireGuardAdapter = {
         WireGuardAdapter(with: self) { logLevel, message in
             if logLevel == .error {
                 os_log("🔴 Received error from adapter: %{public}@", log: .networkProtection, type: .error, message)
@@ -147,9 +147,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 os_log("Received message from adapter: %{public}@", log: .networkProtection, message)
             }
         }
-    }
-
-    private lazy var adapter = makeAdapter(with: self)
+    }()
 
     // MARK: - Timers Support
 
@@ -915,9 +913,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             await stopMonitors()
         }
 
-        var tunnelConfiguration: TunnelConfiguration?
-
         do {
+            let tunnelConfiguration: TunnelConfiguration
+
             switch updateMethod {
             case .selectServer(let serverSelectionMethod):
                 tunnelConfiguration = try await generateTunnelConfiguration(serverSelectionMethod: serverSelectionMethod,
@@ -930,7 +928,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 tunnelConfiguration = newTunnelConfiguration
             }
 
-            try await updateAdapterConfiguration(tunnelConfiguration: tunnelConfiguration!, reassert: reassert)
+            try await updateAdapterConfiguration(tunnelConfiguration: tunnelConfiguration, reassert: reassert)
 
             if reassert {
                 try await handleAdapterStarted(startReason: .reconnected)

--- a/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
@@ -27,10 +27,10 @@ public enum WireGuardAdapterError: CustomNSError {
     case setNetworkSettings(Error)
 
     /// Failure to start WireGuard backend.
-    case startWireGuardBackend(Int32)
+    case startWireGuardBackend(Error)
 
     /// Failure to set the configuration for the WireGuard adapter
-    case setWireguardConfig(errorCode: Int64)
+    case setWireguardConfig(Error)
 
     static let wireguardAdapterDomain = "WireGuardAdapter"
 
@@ -58,11 +58,9 @@ public enum WireGuardAdapterError: CustomNSError {
             return [NSUnderlyingErrorKey: firstError as NSError]
         case .setNetworkSettings(let error):
             return [NSUnderlyingErrorKey: error as NSError]
-        case .startWireGuardBackend(let code):
-            let error = NSError(domain: Self.wireguardAdapterDomain, code: Int(code))
+        case .startWireGuardBackend(let error):
             return [NSUnderlyingErrorKey: error as NSError]
-        case .setWireguardConfig(let code):
-            let error = NSError(domain: Self.wireguardAdapterDomain, code: Int(code))
+        case .setWireguardConfig(let error):
             return [NSUnderlyingErrorKey: error as NSError]
         }
     }
@@ -435,7 +433,9 @@ public class WireGuardAdapter {
                     let result = wgSetConfig(handle, wgConfig)
 
                     if result < 0 {
-                        throw WireGuardAdapterError.setWireguardConfig(errorCode: result)
+                        let error = NSError(domain: WireGuardAdapterError.wireguardAdapterDomain,
+                                            code: Int(result))
+                        throw WireGuardAdapterError.setWireguardConfig(error)
                     }
 
                     #if os(iOS)
@@ -553,7 +553,9 @@ public class WireGuardAdapter {
 
         let handle = wgTurnOn(wgConfig, tunnelFileDescriptor)
         if handle < 0 {
-            throw WireGuardAdapterError.startWireGuardBackend(handle)
+            let error = NSError(domain: WireGuardAdapterError.wireguardAdapterDomain,
+                                code: Int(handle))
+            throw WireGuardAdapterError.startWireGuardBackend(error)
         }
         #if os(iOS)
         wgDisableSomeRoamingForBrokenMobileSemantics(handle)

--- a/Tests/NetworkProtectionTests/NetworkProtectionErrorTests.swift
+++ b/Tests/NetworkProtectionTests/NetworkProtectionErrorTests.swift
@@ -54,8 +54,6 @@ final class NetworkProtectionErrorTests: XCTestCase {
             .keychainUpdateError(field: "test", status: 1),
             .keychainDeleteError(status: 1),
             .wireGuardInvalidState(reason: "test"),
-            .startWireGuardBackend(1),
-
         ]
 
         for error in errorsWithoutUnderlyingError {
@@ -77,6 +75,7 @@ final class NetworkProtectionErrorTests: XCTestCase {
             .failedToRedeemInviteCode(underlyingError),
             .failedToParseRedeemResponse(underlyingError),
             .wireGuardSetNetworkSettings(underlyingError),
+            .startWireGuardBackend(underlyingError),
             .unhandledError(function: #function, line: #line, error: underlyingError),
         ]
 

--- a/Tests/NetworkProtectionTests/Recovery/FailureRecoveryHandlerTests.swift
+++ b/Tests/NetworkProtectionTests/Recovery/FailureRecoveryHandlerTests.swift
@@ -337,7 +337,8 @@ final class FailureRecoveryHandlerTests: XCTestCase {
             dnsSettings: .default,
             isKillSwitchEnabled: false
         ) { _ in
-            throw WireGuardAdapterError.startWireGuardBackend(0)
+            let underlyingError = NSError(domain: "test", code: 1)
+            throw WireGuardAdapterError.startWireGuardBackend(underlyingError)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208000338328853/f

iOS PR: https://github.com/duckduckgo/iOS/pull/3204
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3084

What kind of version bump will this require?: Major

## Description

Adds a recovery mechanism for the tunnel so that when WireGuard throws an error on tunnel update, we restart the VPN tunnel.

## Testing

See the platform-specific PRs for testing instructions.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
