### PR TITLE
Bump C.S.S to fix DuckPlayer FE Issue

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "9f3717b3913a12956f1386fe7b657f68545fba83",
-        "version" : "6.15.0"
+        "revision" : "2bed9e2963b2a9232452911d0773fac8b56416a1",
+        "version" : "6.17.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "2.1.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "5.3.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "6.15.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "6.17.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208399924957022/f
iOS PR:  TBD
macOS PR:  Not required this is an iOS Hotfix
What kind of version bump will this require?: Hotfix

**Description**:
- Bumps C.S.S to 6.17 to fix Youtube shorts
