### PR TITLE
Allow adding custom bookmarks using AddOrEditBookmarkViewController

### DIFF
--- a/Sources/Bookmarks/BookmarkEditorViewModel.swift
+++ b/Sources/Bookmarks/BookmarkEditorViewModel.swift
@@ -148,7 +148,6 @@ public class BookmarkEditorViewModel: ObservableObject {
         }
     }
 
-
     private func registerForChanges() {
         observer = NotificationCenter.default.addObserver(forName: NSManagedObjectContext.didSaveObjectsNotification,
                                                           object: nil,
@@ -241,5 +240,3 @@ public class BookmarkEditorViewModel: ObservableObject {
         }
     }
 }
-
-

--- a/Sources/Bookmarks/BookmarkSanitization.swift
+++ b/Sources/Bookmarks/BookmarkSanitization.swift
@@ -1,0 +1,46 @@
+//
+//  BookmarkSanitization.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Provides strategies to sanitize edited Bookmark.
+public enum BookmarkSanitization {
+
+    /// Treats input as a potentially navigational address, appending scheme and fixing common known issues
+    case navigational
+
+    /// Provides a custom sanitization function
+    case custom((BookmarkEntity) -> Void)
+
+    func sanitize(_ bookmark: BookmarkEntity) {
+        switch self {
+        case .navigational:
+            navigationalSanitization(bookmark)
+        case .custom(let sanitize):
+            sanitize(bookmark)
+        }
+    }
+
+    private func navigationalSanitization(_ bookmark: BookmarkEntity) {
+        guard let url = bookmark.url else {
+            return
+        }
+
+        bookmark.url = URL(trimmedAddressBarString: url)?.absoluteString ?? url
+    }
+}

