### PR TITLE
Adds new Autofill unknownUsernameCategorization feature flag

### DIFF
--- a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -77,6 +77,8 @@ public struct ContentScopeFeatureToggles: Encodable {
     public let inlineIconCredentials: Bool
     public let thirdPartyCredentialsProvider: Bool
 
+    public let unknownUsernameCategorization: Bool
+
     // Explicitly defined memberwise init only so it can be public
     public init(emailProtection: Bool,
                 emailProtectionIncontextSignup: Bool,
@@ -86,7 +88,8 @@ public struct ContentScopeFeatureToggles: Encodable {
                 credentialsSaving: Bool,
                 passwordGeneration: Bool,
                 inlineIconCredentials: Bool,
-                thirdPartyCredentialsProvider: Bool) {
+                thirdPartyCredentialsProvider: Bool,
+                unknownUsernameCategorization: Bool) {
 
         self.emailProtection = emailProtection
         self.emailProtectionIncontextSignup = emailProtectionIncontextSignup
@@ -97,6 +100,7 @@ public struct ContentScopeFeatureToggles: Encodable {
         self.passwordGeneration = passwordGeneration
         self.inlineIconCredentials = inlineIconCredentials
         self.thirdPartyCredentialsProvider = thirdPartyCredentialsProvider
+        self.unknownUsernameCategorization = unknownUsernameCategorization
     }
 
     enum CodingKeys: String, CodingKey {
@@ -113,6 +117,7 @@ public struct ContentScopeFeatureToggles: Encodable {
 
         case inlineIconCredentials = "inlineIcon_credentials"
         case thirdPartyCredentialsProvider = "third_party_credentials_provider"
+        case unknownUsernameCategorization = "unknown_username_categorization"
     }
 }
 

--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -76,6 +76,7 @@ public enum AutofillSubfeature: String, PrivacySubfeature {
     case onByDefault
     case deduplicateLoginsOnImport
     case onForExistingUsers
+    case unknownUsernameCategorization
 }
 
 public enum DBPSubfeature: String, Equatable, PrivacySubfeature {

--- a/Tests/BrowserServicesKitTests/ContentScopeScriptTests/ContentScopePropertiesMocks.swift
+++ b/Tests/BrowserServicesKitTests/ContentScopeScriptTests/ContentScopePropertiesMocks.swift
@@ -27,5 +27,6 @@ extension ContentScopeFeatureToggles {
                                                          credentialsSaving: true,
                                                          passwordGeneration: true,
                                                          inlineIconCredentials: true,
-                                                         thirdPartyCredentialsProvider: false)
+                                                         thirdPartyCredentialsProvider: false,
+                                                         unknownUsernameCategorization: true)
 }

--- a/Tests/BrowserServicesKitTests/Fingerprinting/FingerprintingReferenceTests.swift
+++ b/Tests/BrowserServicesKitTests/Fingerprinting/FingerprintingReferenceTests.swift
@@ -215,7 +215,8 @@ final class FingerprintingReferenceTests: XCTestCase {
                                                              credentialsSaving: false,
                                                              passwordGeneration: false,
                                                              inlineIconCredentials: false,
-                                                             thirdPartyCredentialsProvider: false)
+                                                             thirdPartyCredentialsProvider: false,
+                                                             unknownUsernameCategorization: false)
 
         let contentScopeProperties = ContentScopeProperties(gpcEnabled: false,
                                                             sessionKey: UUID().uuidString,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201462886803403/1208150709359291/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3288
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3170
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
Adds new Autofill unknownUsernameCategorization feature flag to privacy config

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
