### PR TITLE
Fix address bar queries when doing math expressions

### DIFF
--- a/Sources/Common/Extensions/StringExtension.swift
+++ b/Sources/Common/Extensions/StringExtension.swift
@@ -367,7 +367,7 @@ public extension String {
         return (isValidHostname || isValidIpHost) && !isMathFormula
     }
 
-    var isMathFormula: Bool {
+    private var isMathFormula: Bool {
         return matches(.mathExpression)
     }
 

--- a/Sources/Common/Extensions/StringExtension.swift
+++ b/Sources/Common/Extensions/StringExtension.swift
@@ -31,6 +31,8 @@ extension RegEx {
     static let hostName = regex("^(((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)*[A-Za-z0-9-]{2,63})$", .caseInsensitive)
 
     static let email = regex(#"[^\s]+@[^\s]+\.[^\s]+"#)
+
+    static let mathExpression = regex(#"^[\s$]*([\d]+(\.[\d]+)?|\\.[\d]+)([\s]*[+\-*/][\s]*([\d]+(\.[\d]+)?|\\.[\d]+))*[\s$]*$"#)
 }
 
 // Use this instead of NSLocalizedString for strings that are not supposed to be translated
@@ -362,7 +364,11 @@ public extension String {
     // MARK: Host name validation
 
     var isValidHost: Bool {
-        return isValidHostname || isValidIpHost
+        return (isValidHostname || isValidIpHost) && !isMathFormula
+    }
+
+    var isMathFormula: Bool {
+        return matches(.mathExpression)
     }
 
     var isValidHostname: Bool {

--- a/Tests/CommonTests/Extensions/StringExtensionTests.swift
+++ b/Tests/CommonTests/Extensions/StringExtensionTests.swift
@@ -336,4 +336,38 @@ final class StringExtensionTests: XCTestCase {
 
     }
 
+    func testWhenStringIsValidHost_thenValidHostIsTrue() {
+        let validHostnames = [
+            "example.com",
+            "subdomain.example.com",
+            "my-host123",
+            "localhost",
+            "192.168.1.1", // Valid IP address
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334" // Valid IPv6 address
+        ]
+
+        for hostname in validHostnames {
+            XCTAssertTrue(hostname.isValidHost, "\(hostname) should be a valid host")
+        }
+    }
+
+    func testWhenStringIsInvalidHost_thenValidHostIsFalse() {
+        let invalidHostnames = [
+            "invalid_hostname", // Invalid character
+            "-example.com", // Starts with a hyphen
+            "example-.com", // Ends with a hyphen
+            "example..com", // Consecutive dots
+            "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890.com", // Too long
+            "example.com.", // Ends with a dot
+            "3 + 5 * (2 - 1)", // Mathematical expression
+            "16385-12228.72", // Other mathetmatical expression
+            "example@domain.com", // Invalid character
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334:1234" // Invalid IPv6 address
+        ]
+
+        for hostname in invalidHostnames {
+            XCTAssertFalse(hostname.isValidHost, "\(hostname) should NOT be a valid host")
+        }
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208002970105121/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3262
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3130
What kind of version bump will this require?: Minor

**Description**:
This pull request introduces a change on how we check for valid hostnames. The current regurlar expression had an issue where some mathematical expressions where valid hostnames.

**Steps to test this PR**:
Follow the tests provided for each platform pull request.

###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
