### PR TITLE
return urls on burn domains

### DIFF
--- a/Sources/History/HistoryCoordinator.swift
+++ b/Sources/History/HistoryCoordinator.swift
@@ -41,7 +41,7 @@ public protocol HistoryCoordinating: AnyObject {
     func title(for url: URL) -> String?
 
     func burnAll(completion: @escaping () -> Void)
-    func burnDomains(_ baseDomains: Set<String>, tld: TLD, completion: @escaping () -> Void)
+    func burnDomains(_ baseDomains: Set<String>, tld: TLD, completion: @escaping (Set<URL>) -> Void)
     func burnVisits(_ visits: [Visit], completion: @escaping () -> Void)
 
 }
@@ -168,19 +168,18 @@ final public class HistoryCoordinator: HistoryCoordinating {
         }
     }
 
-    public func burnDomains(_ baseDomains: Set<String>, tld: TLD, completion: @escaping () -> Void) {
+    public func burnDomains(_ baseDomains: Set<String>, tld: TLD, completion: @escaping (Set<URL>) -> Void) {
         guard let historyDictionary = historyDictionary else { return }
 
+        var urls = Set<URL>()
         let entries: [HistoryEntry] = historyDictionary.values.filter { historyEntry in
-            guard let host = historyEntry.url.host, let baseDomain = tld.eTLDplus1(host) else {
-                return false
-            }
-
+            guard let host = historyEntry.url.host, let baseDomain = tld.eTLDplus1(host) else { return false }
+            urls.insert(historyEntry.url)
             return baseDomains.contains(baseDomain)
         }
 
         removeEntries(entries, completionHandler: { _ in
-            completion()
+            completion(urls)
         })
     }
 

--- a/Sources/History/HistoryCoordinator.swift
+++ b/Sources/History/HistoryCoordinator.swift
@@ -173,9 +173,11 @@ final public class HistoryCoordinator: HistoryCoordinating {
 
         var urls = Set<URL>()
         let entries: [HistoryEntry] = historyDictionary.values.filter { historyEntry in
-            guard let host = historyEntry.url.host, let baseDomain = tld.eTLDplus1(host) else { return false }
+            guard let host = historyEntry.url.host,
+                  let baseDomain = tld.eTLDplus1(host),
+                  baseDomains.contains(baseDomain) else { return false }
             urls.insert(historyEntry.url)
-            return baseDomains.contains(baseDomain)
+            return true
         }
 
         removeEntries(entries, completionHandler: { _ in

--- a/Tests/BrowserServicesKitTests/Autofill/AutofillEmailUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/AutofillEmailUserScriptTests.swift
@@ -332,9 +332,44 @@ class MockAutofillEmailDelegate: AutofillEmailDelegate {
 class MockWebView: WKWebView {
 
     var javaScriptString: String?
+    var evaluateJavaScriptResult: Any?
 
-    override func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)? = nil) {
-        self.javaScriptString = javaScriptString
+    convenience init() {
+        self.init(frame: .zero, configuration: WKWebViewConfiguration())
+    }
+
+    override init(frame: CGRect, configuration: WKWebViewConfiguration) {
+        _=Self.swizzleEvaluateJavaScriptOnce
+        super.init(frame: frame, configuration: configuration)
+    }
+
+    required init?(coder: NSCoder) {
+        _=Self.swizzleEvaluateJavaScriptOnce
+        super.init(coder: coder)
+    }
+
+}
+private extension WKWebView {
+
+    static let swizzleEvaluateJavaScriptOnce: () = {
+        guard let originalMethod = class_getInstanceMethod(WKWebView.self, #selector(evaluateJavaScript(_:completionHandler:))),
+              let swizzledMethod = class_getInstanceMethod(WKWebView.self, #selector(swizzled_evaluateJavaScript(_:completionHandler:))) else {
+            assertionFailure("Methods not available")
+            return
+        }
+
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }()
+
+    // place popover inside bounds of its owner Main Window
+    @objc(swizzled_evaluateJavaScript:completionHandler:)
+    private dynamic func swizzled_evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, (any Error)?) -> Void)? = nil) {
+        if let mockWebView = self as? MockWebView {
+            mockWebView.javaScriptString = javaScriptString
+            completionHandler?(mockWebView.evaluateJavaScriptResult, nil)
+            return
+        }
+        self.swizzled_evaluateJavaScript(javaScriptString, completionHandler: completionHandler) // call the original
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1175293949586521/1204211850543327/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3353
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3261
What kind of version bump will this require?: Major

**Optional**:

Tech Design URL:
CC:

**Description**:
- return retreived URLs in callback when burning history entries by domain

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
