### PR TITLE
Freemium PIR - Add Desktop RMF Attribute

### DIFF
--- a/Sources/RemoteMessaging/Matchers/UserAttributeMatcher.swift
+++ b/Sources/RemoteMessaging/Matchers/UserAttributeMatcher.swift
@@ -98,6 +98,7 @@ public struct MobileUserAttributeMatcher: AttributeMatching {
 public struct DesktopUserAttributeMatcher: AttributeMatching {
     private let pinnedTabsCount: Int
     private let hasCustomHomePage: Bool
+    private let isCurrentFreemiumPIRUser: Bool
     private let dismissedDeprecatedMacRemoteMessageIds: [String]
 
     private let commonUserAttributeMatcher: CommonUserAttributeMatcher
@@ -123,10 +124,12 @@ public struct DesktopUserAttributeMatcher: AttributeMatching {
                 hasCustomHomePage: Bool,
                 isDuckPlayerOnboarded: Bool,
                 isDuckPlayerEnabled: Bool,
+                isCurrentFreemiumPIRUser: Bool,
                 dismissedDeprecatedMacRemoteMessageIds: [String]
     ) {
         self.pinnedTabsCount = pinnedTabsCount
         self.hasCustomHomePage = hasCustomHomePage
+        self.isCurrentFreemiumPIRUser = isCurrentFreemiumPIRUser
         self.dismissedDeprecatedMacRemoteMessageIds = dismissedDeprecatedMacRemoteMessageIds
 
         commonUserAttributeMatcher = .init(
@@ -158,6 +161,8 @@ public struct DesktopUserAttributeMatcher: AttributeMatching {
             return matchingAttribute.evaluate(for: pinnedTabsCount)
         case let matchingAttribute as CustomHomePageMatchingAttribute:
             return matchingAttribute.evaluate(for: hasCustomHomePage)
+        case let matchingAttribute as FreemiumPIRCurrentUserMatchingAttribute:
+            return matchingAttribute.evaluate(for: isCurrentFreemiumPIRUser)
         case let matchingAttribute as InteractedWithDeprecatedMacRemoteMessageMatchingAttribute:
             if dismissedDeprecatedMacRemoteMessageIds.contains(where: { messageId in
                 StringArrayMatchingAttribute(matchingAttribute.value).matches(value: messageId) == .match

--- a/Sources/RemoteMessaging/Model/MatchingAttributes.swift
+++ b/Sources/RemoteMessaging/Model/MatchingAttributes.swift
@@ -191,6 +191,11 @@ struct DuckPlayerEnabledMatchingAttribute: SingleValueMatching {
     var fallback: Bool?
 }
 
+struct FreemiumPIRCurrentUserMatchingAttribute: SingleValueMatching {
+    var value: Bool?
+    var fallback: Bool?
+}
+
 struct MessageShownMatchingAttribute: SingleValueMatching {
     var value: [String]? = []
     var fallback: Bool?

--- a/Tests/RemoteMessagingTests/Matchers/DesktopUserAttributeMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/Matchers/DesktopUserAttributeMatcherTests.swift
@@ -133,6 +133,18 @@ class DesktopUserAttributeMatcherTests: XCTestCase {
                        .fail)
     }
 
+    // MARK: - FreemiumPIRCurrentUser
+
+    func testWhenIsCurrentFreemiumPIRUserEnabledMatchesThenReturnMatch() throws {
+        XCTAssertEqual(matcher.evaluate(matchingAttribute: FreemiumPIRCurrentUserMatchingAttribute(value: false, fallback: nil)),
+                       .match)
+    }
+
+    func testWhenIsCurrentFreemiumPIRUserDoesNotMatchThenReturnFail() throws {
+        XCTAssertEqual(matcher.evaluate(matchingAttribute: FreemiumPIRCurrentUserMatchingAttribute(value: true, fallback: nil)),
+                       .fail)
+    }
+
     // MARK: - DeprecatedMacRemoteMessage
 
     func testWhenNoDismissedMessageIdsAreProvidedThenReturnFail() throws {
@@ -186,6 +198,7 @@ class DesktopUserAttributeMatcherTests: XCTestCase {
             hasCustomHomePage: true,
             isDuckPlayerOnboarded: true,
             isDuckPlayerEnabled: false,
+            isCurrentFreemiumPIRUser: false,
             dismissedDeprecatedMacRemoteMessageIds: dismissedDeprecatedMacRemoteMessageIds
         )
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL:  https://app.asana.com/0/1206488453854252/1208051900144618/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/3275
macOS PR:  https://github.com/duckduckgo/macos-browser/pull/3146
What kind of version bump will this require?: Major

**Optional**:

Tech Design URL:
CC:

**Description**: Add Freemium PIR RMF attribute to allow targeting current Freemium PIR users with RMF messages.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See platform CI

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
