### PR TITLE
Include status code in the keychain failure errors

### DIFF
--- a/Sources/Subscription/AccountStorage/AccountKeychainStorage.swift
+++ b/Sources/Subscription/AccountStorage/AccountKeychainStorage.swift
@@ -41,9 +41,9 @@ public enum AccountKeychainAccessError: Error, Equatable {
         switch self {
         case .failedToDecodeKeychainValueAsData: return "failedToDecodeKeychainValueAsData"
         case .failedToDecodeKeychainDataAsString: return "failedToDecodeKeychainDataAsString"
-        case .keychainSaveFailure: return "keychainSaveFailure"
-        case .keychainDeleteFailure: return "keychainDeleteFailure"
-        case .keychainLookupFailure: return "keychainLookupFailure"
+        case .keychainSaveFailure(let status): return "keychainSaveFailure(\(status))"
+        case .keychainDeleteFailure(let status): return "keychainDeleteFailure(\(status))"
+        case .keychainLookupFailure(let status): return "keychainLookupFailure(\(status))"
         }
     }
 }


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201037661562251/1208146974665104/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3276
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3147
What kind of version bump will this require?: Major/Minor/Patch


**Description**:
Include status code in the keychain failure errors in their description.

**Steps to test this PR**:
See platform PRs

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
