### PR TITLE
C.S.S Patch Privacy Config on C.S.S for "internal" support in DuckPlayer 

### DIFF
--- a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -162,7 +162,7 @@ public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessa
                                       isolated: Bool,
                                       config: WebkitMessagingConfig
     ) -> String {
- 
+
         guard var privacyConfigJson = String(data: privacyConfigurationManager.currentConfig, encoding: .utf8) else {
             return ""
         }
@@ -195,27 +195,27 @@ public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessa
     public let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
     public let forMainFrameOnly: Bool = false
     public var requiresRunInPageContentWorld: Bool { !self.isIsolated }
-    
-    
+
+
     // The Frontend does not support "internal" state for features, so in order to release
     // DuckPlayer to internal users, we need to patch the Privacy Config to replace "internal" with "enabled"
     // This will be removed once DuckPlayer is released to the public
     private static func patchPrivacyConfigForDuckPlayerInternal(privacyConfigJson: String) -> String {
         do {
-            
+ 
             guard let jsonData = privacyConfigJson.data(using: .utf8) else { return privacyConfigJson }
-            
+
             guard var jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] else {
                 return privacyConfigJson
             }
-                        
+
             if var features = jsonObject["features"] as? [String: Any],
                var duckPlayer = features["duckPlayer"] as? [String: Any] {
                 duckPlayer["state"] = "enabled"
                 features["duckPlayer"] = duckPlayer
                 jsonObject["features"] = features
             }
-                        
+
             let modifiedData = try JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted)
             return String(data: modifiedData, encoding: .utf8) ?? privacyConfigJson
             
@@ -223,7 +223,7 @@ public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessa
             return privacyConfigJson
         }
     }
-    
+
 }
 
 @available(macOS 11.0, iOS 14.0, *)

--- a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -196,13 +196,12 @@ public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessa
     public let forMainFrameOnly: Bool = false
     public var requiresRunInPageContentWorld: Bool { !self.isIsolated }
 
-
     // The Frontend does not support "internal" state for features, so in order to release
     // DuckPlayer to internal users, we need to patch the Privacy Config to replace "internal" with "enabled"
     // This will be removed once DuckPlayer is released to the public
     private static func patchPrivacyConfigForDuckPlayerInternal(privacyConfigJson: String) -> String {
         do {
- 
+
             guard let jsonData = privacyConfigJson.data(using: .utf8) else { return privacyConfigJson }
 
             guard var jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] else {
@@ -218,7 +217,7 @@ public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessa
 
             let modifiedData = try JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted)
             return String(data: modifiedData, encoding: .utf8) ?? privacyConfigJson
-            
+
         } catch {
             return privacyConfigJson
         }

--- a/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -162,14 +162,21 @@ public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessa
                                       isolated: Bool,
                                       config: WebkitMessagingConfig
     ) -> String {
+ 
+        guard var privacyConfigJson = String(data: privacyConfigurationManager.currentConfig, encoding: .utf8) else {
+            return ""
+        }
 
-        guard let privacyConfigJson = String(data: privacyConfigurationManager.currentConfig, encoding: .utf8),
-              let userUnprotectedDomains = try? JSONEncoder().encode(privacyConfigurationManager.privacyConfig.userUnprotectedDomains),
-              let userUnprotectedDomainsString = String(data: userUnprotectedDomains, encoding: .utf8),
-              let jsonProperties = try? JSONEncoder().encode(properties),
-              let jsonPropertiesString = String(data: jsonProperties, encoding: .utf8),
-              let jsonConfig = try? JSONEncoder().encode(config),
-              let jsonConfigString = String(data: jsonConfig, encoding: .utf8)
+        if privacyConfigurationManager.internalUserDecider.isInternalUser {
+            privacyConfigJson = patchPrivacyConfigForDuckPlayerInternal(privacyConfigJson: privacyConfigJson)
+        }
+
+        guard let userUnprotectedDomains = try? JSONEncoder().encode(privacyConfigurationManager.privacyConfig.userUnprotectedDomains),
+                let userUnprotectedDomainsString = String(data: userUnprotectedDomains, encoding: .utf8),
+                let jsonProperties = try? JSONEncoder().encode(properties),
+                let jsonPropertiesString = String(data: jsonProperties, encoding: .utf8),
+                let jsonConfig = try? JSONEncoder().encode(config),
+                let jsonConfigString = String(data: jsonConfig, encoding: .utf8)
         else {
             return ""
         }
@@ -188,6 +195,35 @@ public final class ContentScopeUserScript: NSObject, UserScript, UserScriptMessa
     public let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
     public let forMainFrameOnly: Bool = false
     public var requiresRunInPageContentWorld: Bool { !self.isIsolated }
+    
+    
+    // The Frontend does not support "internal" state for features, so in order to release
+    // DuckPlayer to internal users, we need to patch the Privacy Config to replace "internal" with "enabled"
+    // This will be removed once DuckPlayer is released to the public
+    private static func patchPrivacyConfigForDuckPlayerInternal(privacyConfigJson: String) -> String {
+        do {
+            
+            guard let jsonData = privacyConfigJson.data(using: .utf8) else { return privacyConfigJson }
+            
+            guard var jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] else {
+                return privacyConfigJson
+            }
+                        
+            if var features = jsonObject["features"] as? [String: Any],
+               var duckPlayer = features["duckPlayer"] as? [String: Any] {
+                duckPlayer["state"] = "enabled"
+                features["duckPlayer"] = duckPlayer
+                jsonObject["features"] = features
+            }
+                        
+            let modifiedData = try JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted)
+            return String(data: modifiedData, encoding: .utf8) ?? privacyConfigJson
+            
+        } catch {
+            return privacyConfigJson
+        }
+    }
+    
 }
 
 @available(macOS 11.0, iOS 14.0, *)


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1204099484721401/1208292211771741/f
iOS PR:  https://github.com/duckduckgo/iOS/pull/3359
macOS PR:  https://github.com/duckduckgo/macos-browser/pull/3272
What kind of version bump will this require?: Minor

**Description**:
The Frontend does not support "internal" state for features, so in order to release
 DuckPlayer to internal users, we need to patch the Privacy Config to replace "internal" with "enabled"
 This will be removed once DuckPlayer is released to the public

**Testing**
- Check Platform PRs