### PR TITLE
Re-Enable Broken Site Toast on iOS

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -49,6 +49,7 @@ public enum PrivacyFeature: String {
     case sslCertificates
     case brokenSiteReportExperiment
     case toggleReports
+    case brokenSitePrompt
     case remoteMessaging
     case additionalCampaignPixelParams
 }

--- a/Sources/PrivacyDashboard/PrivacyDashboardController.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardController.swift
@@ -160,6 +160,7 @@ public protocol PrivacyDashboardControllerDelegate: AnyObject {
         switch entryPoint {
         case .report: source = .appMenu
         case .dashboard: source = .dashboard
+        case .prompt(let event): source = .prompt(event)
         case .toggleReport: source = .onProtectionsOffMenu
         case .afterTogglePrompt: source = .afterTogglePrompt
         }

--- a/Sources/PrivacyDashboard/PrivacyDashboardEntryPoint.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardEntryPoint.swift
@@ -30,6 +30,10 @@ public enum PrivacyDashboardEntryPoint: Equatable {
     /// This is only available on iOS, as macOS does not have an option to disable protection outside of the dashboard.
     case toggleReport(completionHandler: (Bool) -> Void)
 
+    /// The prompt report screen, which is triggered whenever the user taps report from the toast popup for refreshes
+    /// This is currently only available on iOS.
+    case prompt(String)
+
     /// The experimental after toggle prompt screen, presented in variant B.
     /// After the user toggles off protection, this prompt asks if the action helped and allows the user to report their experience.
     /// - Parameters:
@@ -47,6 +51,7 @@ public enum PrivacyDashboardEntryPoint: Equatable {
 
         case (.afterTogglePrompt, _): return .choiceBreakageForm
 
+        case (.prompt, _): return .promptBreakageForm
         case (.toggleReport, _): return .toggleReport
         }
     }
@@ -57,6 +62,7 @@ public enum PrivacyDashboardEntryPoint: Equatable {
             (.dashboard, .dashboard),
             (.report, .report),
             (.toggleReport, .toggleReport),
+            (.prompt, .prompt),
             (.afterTogglePrompt, .afterTogglePrompt):
             return true
         default:


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1163321984198618/1207889813347127/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3244
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3108
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL:
CC:

**Description**:
This PR adds the `prompt` entry point back to BSK for the broken site report.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See [iOS PR](https://github.com/duckduckgo/iOS/pull/3244)
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
