### PR TITLE
Add Events Firing for Phishing Detection Settings

### DIFF
--- a/Sources/PhishingDetection/PhishingDetectionEvents.swift
+++ b/Sources/PhishingDetection/PhishingDetectionEvents.swift
@@ -22,6 +22,7 @@ import PixelKit
 public extension PixelKit {
     enum Parameters: Hashable {
         public static let clientSideHit = "client_side_hit"
+        public static let settingToggledTo = "setting_toggled_to"
     }
 }
 
@@ -30,6 +31,7 @@ public enum PhishingDetectionEvents: PixelKitEventV2 {
     case visitSite
     case iframeLoaded
     case updateTaskFailed48h(error: Error?)
+    case settingToggled(to: Bool)
 
     public var name: String {
         switch self {
@@ -41,6 +43,8 @@ public enum PhishingDetectionEvents: PixelKitEventV2 {
             return "phishing_detection_iframe-loaded"
         case .updateTaskFailed48h:
             return "phishing_detection_update-task-failed-48h"
+        case .settingToggled:
+            return "phishing_detection_setting-toggled"
         }
     }
 
@@ -54,6 +58,8 @@ public enum PhishingDetectionEvents: PixelKitEventV2 {
             return [:]
         case .updateTaskFailed48h(let error):
             return error?.pixelParameters
+        case .settingToggled(let state):
+            return [PixelKit.Parameters.settingToggledTo: String(state)]
         }
     }
 
@@ -66,6 +72,8 @@ public enum PhishingDetectionEvents: PixelKitEventV2 {
         case .visitSite:
             return nil
         case .iframeLoaded:
+            return nil
+        case .settingToggled:
             return nil
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/72649045549333/1208270234071171/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3423
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3379
What kind of version bump will this require?:Minor

**Optional**:

Tech Design URL: N/A
CC:

**Description**:
In [✓ Phishing Detection Pixels](https://app.asana.com/0/0/1207699541075655/f) we defined several pixels to include, and one of them did not make it into the initial release: 
- macos.phishing-detection.feature-toggled:
  - Parameters:
    - newState - on/off, indicating whether the user turned it on or off
- Condition
  - triggers when a user disables the feature from the settings page
- Reasoning
  - the aim is to use this as a "do-no-harm" KPI, to determine how many users are actively choosing to disable/enable phishing protection

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Point to tespach/phish-det-settings-event
2. Build the macOS browser
3. Filter by `m_mac_phishing_detection_setting-toggled` in the debug output of the app
4. Ensure you're authenticated via use-login.duckduckgo.com - this feature is internal only
5. Go to Settings>General
6. Toggle "Malicious Site Protection"
7. Return to debug output and ensure you see:
8. `👾[Standard-Fired] m_mac_phishing_detection_setting-toggled ["appVersion": "1.109.0", "pixelSource": "browser-dmg", "setting_toggled_to": "false"]`

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
