### PR TITLE
fix crash on Navigation Action Task cancellation

### DIFF
--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -301,8 +301,8 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
 
     // MARK: Policy making
 
-    @MainActor
-    public func webView(_ webView: WKWebView, decidePolicyFor wkNavigationAction: WKNavigationAction, preferences wkPreferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
+    // swiftlint:disable:next cyclomatic_complexity
+    @MainActor public func webView(_ webView: WKWebView, decidePolicyFor wkNavigationAction: WKNavigationAction, preferences wkPreferences: WKWebpagePreferences, decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
 
         // new navigation or an ongoing navigation (for a server-redirect)?
         let navigation = navigation(for: wkNavigationAction, in: webView)

--- a/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -342,7 +342,7 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
 
         var preferences = NavigationPreferences(userAgent: webView.customUserAgent, preferences: wkPreferences)
         // keep WKNavigationAction alive until the decision is made but not any longer!
-        var wkNavigationAction: WKNavigationAction! = wkNavigationAction
+        var wkNavigationAction: WKNavigationAction? = wkNavigationAction
         // pass async decision making to Navigation.navigationResponders (or the delegate navigationResponders for non-main-frame navigations)
         let task = makeAsyncDecision(for: navigationAction, boundToLifetimeOf: webView, with: mainFrameNavigation?.navigationResponders ?? responders) { @MainActor responder in
             dispatchPrecondition(condition: .onQueue(.main))
@@ -355,6 +355,12 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
 
         } completion: { @MainActor [self, weak webView] (decision: NavigationActionPolicy?) in
             dispatchPrecondition(condition: .onQueue(.main))
+            guard wkNavigationAction != nil else { return } // the Task has been cancelled
+            defer {
+                // don‘t release the original WKNavigationAction until the end
+                withExtendedLifetime(wkNavigationAction) {}
+                wkNavigationAction = nil
+            }
             guard let webView else {
                 decisionHandler(.cancel, wkPreferences)
                 return
@@ -401,19 +407,19 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
                 self.willStartDownload(with: navigationAction, in: webView)
                 decisionHandler(.downloadPolicy, wkPreferences)
             }
-            // don‘t release the original WKNavigationAction until the end
-            withExtendedLifetime(wkNavigationAction) {}
 
         } /* Task */ cancellation: {
             dispatchPrecondition(condition: .onQueue(.main))
+            guard wkNavigationAction != nil else { return } // the decision was already made
+            defer {
+                // in case decision making is hung release WKNavigationAction just after cancellation
+                // to release WKProcessPool and everything bound to it including UserContentController
+                withExtendedLifetime(wkNavigationAction) {}
+                wkNavigationAction = nil
+            }
 
             Logger.navigation.log("Task cancelled for \(navigationAction.debugDescription)")
             decisionHandler(.cancel, wkPreferences)
-
-            // in case decision making is hung release WKNavigationAction just after cancellation
-            // to release WKProcessPool and everything bound to it including UserContentController
-            withExtendedLifetime(wkNavigationAction) {}
-            wkNavigationAction = nil
         }
 
         if navigationAction.isForMainFrame {

--- a/Tests/NavigationTests/Helpers/NavigationResponderMock.swift
+++ b/Tests/NavigationTests/Helpers/NavigationResponderMock.swift
@@ -375,7 +375,7 @@ class NavigationResponderMock: NavigationResponder {
     var onDidTerminate: (@MainActor (WKProcessTerminationReason?) -> Void)?
     func webContentProcessDidTerminate(with reason: WKProcessTerminationReason?) {
         let event = append(.didTerminate(reason))
-        onDidTerminate?(reason) ?? defaultHandler(event)
+        onDidTerminate?(reason)
     }
 
 }


### PR DESCRIPTION
…on making Task cancellation

<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1207340338530322/1208145681457166/f
iOS PR: not affected
macOS PR: alex/window-deallocation
What kind of version bump will this require?: Patch

**Description**:
- Fix crash on Navigation Action decision making Task cancellation
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. add the following code to `Tab.swift` `decidePolicy(for:preferences:)` method:
```
navigationAction.url.isDuckDuckGoSearch {
    try? await Task.sleep(interval: 10)
    return .allow
}
```
2. Search for something; Close the tab while loading is in progress
3. Validate `cancellation:` handler at `DistributedNavigationDelegate.swift:412` is called and not crashing

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