--- a/Tests/BookmarksTests/BookmarksSanitizationTests.swift
+++ b/Tests/BookmarksTests/BookmarksSanitizationTests.swift
@@ -23,17 +23,17 @@ import CoreData
 import Foundation
 
 final class BookmarksSanitizationTests: XCTestCase {
-    
+
     private var bookmarksDatabase: CoreDataDatabase!
     private var location: URL!
     private var context: NSManagedObjectContext!
     private var rootFolder: BookmarkEntity!
-    
+
     override func setUp() {
         super.setUp()
-        
+
         location = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        
+
         let bundle = Bookmarks.bundle
         guard let model = CoreDataDatabase.loadModel(from: bundle, named: "BookmarksModel") else {
             XCTFail("Failed to load model")
@@ -41,88 +41,88 @@ final class BookmarksSanitizationTests: XCTestCase {
         }
         bookmarksDatabase = CoreDataDatabase(name: type(of: self).description(), containerLocation: location, model: model)
         bookmarksDatabase.loadStore()
-        
+
         context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
         context.performAndWait {
             BookmarkUtils.prepareFoldersStructure(in: context)
             try! context.save()
         }
-        
+
         rootFolder = BookmarkUtils.fetchRootFolder(context)
     }
-    
+
     override func tearDown() {
         super.tearDown()
-        
+
         try? FileManager.default.removeItem(at: location)
     }
-    
+
     func testRunsCustomSanitization() {
         let bookmark = stubBookmark(url: "some.url", in: context)
         var didRunCustomFunction = false
         let sanitization = BookmarkSanitization.custom { _ in
             didRunCustomFunction = true
         }
-        
+
         sanitization.sanitize(bookmark)
-        
+
         XCTAssertTrue(didRunCustomFunction)
     }
-    
+
     func testNavigationalSanitizationAddsSchemeToURL() {
         let bookmark = stubBookmark(url: "some.url", in: context)
         let sanitization = BookmarkSanitization.navigational
-        
+
         sanitization.sanitize(bookmark)
-        
+
         XCTAssertEqual(bookmark.url, "http://some.url")
     }
-    
+
     func testNavigationalSanitizationAllowsIPAddress() {
         let bookmark = stubBookmark(url: "192.168.1.1", in: context)
         let sanitization = BookmarkSanitization.navigational
-        
+
         sanitization.sanitize(bookmark)
-        
+
         XCTAssertEqual(bookmark.url, "http://192.168.1.1")
     }
-    
+
     func testNavigationalSanitizationKeepsExistingHTTPScheme() {
         let bookmark = stubBookmark(url: "https://some.url", in: context)
         let sanitization = BookmarkSanitization.navigational
-        
+
         sanitization.sanitize(bookmark)
-        
+
         XCTAssertEqual(bookmark.url, "https://some.url")
     }
-    
+
     func testNavigationalSanitizationKeepsExistingScheme() {
         let bookmark = stubBookmark(url: "somescheme://some.url", in: context)
         let sanitization = BookmarkSanitization.navigational
-        
+
         sanitization.sanitize(bookmark)
-        
+
         XCTAssertEqual(bookmark.url, "somescheme://some.url")
     }
-    
+
     func testNavigationalSanitizationUsesPunycodeForEmoji() {
         let bookmark = stubBookmark(url: "https://😍.url", in: context)
         let sanitization = BookmarkSanitization.navigational
-        
+
         sanitization.sanitize(bookmark)
-        
+
         XCTAssertEqual(bookmark.url, "https://xn--r28h.url")
     }
-    
+
     func testNavigationalSanitizationKeepsEmptyString() {
         let bookmark = stubBookmark(url: "  ", in: context)
         let sanitization = BookmarkSanitization.navigational
-        
+
         sanitization.sanitize(bookmark)
-        
+
         XCTAssertEqual(bookmark.url, "  ")
     }
-    
+
     private func stubBookmark(url: String, in context: NSManagedObjectContext) -> BookmarkEntity {
         BookmarkEntity.makeBookmark(title: "", url: url, parent: rootFolder, context: context)
     }

--- a/Tests/BookmarksTests/BookmarksSanitizationTests.swift
+++ b/Tests/BookmarksTests/BookmarksSanitizationTests.swift
@@ -1,0 +1,129 @@
+//
+//  BookmarksSanitizationTests.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Persistence
+@testable import Bookmarks
+import CoreData
+import Foundation
+
+final class BookmarksSanitizationTests: XCTestCase {
+
+    private var bookmarksDatabase: CoreDataDatabase!
+    private var location: URL!
+    private var context: NSManagedObjectContext!
+    private var rootFolder: BookmarkEntity!
+
+    override func setUp() {
+        super.setUp()
+
+        location = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        let bundle = Bookmarks.bundle
+        guard let model = CoreDataDatabase.loadModel(from: bundle, named: "BookmarksModel") else {
+            XCTFail("Failed to load model")
+            return
+        }
+        bookmarksDatabase = CoreDataDatabase(name: type(of: self).description(), containerLocation: location, model: model)
+        bookmarksDatabase.loadStore()
+
+        context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+        context.performAndWait {
+            BookmarkUtils.prepareFoldersStructure(in: context)
+            try! context.save()
+        }
+
+        rootFolder = BookmarkUtils.fetchRootFolder(context)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        try? FileManager.default.removeItem(at: location)
+    }
+
+    func testRunsCustomSanitization() {
+        let bookmark = stubBookmark(url: "some.url", in: context)
+        var didRunCustomFunction = false
+        let sanitization = BookmarkSanitization.custom { _ in
+            didRunCustomFunction = true
+        }
+
+        sanitization.sanitize(bookmark)
+
+        XCTAssertTrue(didRunCustomFunction)
+    }
+
+    func testNavigationalSanitizationAddsSchemeToURL() {
+        let bookmark = stubBookmark(url: "some.url", in: context)
+        let sanitization = BookmarkSanitization.navigational
+        
+        sanitization.sanitize(bookmark)
+
+        XCTAssertEqual(bookmark.url, "http://some.url")
+    }
+
+    func testNavigationalSanitizationAllowsIPAddress() {
+        let bookmark = stubBookmark(url: "192.168.1.1", in: context)
+        let sanitization = BookmarkSanitization.navigational
+        
+        sanitization.sanitize(bookmark)
+        
+        XCTAssertEqual(bookmark.url, "http://192.168.1.1")
+    }
+
+    func testNavigationalSanitizationKeepsExistingHTTPScheme() {
+        let bookmark = stubBookmark(url: "https://some.url", in: context)
+        let sanitization = BookmarkSanitization.navigational
+
+        sanitization.sanitize(bookmark)
+
+        XCTAssertEqual(bookmark.url, "https://some.url")
+    }
+
+    func testNavigationalSanitizationKeepsExistingScheme() {
+        let bookmark = stubBookmark(url: "somescheme://some.url", in: context)
+        let sanitization = BookmarkSanitization.navigational
+
+        sanitization.sanitize(bookmark)
+
+        XCTAssertEqual(bookmark.url, "somescheme://some.url")
+    }
+
+    func testNavigationalSanitizationUsesPunycodeForEmoji() {
+        let bookmark = stubBookmark(url: "https://😍.url", in: context)
+        let sanitization = BookmarkSanitization.navigational
+
+        sanitization.sanitize(bookmark)
+
+        XCTAssertEqual(bookmark.url, "https://xn--r28h.url")
+    }
+
+    func testNavigationalSanitizationKeepsEmptyString() {
+        let bookmark = stubBookmark(url: "  ", in: context)
+        let sanitization = BookmarkSanitization.navigational
+
+        sanitization.sanitize(bookmark)
+
+        XCTAssertEqual(bookmark.url, "  ")
+    }
+
+    private func stubBookmark(url: String, in context: NSManagedObjectContext) -> BookmarkEntity {
+        BookmarkEntity.makeBookmark(title: "", url: url, parent: rootFolder, context: context)
+    }
+}

--- a/Tests/BookmarksTests/BookmarksSanitizationTests.swift
+++ b/Tests/BookmarksTests/BookmarksSanitizationTests.swift
@@ -23,17 +23,17 @@ import CoreData
 import Foundation
 
 final class BookmarksSanitizationTests: XCTestCase {
-
+    
     private var bookmarksDatabase: CoreDataDatabase!
     private var location: URL!
     private var context: NSManagedObjectContext!
     private var rootFolder: BookmarkEntity!
-
+    
     override func setUp() {
         super.setUp()
-
+        
         location = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-
+        
         let bundle = Bookmarks.bundle
         guard let model = CoreDataDatabase.loadModel(from: bundle, named: "BookmarksModel") else {
             XCTFail("Failed to load model")
@@ -41,43 +41,43 @@ final class BookmarksSanitizationTests: XCTestCase {
         }
         bookmarksDatabase = CoreDataDatabase(name: type(of: self).description(), containerLocation: location, model: model)
         bookmarksDatabase.loadStore()
-
+        
         context = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
         context.performAndWait {
             BookmarkUtils.prepareFoldersStructure(in: context)
             try! context.save()
         }
-
+        
         rootFolder = BookmarkUtils.fetchRootFolder(context)
     }
-
+    
     override func tearDown() {
         super.tearDown()
-
+        
         try? FileManager.default.removeItem(at: location)
     }
-
+    
     func testRunsCustomSanitization() {
         let bookmark = stubBookmark(url: "some.url", in: context)
         var didRunCustomFunction = false
         let sanitization = BookmarkSanitization.custom { _ in
             didRunCustomFunction = true
         }
-
+        
         sanitization.sanitize(bookmark)
-
+        
         XCTAssertTrue(didRunCustomFunction)
     }
-
+    
     func testNavigationalSanitizationAddsSchemeToURL() {
         let bookmark = stubBookmark(url: "some.url", in: context)
         let sanitization = BookmarkSanitization.navigational
         
         sanitization.sanitize(bookmark)
-
+        
         XCTAssertEqual(bookmark.url, "http://some.url")
     }
-
+    
     func testNavigationalSanitizationAllowsIPAddress() {
         let bookmark = stubBookmark(url: "192.168.1.1", in: context)
         let sanitization = BookmarkSanitization.navigational
@@ -86,43 +86,43 @@ final class BookmarksSanitizationTests: XCTestCase {
         
         XCTAssertEqual(bookmark.url, "http://192.168.1.1")
     }
-
+    
     func testNavigationalSanitizationKeepsExistingHTTPScheme() {
         let bookmark = stubBookmark(url: "https://some.url", in: context)
         let sanitization = BookmarkSanitization.navigational
-
+        
         sanitization.sanitize(bookmark)
-
+        
         XCTAssertEqual(bookmark.url, "https://some.url")
     }
-
+    
     func testNavigationalSanitizationKeepsExistingScheme() {
         let bookmark = stubBookmark(url: "somescheme://some.url", in: context)
         let sanitization = BookmarkSanitization.navigational
-
+        
         sanitization.sanitize(bookmark)
-
+        
         XCTAssertEqual(bookmark.url, "somescheme://some.url")
     }
-
+    
     func testNavigationalSanitizationUsesPunycodeForEmoji() {
         let bookmark = stubBookmark(url: "https://😍.url", in: context)
         let sanitization = BookmarkSanitization.navigational
-
+        
         sanitization.sanitize(bookmark)
-
+        
         XCTAssertEqual(bookmark.url, "https://xn--r28h.url")
     }
-
+    
     func testNavigationalSanitizationKeepsEmptyString() {
         let bookmark = stubBookmark(url: "  ", in: context)
         let sanitization = BookmarkSanitization.navigational
-
+        
         sanitization.sanitize(bookmark)
-
+        
         XCTAssertEqual(bookmark.url, "  ")
     }
-
+    
     private func stubBookmark(url: String, in context: NSManagedObjectContext) -> BookmarkEntity {
         BookmarkEntity.makeBookmark(title: "", url: url, parent: rootFolder, context: context)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1208407775147560/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3410
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3355
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL:
CC:

**Description**:

To allow adding custom favorites in Add Favorite flow, there are small changes in BSK required. Usage will be implemented in https://github.com/duckduckgo/iOS/pull/3403.

No changes on macOS.

**Steps to test this PR**:
1. On iOS Open Debug menu and use the option at the end of the list to test the feature.
2. Try adding bookmarks and favorites.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
