### PR TITLE
Fix site owned by major network

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/TrackerRadarKit",
       "state" : {
-        "branch" : "alessandro/fix-site-owned-by-major-network",
-        "revision" : "c02419f6968b953aee052fc2999fadf41ab090a9"
+        "revision" : "5de0a610a7927b638a5fd463a53032c9934a2c3b",
+        "version" : "3.0.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/TrackerRadarKit",
       "state" : {
-        "revision" : "1403e17eeeb8493b92fb9d11eb8c846bb9776581",
-        "version" : "2.1.2"
+        "branch" : "alessandro/fix-site-owned-by-major-network",
+        "revision" : "0961058099f05dd4b8ec2467f64687b9c1900dce"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -87,7 +87,7 @@
       "location" : "https://github.com/duckduckgo/TrackerRadarKit",
       "state" : {
         "branch" : "alessandro/fix-site-owned-by-major-network",
-        "revision" : "0961058099f05dd4b8ec2467f64687b9c1900dce"
+        "revision" : "c02419f6968b953aee052fc2999fadf41ab090a9"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "13.0.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.0"),
-        .package(url: "https://github.com/duckduckgo/TrackerRadarKit", branch: "alessandro/fix-site-owned-by-major-network"),
+        .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
         .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "6.12.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "13.0.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.0"),
-        .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "2.1.2"),
+        .package(url: "https://github.com/duckduckgo/TrackerRadarKit", branch: "alessandro/fix-site-owned-by-major-network"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
         .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "6.12.0"),

--- a/Sources/BrowserServicesKit/ContentBlocking/TrackerDataQueryExtension.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/TrackerDataQueryExtension.swift
@@ -34,10 +34,10 @@ extension TrackerData {
         return nil
     }
 
-    /// Returns the entity associated with the host. If the entity is owned by a parent entity, it returns the parent entity.
+    /// Returns the parent of the entity associated with the host if any. If the entity associated with the host doesn't have a parent return the entity. Otherwise, return nil.
     /// - Parameter host:
     /// - Returns: The entity associated with the host.
-    public func findParentOrFallback(forHost host: String) -> Entity? {
+    public func findParentEntityOrFallback(forHost host: String) -> Entity? {
         // If the entity associated with the host is owned by a parent company (e.g. Instagram is owned by Facebook) return the parent company.
         // If the entity associated with the host is not owned by a parent company return the entity.
         // If the are no entities associated with the host return nil

--- a/Sources/BrowserServicesKit/ContentBlocking/TrackerDataQueryExtension.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/TrackerDataQueryExtension.swift
@@ -34,6 +34,15 @@ extension TrackerData {
         return nil
     }
 
+    public func findParentEntity(forHost host: String) -> Entity? {
+        for host in variations(of: host) {
+            if let tracker = trackers[host], let parentOwnerName = tracker.owner?.ownedBy {
+                return entities[parentOwnerName]
+            }
+        }
+        return nil
+    }
+
     private func variations(of host: String) -> [String] {
         var parts = host.components(separatedBy: ".")
         var domains = [String]()

--- a/Sources/BrowserServicesKit/ContentBlocking/TrackerDataQueryExtension.swift
+++ b/Sources/BrowserServicesKit/ContentBlocking/TrackerDataQueryExtension.swift
@@ -34,10 +34,18 @@ extension TrackerData {
         return nil
     }
 
-    public func findParentEntity(forHost host: String) -> Entity? {
+    /// Returns the entity associated with the host. If the entity is owned by a parent entity, it returns the parent entity.
+    /// - Parameter host:
+    /// - Returns: The entity associated with the host.
+    public func findParentOrFallback(forHost host: String) -> Entity? {
+        // If the entity associated with the host is owned by a parent company (e.g. Instagram is owned by Facebook) return the parent company.
+        // If the entity associated with the host is not owned by a parent company return the entity.
+        // If the are no entities associated with the host return nil
         for host in variations(of: host) {
-            if let tracker = trackers[host], let parentOwnerName = tracker.owner?.ownedBy {
-                return entities[parentOwnerName]
+            if let trackerOwner = trackers[host]?.owner?.ownedBy {
+                return entities[trackerOwner]
+            } else if let entityName = domains[host] {
+                return entities[entityName]
             }
         }
         return nil

--- a/Sources/ContentBlocking/DetectedRequest.swift
+++ b/Sources/ContentBlocking/DetectedRequest.swift
@@ -48,7 +48,7 @@ public struct DetectedRequest: Encodable {
         self.url = url
         self.eTLDplus1 = eTLDplus1
         self.state = state
-        self.ownerName = knownTracker?.owner?.name
+        self.ownerName = knownTracker?.owner?.ownedBy ?? knownTracker?.owner?.name
         self.entityName = entity?.displayName
         self.category = knownTracker?.category
         self.prevalence = entity?.prevalence

--- a/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionRulesSplitterTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionRulesSplitterTests.swift
@@ -134,7 +134,7 @@ final class AdClickAttributionRulesSplitterTests: XCTestCase {
     private func makeKnownTracker(withName name: String, ownerName: String) -> KnownTracker {
         KnownTracker(domain: name,
                      defaultAction: .block,
-                     owner: .init(name: ownerName, displayName: ownerName),
+                     owner: .init(name: ownerName, displayName: ownerName, ownedBy: nil),
                      prevalence: 5.0,
                      subdomains: nil,
                      categories: nil,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ClickToLoadRulesSplitterTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ClickToLoadRulesSplitterTests.swift
@@ -119,7 +119,7 @@ final class ClickToLoadRulesSplitterTests: XCTestCase {
     private func makeKnownTracker(withName name: String, ownerName: String) -> KnownTracker {
         KnownTracker(domain: name,
                      defaultAction: .block,
-                     owner: .init(name: ownerName, displayName: ownerName),
+                     owner: .init(name: ownerName, displayName: ownerName, ownedBy: nil),
                      prevalence: 5.0,
                      subdomains: nil,
                      categories: nil,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockingRulesHelper.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockingRulesHelper.swift
@@ -28,7 +28,7 @@ final class ContentBlockingRulesHelper {
 
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker", displayName: "Tracker"),
+                                   owner: KnownTracker.Owner(name: "Tracker", displayName: "Tracker", ownedBy: nil),
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/TrackerDataQueryExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/TrackerDataQueryExtensionTests.swift
@@ -1,0 +1,221 @@
+//
+//  TrackerDataQueryExtensionTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import TrackerRadarKit
+@testable import BrowserServicesKit
+
+final class TrackerDataQueryExtensionTests: XCTestCase {
+
+    func testWhenHostHasAnEntityAssociatedAndEntityHasAParentThenReturnParent() throws {
+        // GIVEN
+        let tds = try JSONDecoder().decode(TrackerData.self, from: Self.mockTDS)
+
+        // WHEN
+        let result = try XCTUnwrap(tds.findParentOrFallback(forHost: "www.instagram.com"))
+
+        // THEN
+        XCTAssertEqual(result.displayName, "Facebook")
+    }
+
+    func testWhenHostHasAnEntityAssociatedAndEntityDoesNotHaveAParentThenReturnEntityAssociated() throws {
+        // GIVEN
+        let tds = try JSONDecoder().decode(TrackerData.self, from: Self.mockTDS)
+
+        // WHEN
+        let result = try XCTUnwrap(tds.findParentOrFallback(forHost: "www.roku.com"))
+
+        // THEN
+        XCTAssertEqual(result.displayName, "Roku")
+    }
+
+    func testWhenHostDoesNotHaveAnEntityAssociatedThenReturnNil() throws {
+        // GIVEN
+        let tds = try JSONDecoder().decode(TrackerData.self, from: Self.mockTDS)
+
+        // WHEN
+        let result = tds.findParentOrFallback(forHost: "www.test.com")
+
+        // THEN
+        XCTAssertNil(result)
+    }
+
+}
+
+private extension TrackerDataQueryExtensionTests {
+
+    static let mockTDS = """
+{
+    "trackers": {
+        "instagram.com": {
+            "domain": "instagram.com",
+            "owner": {
+                "name": "Instagram",
+                "displayName": "Instagram (Facebook)",
+                "localizedName": "Instagram",
+                "ownedBy": "Facebook, Inc."
+            },
+            "prevalence": 0.00573,
+            "fingerprinting": 1,
+            "cookies": 0.00139,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Advertising",
+                "Embedded Content",
+                "Social - Share",
+                "Social Network"
+            ],
+            "default": "ignore",
+            "rules": [
+                {
+                    "rule": "instagram\\.com\\/en_US\\/embeds\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0
+                },
+                {
+                    "rule": "instagram\\.com\\/embed\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0
+                },
+                {
+                    "rule": "instagram\\.com\\/ajax\\/bz",
+                    "fingerprinting": 0,
+                    "cookies": 0.000864
+                },
+                {
+                    "rule": "instagram\\.com\\/logging\\/falco",
+                    "fingerprinting": 0,
+                    "cookies": 0.0000817
+                },
+                {
+                    "rule": "instagram\\.com\\/static\\/bundles\\/es6\\/EmbedSDK\\.js\\/2fe3a16f6aeb\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0
+                },
+                {
+                    "rule": "instagram\\.com\\/login\\/",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "instagram\\.com\\/accounts\\/login\\/",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "instagram\\.com\\/static\\/images\\/ig-badge-view-24\\.png",
+                    "fingerprinting": 0,
+                    "cookies": 0.0000408,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "instagram\\.com\\/static\\/images\\/ig-badge-view-sprite-24\\.png",
+                    "fingerprinting": 0,
+                    "cookies": 0.0000408,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "instagram\\.com\\/v1\\/users\\/self\\/media\\/recent",
+                    "fingerprinting": 0,
+                    "cookies": 0.0000613,
+                    "comment": "pixel"
+                }
+            ]
+        }
+    },
+    "entities": {
+        "Facebook, Inc.": {
+            "domains": [
+                "accountkit.com",
+                "atdmt.com",
+                "atdmt2.com",
+                "atlassbx.com",
+                "atlassolutions.com",
+                "cdninstagram.com",
+                "crowdtangle.com",
+                "facebook.com",
+                "facebook.net",
+                "facebookmail.com",
+                "fb.com",
+                "fb.gg",
+                "fb.me",
+                "fbcdn.net",
+                "fbsbx.com",
+                "fbthirdpartypixel.com",
+                "fbthirdpartypixel.net",
+                "fbthirdpartypixel.org",
+                "flow.org",
+                "flowtype.org",
+                "graphql.org",
+                "instagram.co",
+                "liverail.com",
+                "m.me",
+                "messenger.com",
+                "oculus.com",
+                "oculuscdn.com",
+                "oculusrift.com",
+                "oculusvr.com",
+                "onavo.com",
+                "onavo.net",
+                "onavo.org",
+                "onavoinsights.com",
+                "powersunitedvr.com",
+                "reactjs.org",
+                "thefind.com",
+                "vircado.com",
+                "wa.me",
+                "whatsapp.com",
+                "whatsapp.net",
+                "wit.ai"
+            ],
+            "prevalence": 26.4,
+            "displayName": "Facebook"
+        },
+        "Roku, Inc.": {
+            "domains": [
+                "dataxu.com",
+                "ravm.net",
+                "ravm.tv",
+                "roku.com",
+                "rokulabs.net",
+                "rokutime.com",
+                "w55c.net"
+            ],
+            "prevalence": 7.57,
+            "displayName": "Roku"
+        },
+    },
+    "Example Limited": {
+        "domains": [
+            "example.com",
+            "examplerules.com"
+        ],
+        "prevalence": 1,
+        "displayName": "Example Ltd"
+    },
+    "domains": {
+        "instagram.com": "Instagram",
+        "roku.com": "Roku, Inc.",
+    },
+    "cnames": {}
+}
+""".data(using: .utf8)!
+}

--- a/Tests/BrowserServicesKitTests/ContentBlocker/TrackerDataQueryExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/TrackerDataQueryExtensionTests.swift
@@ -28,7 +28,7 @@ final class TrackerDataQueryExtensionTests: XCTestCase {
         let tds = try JSONDecoder().decode(TrackerData.self, from: Self.mockTDS)
 
         // WHEN
-        let result = try XCTUnwrap(tds.findParentOrFallback(forHost: "www.instagram.com"))
+        let result = try XCTUnwrap(tds.findParentEntityOrFallback(forHost: "www.instagram.com"))
 
         // THEN
         XCTAssertEqual(result.displayName, "Facebook")
@@ -39,7 +39,7 @@ final class TrackerDataQueryExtensionTests: XCTestCase {
         let tds = try JSONDecoder().decode(TrackerData.self, from: Self.mockTDS)
 
         // WHEN
-        let result = try XCTUnwrap(tds.findParentOrFallback(forHost: "www.roku.com"))
+        let result = try XCTUnwrap(tds.findParentEntityOrFallback(forHost: "www.roku.com"))
 
         // THEN
         XCTAssertEqual(result.displayName, "Roku")
@@ -50,7 +50,7 @@ final class TrackerDataQueryExtensionTests: XCTestCase {
         let tds = try JSONDecoder().decode(TrackerData.self, from: Self.mockTDS)
 
         // WHEN
-        let result = tds.findParentOrFallback(forHost: "www.test.com")
+        let result = tds.findParentEntityOrFallback(forHost: "www.test.com")
 
         // THEN
         XCTAssertNil(result)

--- a/Tests/BrowserServicesKitTests/ContentBlocker/TrackerDataQueryExtensionTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/TrackerDataQueryExtensionTests.swift
@@ -1,6 +1,5 @@
 //
 //  TrackerDataQueryExtensionTests.swift
-//  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //

--- a/Tests/BrowserServicesKitTests/ContentBlocker/TrackerResolverTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/TrackerResolverTests.swift
@@ -419,7 +419,7 @@ class TrackerResolverTests: XCTestCase {
 
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner:.trackerInc,
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,

--- a/Tests/BrowserServicesKitTests/ContentBlocker/TrackerResolverTests.swift
+++ b/Tests/BrowserServicesKitTests/ContentBlocker/TrackerResolverTests.swift
@@ -116,8 +116,7 @@ class TrackerResolverTests: XCTestCase {
 
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: ["Advertising"],
@@ -149,8 +148,7 @@ class TrackerResolverTests: XCTestCase {
 
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -325,8 +323,7 @@ class TrackerResolverTests: XCTestCase {
 
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .ignore,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -392,8 +389,7 @@ class TrackerResolverTests: XCTestCase {
 
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -423,8 +419,7 @@ class TrackerResolverTests: XCTestCase {
 
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner:.trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -456,8 +451,7 @@ class TrackerResolverTests: XCTestCase {
 
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -466,7 +460,8 @@ class TrackerResolverTests: XCTestCase {
         let another = KnownTracker(domain: "another.com",
                                    defaultAction: .block,
                                    owner: KnownTracker.Owner(name: "Another Inc",
-                                                             displayName: "Another Inc company"),
+                                                             displayName: "Another Inc company",
+                                                             ownedBy: nil),
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -504,8 +499,7 @@ class TrackerResolverTests: XCTestCase {
     func testWhenTrackerIsOnUnprotectedSiteItIsNotBlocked() {
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -533,8 +527,7 @@ class TrackerResolverTests: XCTestCase {
     func testWhenTrackerIsOnTempListItIsNotBlocked() {
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -563,8 +556,7 @@ class TrackerResolverTests: XCTestCase {
     func testWhenTrackerIsOnDomainWithDisabledContentBlockingFeatureItIsNotBlocked() {
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -592,8 +584,7 @@ class TrackerResolverTests: XCTestCase {
     func testWhenTrackerIsFirstPartyThenItIsNotNotBlocked() { //
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -621,8 +612,7 @@ class TrackerResolverTests: XCTestCase {
     func testWhenRequestIsThirdPartyNonTrackerThenItIsIgnored() { // Note: User script has additional logic regarding this case
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -648,8 +638,7 @@ class TrackerResolverTests: XCTestCase {
     func testWhenRequestIsFirstPartyNonTrackerThenItIsIgnored() {
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -675,8 +664,7 @@ class TrackerResolverTests: XCTestCase {
     func testWhenRequestIsSameEntityNonTrackerThenItIsIgnored() {
         let tracker = KnownTracker(domain: "tracker.com",
                                    defaultAction: .block,
-                                   owner: KnownTracker.Owner(name: "Tracker Inc",
-                                                             displayName: "Tracker Inc company"),
+                                   owner: .trackerInc,
                                    prevalence: 0.1,
                                    subdomains: nil,
                                    categories: nil,
@@ -704,4 +692,43 @@ class TrackerResolverTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    // MARK: - Owned By
+
+    func testWhenTrackerIsOwnedByAnotherCompanyThenOwnerNameIsParentOwner() throws {
+        // GIVEN
+        let tracker = KnownTracker(domain: "tracker.com",
+                                   defaultAction: .block,
+                                   owner: .init(name: "Tracker Inc", displayName: "Tracker Inc company", ownedBy: "Parent Owner Tracker"),
+                                   prevalence: 0.1,
+                                   subdomains: nil,
+                                   categories: ["Advertising"],
+                                   rules: nil)
+
+        let entity = Entity(displayName: "Trackr Inc company",
+                            domains: ["tracker.com"],
+                            prevalence: 0.1)
+
+        let tds = TrackerData(trackers: ["tracker.com": tracker],
+                              entities: ["Tracker Inc": entity],
+                              domains: ["tracker.com": "Tracker Inc"],
+                              cnames: [:])
+
+        let resolver = TrackerResolver(tds: tds, unprotectedSites: [], tempList: [], tld: tld)
+
+        // WHEN
+        let result = try XCTUnwrap(resolver.trackerFromUrl("https://tracker.com/img/1.png", pageUrlString: "https://example.com", resourceType: "image", potentiallyBlocked: true))
+
+        // THEN
+        XCTAssert(result.isBlocked)
+        XCTAssertEqual(result.state, .blocked)
+        XCTAssertEqual(result.ownerName, tracker.owner?.ownedBy)
+        XCTAssertEqual(result.entityName, entity.displayName)
+        XCTAssertEqual(result.category, tracker.category)
+        XCTAssertEqual(result.prevalence, tracker.prevalence)
+    }
+
+}
+
+private extension KnownTracker.Owner {
+    static let trackerInc = KnownTracker.Owner(name: "Tracker Inc", displayName: "Tracker Inc company", ownedBy: nil)
 }

--- a/Tests/ConfigurationTests/ConfigurationValidatorTests.swift
+++ b/Tests/ConfigurationTests/ConfigurationValidatorTests.swift
@@ -40,7 +40,7 @@ final class ConfigurationValidatorTests: XCTestCase {
         let tracker = KnownTracker(
             domain: "tracker.com",
             defaultAction: .block,
-            owner: .init(name: "Tracker Inc", displayName: "Tracker Inc company"),
+            owner: .init(name: "Tracker Inc", displayName: "Tracker Inc company", ownedBy: nil),
             prevalence: 0.1,
             subdomains: nil,
             categories: nil,


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1176956903599313/1208164650000833/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3286
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3168
What kind of version bump will this require? Minor

**Description**:

There’s an existing [issue](https://app.asana.com/0/0/1207970856546695/1208097565947206/f) that causes showing the wrong education dialog for websites that are owned by a major network like Facebook and Google.

In addition, the Privacy Dashboard [does not reflect weather an entity is owned by a major tracker](https://app.asana.com/0/0/1207970856546695/1208114308033513/f)

This PR exposes the field “ownedBy” with the purpose of identifying when a tracker is owned by another entity. e.g. Instagram is ownedBy is Facebook

**Steps to test this PR**:
1. See iOS  
1. See macOS

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
