### PR TITLE
Refactor Core Data usage in RemoteMessagingStore

### DIFF
--- a/Sources/RemoteMessaging/RemoteMessagingProcessing.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingProcessing.swift
@@ -90,7 +90,7 @@ public extension RemoteMessagingProcessing {
             let storedConfig = store.fetchRemoteMessagingConfig()
 
             if let processorResult = processor.process(jsonRemoteMessagingConfig: jsonConfig, currentConfig: storedConfig) {
-                store.saveProcessedResult(processorResult)
+                await store.saveProcessedResult(processorResult)
             }
 
         } catch {

--- a/Sources/RemoteMessaging/RemoteMessagingStoring.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingStoring.swift
@@ -27,10 +27,8 @@ public protocol RemoteMessagingStoring: RemoteMessagingStoringDebuggingSupport {
     func saveProcessedResult(_ processorResult: RemoteMessagingConfigProcessor.ProcessorResult) async
     func fetchRemoteMessagingConfig() -> RemoteMessagingConfig?
     func fetchScheduledRemoteMessage() -> RemoteMessageModel?
-    func fetchRemoteMessage(withID id: String) -> RemoteMessageModel?
     func hasShownRemoteMessage(withID id: String) -> Bool
     func fetchShownRemoteMessageIDs() -> [String]
-    func hasDismissedRemoteMessage(withID id: String) -> Bool
     func dismissRemoteMessage(withID id: String) async
     func fetchDismissedRemoteMessageIDs() -> [String]
     func updateRemoteMessage(withID id: String, asShown shown: Bool) async

--- a/Sources/RemoteMessaging/RemoteMessagingStoring.swift
+++ b/Sources/RemoteMessaging/RemoteMessagingStoring.swift
@@ -19,20 +19,20 @@
 import Foundation
 
 public protocol RemoteMessagingStoringDebuggingSupport {
-    func resetRemoteMessages()
+    func resetRemoteMessages() async
 }
 
 public protocol RemoteMessagingStoring: RemoteMessagingStoringDebuggingSupport {
 
-    func saveProcessedResult(_ processorResult: RemoteMessagingConfigProcessor.ProcessorResult)
+    func saveProcessedResult(_ processorResult: RemoteMessagingConfigProcessor.ProcessorResult) async
     func fetchRemoteMessagingConfig() -> RemoteMessagingConfig?
     func fetchScheduledRemoteMessage() -> RemoteMessageModel?
     func fetchRemoteMessage(withID id: String) -> RemoteMessageModel?
     func hasShownRemoteMessage(withID id: String) -> Bool
     func fetchShownRemoteMessageIDs() -> [String]
     func hasDismissedRemoteMessage(withID id: String) -> Bool
-    func dismissRemoteMessage(withID id: String)
+    func dismissRemoteMessage(withID id: String) async
     func fetchDismissedRemoteMessageIDs() -> [String]
-    func updateRemoteMessage(withID id: String, asShown shown: Bool)
+    func updateRemoteMessage(withID id: String, asShown shown: Bool) async
 
 }

--- a/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
+++ b/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
@@ -24,10 +24,8 @@ public class MockRemoteMessagingStore: RemoteMessagingStoring {
     public var saveProcessedResultCalls = 0
     public var fetchRemoteMessagingConfigCalls = 0
     public var fetchScheduledRemoteMessageCalls = 0
-    public var fetchRemoteMessageCalls = 0
     public var hasShownRemoteMessageCalls = 0
     public var fetchShownRemoteMessageIDsCalls = 0
-    public var hasDismissedRemoteMessageCalls = 0
     public var dismissRemoteMessageCalls = 0
     public var fetchDismissedRemoteMessageIDsCalls = 0
     public var updateRemoteMessageCalls = 0

--- a/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
+++ b/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
@@ -66,11 +66,6 @@ public class MockRemoteMessagingStore: RemoteMessagingStoring {
         return scheduledRemoteMessage
     }
 
-    public func fetchRemoteMessage(withID id: String) -> RemoteMessageModel? {
-        fetchRemoteMessageCalls += 1
-        return remoteMessages[id]
-    }
-
     public func hasShownRemoteMessage(withID id: String) -> Bool {
         hasShownRemoteMessageCalls += 1
         return shownRemoteMessagesIDs.contains(id)
@@ -79,11 +74,6 @@ public class MockRemoteMessagingStore: RemoteMessagingStoring {
     public func fetchShownRemoteMessageIDs() -> [String] {
         fetchShownRemoteMessageIDsCalls += 1
         return shownRemoteMessagesIDs
-    }
-
-    public func hasDismissedRemoteMessage(withID id: String) -> Bool {
-        hasDismissedRemoteMessageCalls += 1
-        return dismissedRemoteMessagesIDs.contains(id)
     }
 
     public func dismissRemoteMessage(withID id: String) {

--- a/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -126,20 +126,6 @@ class RemoteMessagingStoreTests: XCTestCase {
         XCTAssertEqual(store.fetchShownRemoteMessageIDs(), [remoteMessage.id])
     }
 
-    func testWhenDismissRemoteMessageThenFetchedMessageHasDismissedState() async throws {
-        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
-
-        await store.dismissRemoteMessage(withID: remoteMessage.id)
-
-        guard let fetchedRemoteMessage = store.fetchRemoteMessage(withID: remoteMessage.id) else {
-            XCTFail("No remote message found")
-            return
-        }
-
-        XCTAssertEqual(fetchedRemoteMessage.id, remoteMessage.id)
-        XCTAssertTrue(store.hasDismissedRemoteMessage(withID: fetchedRemoteMessage.id))
-    }
-
     func testFetchDismissedRemoteMessageIds() async throws {
         let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
 
@@ -345,14 +331,6 @@ class RemoteMessagingStoreTests: XCTestCase {
         XCTAssertNil(store.fetchRemoteMessagingConfig())
     }
 
-    func testWhenFeatureFlagIsDisabledThenFetchedMessageReturnsNil() async throws {
-        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
-
-        try await setFeatureFlagEnabled(false)
-
-        XCTAssertNil(store.fetchRemoteMessage(withID: remoteMessage.id))
-    }
-
     func testWhenFeatureFlagIsDisabledThenUpdateShownFlagHasNoEffect() async throws {
         let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
         try await setFeatureFlagEnabled(false)
@@ -377,15 +355,6 @@ class RemoteMessagingStoreTests: XCTestCase {
         await store.dismissRemoteMessage(withID: remoteMessage.id)
 
         XCTAssertEqual(store.fetchDismissedRemoteMessageIDs(), [])
-    }
-
-    func testWhenFeatureFlagIsDisabledThenHasDismissedRemoteMessageReturnsFalse() async throws {
-        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
-
-        await store.dismissRemoteMessage(withID: remoteMessage.id)
-        try await setFeatureFlagEnabled(false)
-
-        XCTAssertEqual(store.hasDismissedRemoteMessage(withID: remoteMessage.id), false)
     }
 
     // MARK: -

--- a/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -72,20 +72,20 @@ class RemoteMessagingStoreTests: XCTestCase {
     // 1. saveProcessedResult()
     // 2. fetch RemoteMessagingConfig and RemoteMessage successfully returned from save in step 1
     // 3. NSNotification RemoteMessagesDidChange is posted
-    func testWhenSaveProcessedResultThenFetchRemoteConfigAndMessageExistsAndNotificationSent() throws {
+    func testWhenSaveProcessedResultThenFetchRemoteConfigAndMessageExistsAndNotificationSent() async throws {
         let expectation = XCTNSNotificationExpectation(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
                                                        object: nil, notificationCenter: notificationCenter)
 
-        _ = try saveProcessedResultFetchRemoteMessage()
+        _ = try await saveProcessedResultFetchRemoteMessage()
 
         // 3. NSNotification RemoteMessagesDidChange is posted
-        wait(for: [expectation], timeout: 10)
+        await fulfillment(of: [expectation], timeout: 10)
     }
 
-    func saveProcessedResultFetchRemoteMessage(for configJSON: String? = nil) throws -> RemoteMessageModel {
+    func saveProcessedResultFetchRemoteMessage(for configJSON: String? = nil) async throws -> RemoteMessageModel {
         let processorResult = try processorResult(for: configJSON)
         // 1. saveProcessedResult()
-        store.saveProcessedResult(processorResult)
+        await store.saveProcessedResult(processorResult)
 
         // 2. fetch RemoteMessagingConfig and RemoteMessage successfully returned from save in step 1
         let config = store.fetchRemoteMessagingConfig()
@@ -101,35 +101,35 @@ class RemoteMessagingStoreTests: XCTestCase {
         return remoteMessage
     }
 
-    func testWhenHasNotShownMessageThenReturnFalse() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
+    func testWhenHasNotShownMessageThenReturnFalse() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
         XCTAssertFalse(store.hasShownRemoteMessage(withID: remoteMessage.id))
     }
 
-    func testWhenUpdateRemoteMessageAsShownMessageThenHasShownIsTrue() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
-        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+    func testWhenUpdateRemoteMessageAsShownMessageThenHasShownIsTrue() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
         XCTAssertTrue(store.hasShownRemoteMessage(withID: remoteMessage.id))
     }
 
-    func testWhenUpdateRemoteMessageAsShownFalseThenHasShownIsFalse() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
-        store.updateRemoteMessage(withID: remoteMessage.id, asShown: false)
+    func testWhenUpdateRemoteMessageAsShownFalseThenHasShownIsFalse() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: false)
         XCTAssertFalse(store.hasShownRemoteMessage(withID: remoteMessage.id))
     }
 
-    func testFetchShownRemoteMessageIds() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
+    func testFetchShownRemoteMessageIds() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
         XCTAssertEqual(store.fetchShownRemoteMessageIDs(), [])
 
-        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
         XCTAssertEqual(store.fetchShownRemoteMessageIDs(), [remoteMessage.id])
     }
 
-    func testWhenDismissRemoteMessageThenFetchedMessageHasDismissedState() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
+    func testWhenDismissRemoteMessageThenFetchedMessageHasDismissedState() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
 
-        store.dismissRemoteMessage(withID: remoteMessage.id)
+        await store.dismissRemoteMessage(withID: remoteMessage.id)
 
         guard let fetchedRemoteMessage = store.fetchRemoteMessage(withID: remoteMessage.id) else {
             XCTFail("No remote message found")
@@ -140,19 +140,19 @@ class RemoteMessagingStoreTests: XCTestCase {
         XCTAssertTrue(store.hasDismissedRemoteMessage(withID: fetchedRemoteMessage.id))
     }
 
-    func testFetchDismissedRemoteMessageIds() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
+    func testFetchDismissedRemoteMessageIds() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
 
-        store.dismissRemoteMessage(withID: remoteMessage.id)
+        await store.dismissRemoteMessage(withID: remoteMessage.id)
 
         let dismissedRemoteMessageIds = store.fetchDismissedRemoteMessageIDs()
         XCTAssertEqual(dismissedRemoteMessageIds.count, 1)
         XCTAssertEqual(dismissedRemoteMessageIds.first, remoteMessage.id)
     }
 
-    func testConfigUpdateWhenMessageWasShownAndNotInteractedWithThenItIsNotRemovedFromDatabase() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
-        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+    func testConfigUpdateWhenMessageWasShownAndNotInteractedWithThenItIsNotRemovedFromDatabase() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
 
         let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
         context.performAndWait {
@@ -163,7 +163,7 @@ class RemoteMessagingStoreTests: XCTestCase {
             XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
         }
 
-        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
+        _ = try await saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
 
         context.performAndWait {
             context.refreshAllObjects()
@@ -180,10 +180,10 @@ class RemoteMessagingStoreTests: XCTestCase {
         }
     }
 
-    func testConfigUpdateWhenMessageWasInteractedWithThenItIsNotRemovedFromDatabase() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
-        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
-        store.dismissRemoteMessage(withID: remoteMessage.id)
+    func testConfigUpdateWhenMessageWasInteractedWithThenItIsNotRemovedFromDatabase() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+        await store.dismissRemoteMessage(withID: remoteMessage.id)
 
         let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
         context.performAndWait {
@@ -195,7 +195,7 @@ class RemoteMessagingStoreTests: XCTestCase {
             XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.dismissed.rawValue)
         }
 
-        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
+        _ = try await saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
 
         context.performAndWait {
             context.refreshAllObjects()
@@ -212,8 +212,8 @@ class RemoteMessagingStoreTests: XCTestCase {
         }
     }
 
-    func testConfigUpdateWhenMessageWasNotShownThenItIsRemovedFromDatabase() throws {
-        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+    func testConfigUpdateWhenMessageWasNotShownThenItIsRemovedFromDatabase() async throws {
+        _ = try await saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
 
         let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
         context.performAndWait {
@@ -225,7 +225,7 @@ class RemoteMessagingStoreTests: XCTestCase {
             XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
         }
 
-        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
+        _ = try await saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
 
         context.performAndWait {
             context.refreshAllObjects()
@@ -239,9 +239,9 @@ class RemoteMessagingStoreTests: XCTestCase {
         }
     }
 
-    func testConfigUpdateWhenShownAndNotInteractedWithMessageIsReintroducedInNewConfigThenItIsMarkedAsScheduled() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
-        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+    func testConfigUpdateWhenShownAndNotInteractedWithMessageIsReintroducedInNewConfigThenItIsMarkedAsScheduled() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 1, messageID: 1))
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
 
         let context = remoteMessagingDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
         context.performAndWait {
@@ -253,8 +253,8 @@ class RemoteMessagingStoreTests: XCTestCase {
             XCTAssertEqual(firstMessage.status?.int16Value, RemoteMessagingStore.RemoteMessageStatus.scheduled.rawValue)
         }
 
-        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
-        _ = try saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 3, messageID: 1))
+        _ = try await saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 2, messageID: 2))
+        _ = try await saveProcessedResultFetchRemoteMessage(for: minimalConfig(version: 3, messageID: 1))
 
         context.performAndWait {
             context.refreshAllObjects()
@@ -270,125 +270,130 @@ class RemoteMessagingStoreTests: XCTestCase {
 
     // MARK: - Feature Flag
 
-    func testWhenFeatureFlagIsDisabledThenScheduledRemoteMessagesAreDeleted() throws {
-        _ = try saveProcessedResultFetchRemoteMessage()
+    func testWhenFeatureFlagIsDisabledThenScheduledRemoteMessagesAreDeleted() async throws {
+        _ = try await saveProcessedResultFetchRemoteMessage()
         XCTAssertNotNil(store.fetchScheduledRemoteMessage())
 
         let expectation = XCTNSNotificationExpectation(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
                                                        object: nil, notificationCenter: notificationCenter)
 
-        availabilityProvider.isRemoteMessagingAvailable = false
+        try await setFeatureFlagEnabled(false)
         XCTAssertNil(store.fetchScheduledRemoteMessage())
 
-        wait(for: [expectation], timeout: 1)
+        await fulfillment(of: [expectation], timeout: 1)
 
         // Re-enabling remote messaging doesn't trigger a refetch on a Store level so no new scheduled messages should appear
-        availabilityProvider.isRemoteMessagingAvailable = true
+        try await setFeatureFlagEnabled(true)
         XCTAssertNil(store.fetchScheduledRemoteMessage())
     }
 
-    func testWhenFeatureFlagIsDisabledAndThereWereNoMessagesThenNotificationIsNotSent() throws {
+    func testWhenFeatureFlagIsDisabledAndThereWereNoMessagesThenNotificationIsNotSent() async throws {
         XCTAssertNil(store.fetchScheduledRemoteMessage())
 
         let expectation = XCTNSNotificationExpectation(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
                                                        object: nil, notificationCenter: notificationCenter)
         expectation.isInverted = true
 
-        availabilityProvider.isRemoteMessagingAvailable = false
+        try await setFeatureFlagEnabled(false)
         XCTAssertNil(store.fetchScheduledRemoteMessage())
 
-        wait(for: [expectation], timeout: 1)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
-    func testWhenFeatureFlagIsDisabledAndThereWereNoScheduledMessagesThenNotificationIsNotSent() throws {
-        _ = try saveProcessedResultFetchRemoteMessage()
+    func testWhenFeatureFlagIsDisabledAndThereWereNoScheduledMessagesThenNotificationIsNotSent() async throws {
+        _ = try await saveProcessedResultFetchRemoteMessage()
 
         // Dismiss all available messages
         while let remoteMessage = store.fetchScheduledRemoteMessage() {
-            store.dismissRemoteMessage(withID: remoteMessage.id)
+            await store.dismissRemoteMessage(withID: remoteMessage.id)
         }
 
         let expectation = XCTNSNotificationExpectation(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
                                                        object: nil, notificationCenter: notificationCenter)
         expectation.isInverted = true
 
-        availabilityProvider.isRemoteMessagingAvailable = false
+        try await setFeatureFlagEnabled(false)
         XCTAssertNil(store.fetchScheduledRemoteMessage())
 
-        wait(for: [expectation], timeout: 1)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
-    func testWhenFeatureFlagIsDisabledThenProcessedResultIsNotSaved() throws {
-        availabilityProvider.isRemoteMessagingAvailable = false
+    func testWhenFeatureFlagIsDisabledThenProcessedResultIsNotSaved() async throws {
+        try await setFeatureFlagEnabled(false)
 
         let expectation = XCTNSNotificationExpectation(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
                                                        object: nil, notificationCenter: notificationCenter)
         expectation.isInverted = true
 
         let processorResult = try processorResult()
-        store.saveProcessedResult(processorResult)
+        await store.saveProcessedResult(processorResult)
 
-        wait(for: [expectation], timeout: 1)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
-    func testWhenFeatureFlagIsDisabledThenFetchScheduledRemoteMessageReturnsNil() throws {
-        _ = try saveProcessedResultFetchRemoteMessage()
-        availabilityProvider.isRemoteMessagingAvailable = false
+    func testWhenFeatureFlagIsDisabledThenFetchScheduledRemoteMessageReturnsNil() async throws {
+        _ = try await saveProcessedResultFetchRemoteMessage()
+        try await setFeatureFlagEnabled(false)
 
         XCTAssertNil(store.fetchScheduledRemoteMessage())
     }
 
-    func testWhenFeatureFlagIsDisabledThenFetchRemoteMessagingConfigReturnsNil() throws {
-        _ = try saveProcessedResultFetchRemoteMessage()
-        availabilityProvider.isRemoteMessagingAvailable = false
+    func testWhenFeatureFlagIsDisabledThenFetchRemoteMessagingConfigReturnsNil() async throws {
+        _ = try await saveProcessedResultFetchRemoteMessage()
+        try await setFeatureFlagEnabled(false)
 
         XCTAssertNil(store.fetchRemoteMessagingConfig())
     }
 
-    func testWhenFeatureFlagIsDisabledThenFetchedMessageReturnsNil() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
+    func testWhenFeatureFlagIsDisabledThenFetchedMessageReturnsNil() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
 
-        availabilityProvider.isRemoteMessagingAvailable = false
+        try await setFeatureFlagEnabled(false)
 
         XCTAssertNil(store.fetchRemoteMessage(withID: remoteMessage.id))
     }
 
-    func testWhenFeatureFlagIsDisabledThenUpdateShownFlagHasNoEffect() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
-        availabilityProvider.isRemoteMessagingAvailable = false
+    func testWhenFeatureFlagIsDisabledThenUpdateShownFlagHasNoEffect() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
+        try await setFeatureFlagEnabled(false)
 
-        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
-
-        XCTAssertFalse(store.hasShownRemoteMessage(withID: remoteMessage.id))
-    }
-
-    func testWhenFeatureFlagIsDisabledThenHasShownMessageReturnFalse() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
-        store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
-        availabilityProvider.isRemoteMessagingAvailable = false
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
 
         XCTAssertFalse(store.hasShownRemoteMessage(withID: remoteMessage.id))
     }
 
-    func testWhenFeatureFlagIsDisabledThenDismissingRemoteMessageHasNoEffect() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
+    func testWhenFeatureFlagIsDisabledThenHasShownMessageReturnFalse() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+        try await setFeatureFlagEnabled(false)
 
-        availabilityProvider.isRemoteMessagingAvailable = false
-        store.dismissRemoteMessage(withID: remoteMessage.id)
+        XCTAssertFalse(store.hasShownRemoteMessage(withID: remoteMessage.id))
+    }
+
+    func testWhenFeatureFlagIsDisabledThenDismissingRemoteMessageHasNoEffect() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
+
+        try await setFeatureFlagEnabled(false)
+        await store.dismissRemoteMessage(withID: remoteMessage.id)
 
         XCTAssertEqual(store.fetchDismissedRemoteMessageIDs(), [])
     }
 
-    func testWhenFeatureFlagIsDisabledThenHasDismissedRemoteMessageReturnsFalse() throws {
-        let remoteMessage = try saveProcessedResultFetchRemoteMessage()
+    func testWhenFeatureFlagIsDisabledThenHasDismissedRemoteMessageReturnsFalse() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
 
-        store.dismissRemoteMessage(withID: remoteMessage.id)
-        availabilityProvider.isRemoteMessagingAvailable = false
+        await store.dismissRemoteMessage(withID: remoteMessage.id)
+        try await setFeatureFlagEnabled(false)
 
         XCTAssertEqual(store.hasDismissedRemoteMessage(withID: remoteMessage.id), false)
     }
 
     // MARK: -
+
+    func setFeatureFlagEnabled(_ isRemoteMessagingAvailable: Bool) async throws {
+        availabilityProvider.isRemoteMessagingAvailable = isRemoteMessagingAvailable
+        try await Task.sleep(interval: 0.1)
+    }
 
     func decodeJson(fileName: String) throws -> RemoteMessageResponse.JsonRemoteMessagingConfig {
         let resourceURL = Bundle.module.resourceURL!.appendingPathComponent(fileName, conformingTo: .json)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201048563534612/1208493869353425/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3425
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3381
What kind of version bump will this require?: Major

**Description**:
This change fixes Core Data usage in RemoteMessagingStore. Two types of managed object
contexts are now in use. One of them is long-lived and is used for saving data to the Store.
The other is created on demand and used for fetching data. The long-lived context uses asynchronous
Core Data API to avoid potential deadlocks, and is wrapped in async functions for simpler use.
Single instance of a long-lived context helps prevent merge conflicts.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Smoke test RMF on both platforms:
1. Override config in RemoteMessagingClient.swift in both clients to use `https://www.jsonblob.com/api/1261360708536098816`.
2. Run the app and trigger a few messages (you can use Debug Menu on both iOS and macOS to trigger config refetch).
3. Override Privacy Config to use `https://www.jsonblob.com/1293850561760583680`
4. Edit that config to set `disabled` for `remoteMessaging` flag.
5. After refreshing Privacy Config, verify that the remote message is gone, but all shown messages are kept in the database.
6. Re-enable the Privacy Config flag and trigger a remote message fetch.
7. Verify that you receive a new, not previously seen, Remote Message.
8. Verify that dismiss button as well as action buttons work on remote messages.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
