### PR TITLE
fix suggestions performance

### DIFF
--- a/Sources/Suggestions/SuggestionProcessing.swift
+++ b/Sources/Suggestions/SuggestionProcessing.swift
@@ -58,7 +58,8 @@ final class SuggestionProcessing {
         }
 
         // Get best matches from history and bookmarks
-        let allLocalSuggestions = localSuggestions(from: history, bookmarks: bookmarks, internalPages: internalPages, openTabs: openTabs, query: query)
+        let allLocalSuggestions = Array(localSuggestions(from: history, bookmarks: bookmarks, internalPages: internalPages, openTabs: openTabs, query: query)
+            .prefix(100)) // temporary optimsiation
 
         // Combine HaB and domains into navigational suggestions and remove duplicates
         let navigationalSuggestions = allLocalSuggestions + duckDuckGoDomainSuggestions


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/1201048563534612/1208413716679959/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3405
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3353
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
Fix suggestions performance issue by just looking at the first 100 sorted local results.

**Steps to test this PR**:
1. Run the app on a local large data source (history entries > 1000 entries ideally)
1. Use autocomplete and check that it doesn't time out for a broad range of matches

