### PR TITLE
Remove WireGuard from BSK

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -89,15 +89,6 @@
         "revision" : "1403e17eeeb8493b92fb9d11eb8c846bb9776581",
         "version" : "2.1.2"
       }
-    },
-    {
-      "identity" : "wireguard-apple",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/wireguard-apple",
-      "state" : {
-        "revision" : "13fd026384b1af11048451061cc1b21434990668",
-        "version" : "1.1.3"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,6 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "5.0.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),
-        .package(url: "https://github.com/duckduckgo/wireguard-apple", exact: "1.1.3"),
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1")
     ],
     targets: [
@@ -321,7 +320,6 @@ let package = Package(
             name: "NetworkProtection",
             dependencies: [
                 .target(name: "WireGuardC"),
-                .product(name: "WireGuard", package: "wireguard-apple"),
                 "Common",
             ],
             swiftSettings: [

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -140,7 +140,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     // MARK: - WireGuard
 
     private lazy var adapter: WireGuardAdapter = {
-        WireGuardAdapter(with: self) { logLevel, message in
+        WireGuardAdapter(with: self, wireGuardInterface: self.wireGuardInterface) { logLevel, message in
             if logLevel == .error {
                 os_log("🔴 Received error from adapter: %{public}@", log: .networkProtection, type: .error, message)
             } else {
@@ -416,6 +416,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     private let controllerErrorStore: NetworkProtectionTunnelErrorStore
     private let knownFailureStore: NetworkProtectionKnownFailureStore
     private let snoozeTimingStore: NetworkProtectionSnoozeTimingStore
+    private let wireGuardInterface: WireGuardInterface
 
     // MARK: - Cancellables
 
@@ -435,6 +436,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 controllerErrorStore: NetworkProtectionTunnelErrorStore,
                 knownFailureStore: NetworkProtectionKnownFailureStore = NetworkProtectionKnownFailureStore(),
                 snoozeTimingStore: NetworkProtectionSnoozeTimingStore,
+                wireGuardInterface: WireGuardInterface,
                 keychainType: KeychainType,
                 tokenStore: NetworkProtectionTokenStore,
                 debugEvents: EventMapping<NetworkProtectionError>?,
@@ -454,6 +456,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         self.controllerErrorStore = controllerErrorStore
         self.knownFailureStore = knownFailureStore
         self.snoozeTimingStore = snoozeTimingStore
+        self.wireGuardInterface = wireGuardInterface
         self.settings = settings
         self.defaults = defaults
         self.isSubscriptionEnabled = isSubscriptionEnabled

--- a/Sources/NetworkProtection/WireGuardKit/PacketTunnelSettingsGenerator.swift
+++ b/Sources/NetworkProtection/WireGuardKit/PacketTunnelSettingsGenerator.swift
@@ -6,10 +6,6 @@ import Network
 import NetworkExtension
 import Common
 
-#if SWIFT_PACKAGE
-import WireGuard
-#endif
-
 /// A type alias for `Result` type that holds a tuple with source and resolved endpoint.
 typealias EndpointResolutionResult = Result<(Endpoint, Endpoint), DNSResolutionError>
 

--- a/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
@@ -448,7 +448,7 @@ public class WireGuardAdapter {
                     }
 
                     #if os(iOS)
-                    wireGuardInterface.disableSomeRoamingForBrokenMobileSemantics(handle: handle)
+                    self.wireGuardInterface.disableSomeRoamingForBrokenMobileSemantics(handle: handle)
                     #endif
 
                     self.state = .started(handle, settingsGenerator)
@@ -568,7 +568,7 @@ public class WireGuardAdapter {
             throw WireGuardAdapterError.startWireGuardBackend(error)
         }
         #if os(iOS)
-        wgDisableSomeRoamingForBrokenMobileSemantics(handle)
+        wireGuardInterface.disableSomeRoamingForBrokenMobileSemantics(handle: handle)
         #endif
         return handle
     }
@@ -617,14 +617,14 @@ public class WireGuardAdapter {
                 let (wgConfig, resolutionResults) = settingsGenerator.endpointUapiConfiguration()
                 self.logEndpointResolutionResults(resolutionResults)
 
-                wgSetConfig(handle, wgConfig)
-                wgDisableSomeRoamingForBrokenMobileSemantics(handle)
-                wgBumpSockets(handle)
+                self.wireGuardInterface.setConfig(handle: handle, config: wgConfig)
+                self.wireGuardInterface.disableSomeRoamingForBrokenMobileSemantics(handle: handle)
+                self.wireGuardInterface.bumpSockets(handle: handle)
             } else {
                 self.logHandler(.verbose, "Connectivity offline, pausing backend.")
 
                 self.state = .temporaryShutdown(settingsGenerator)
-                wgTurnOff(handle)
+                self.wireGuardInterface.turnOff(handle: handle)
             }
 
         case .temporaryShutdown(let settingsGenerator):

--- a/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
@@ -617,7 +617,7 @@ public class WireGuardAdapter {
                 let (wgConfig, resolutionResults) = settingsGenerator.endpointUapiConfiguration()
                 self.logEndpointResolutionResults(resolutionResults)
 
-                self.wireGuardInterface.setConfig(handle: handle, config: wgConfig)
+                _ = self.wireGuardInterface.setConfig(handle: handle, config: wgConfig)
                 self.wireGuardInterface.disableSomeRoamingForBrokenMobileSemantics(handle: handle)
                 self.wireGuardInterface.bumpSockets(handle: handle)
             } else {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1207874749913488/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3273
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3144
What kind of version bump will this require?: Major

**Description**:

This PR removes `wireguard-apple` as a direct dependency of BSK, and shifts that dependency to the clients.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
