### PR TITLE
Switch PR Checks to macos-14 free runner

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,15 +61,12 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_$(<.xcode-version).app/Contents/Developer
 
-      - name: Install xcbeautify
-        continue-on-error: true
-        run: brew install xcbeautify
+      
+      - name: Build BSK
+        run: set -o pipefail && swift build | tee build-log.txt | xcbeautify
 
       - name: Run tests
-        run: |
-          set -o pipefail && swift build -v | tee build-log.txt
-          set -o pipefail && swift test | tee -a build-log.txt
-          xcbeautify -qq --report junit --report-path . --junit-report-filename tests.xml < build-log.txt
+        run: set -o pipefail && swift test | tee -a build-log.txt | xcbeautify --report junit --report-path . --junit-report-filename tests.xml
 
       - name: Publish Unit Tests Report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   swiftlint:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
 
       name: Run unit tests (macOS)
 
-      runs-on: macos-14-xlarge
+      runs-on: macos-14
       timeout-minutes: 30
 
       outputs:
@@ -109,7 +109,7 @@ jobs:
 
       name: Run unit tests (iOS)
 
-      runs-on: macos-14-xlarge
+      runs-on: macos-14
       timeout-minutes: 30
 
       steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-  workflow_dispatch:
 
 jobs:
   swiftlint:
@@ -61,7 +60,6 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_$(<.xcode-version).app/Contents/Developer
 
-      
       - name: Build BSK
         run: set -o pipefail && swift build | tee build-log.txt | xcbeautify
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,7 +67,8 @@ jobs:
 
       - name: Run tests
         run: |
-          set -o pipefail && swift test | tee build-log.txt
+          set -o pipefail && swift build -v | tee build-log.txt
+          set -o pipefail && swift test | tee -a build-log.txt
           xcbeautify -qq --report junit --report-path . --junit-report-filename tests.xml < build-log.txt
 
       - name: Publish Unit Tests Report

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,9 @@ jobs:
         run: brew install xcbeautify
 
       - name: Run tests
-        run: set -o pipefail && swift test | tee build-log.txt | xcbeautify --report junit --report-path . --junit-report-filename tests.xml
+        run: |
+          set -o pipefail && swift test | tee build-log.txt
+          xcbeautify -qq --report junit --report-path . --junit-report-filename tests.xml < build-log.txt
 
       - name: Publish Unit Tests Report
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203301625297703/1208137627434467/f
iOS PR: N/A
macOS PR: N/A
What kind of version bump will this require?: N/A

**Description**:
This change updates pr.yml to use macos-14 free GHA runner.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Verify that CI is green.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
