### PR TITLE
Update PixelKit so that ENABLE_TESTABILITY override isn't required for PR Checks workflow run

### DIFF
--- a/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
+++ b/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
@@ -17,7 +17,7 @@
 //
 
 import Foundation
-@testable import PixelKit
+import PixelKit
 import XCTest
 
 public extension XCTestCase {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203301625297703/1208100078742782/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3256
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3126
What kind of version bump will this require?: Patch

**Description**:
PixelKitTestingUtilities, as a regular Swift module (non-test target) shouldn't use testable imports.
This change removes a testable import from XCTestCase+PixelKit.swift in order to simplify macOS CI workflow
by removing the need to pass ENABLE_TESTABILITY=1 for xcodebuild invocations.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Verify that CI is green.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
