### PR TITLE
Fix failure to shut down VPN when subscription expires

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -1310,8 +1310,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         manager.isOnDemandEnabled = false
-        try await manager.loadFromPreferences()
         try await manager.saveToPreferences()
+        try await manager.loadFromPreferences()
 
         await cancelTunnel(with: TunnelError.vpnAccessRevoked)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1208033535142062/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3229
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3099
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC:

**Description**:

A recent change reverses the order of these 2 function calls. This PR reverts it back.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Enable the VPN on staging
1. Wait till the subscription expires
2. The VPN should be stopped and removed properly

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
