### PR TITLE
Enable credentials import promo for all users

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "branch" : "dbajpeyi/remove-get-available-input-types-caching",
-        "revision" : "131e0d5efc8548b449fa4b811004fba26048a41c"
+        "revision" : "945ac09a0189dc6736db617867fde193ea984b20",
+        "version" : "15.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "branch" : "dbajpeyi/feature/dismiss-password-import-flow",
-        "revision" : "cc23669514be5c2b9ec167a706dd20aeadb8c444"
+        "branch" : "dbajpeyi/remove-get-available-input-types-caching",
+        "revision" : "b7f60f08bdf1a3ad7f35507c19ff411cd474d4a5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
         "branch" : "dbajpeyi/feature/dismiss-password-import-flow",
-        "revision" : "bf31f3f2c55d0183ff67bea8bf95d145116f6366"
+        "revision" : "cc23669514be5c2b9ec167a706dd20aeadb8c444"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
         "branch" : "dbajpeyi/remove-get-available-input-types-caching",
-        "revision" : "b7f60f08bdf1a3ad7f35507c19ff411cd474d4a5"
+        "revision" : "131e0d5efc8548b449fa4b811004fba26048a41c"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "1fee787458d13f8ed07f9fe81aecd6e59609339e",
-        "version" : "13.1.0"
+        "branch" : "dbajpeyi/feature/dismiss-password-import-flow",
+        "revision" : "bf31f3f2c55d0183ff67bea8bf95d145116f6366"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         .library(name: "Onboarding", targets: ["Onboarding"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", branch: "dbajpeyi/remove-get-available-input-types-caching"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "15.0.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         .library(name: "Onboarding", targets: ["Onboarding"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", branch: "dbajpeyi/feature/dismiss-password-import-flow"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", branch: "dbajpeyi/remove-get-available-input-types-caching"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         .library(name: "Onboarding", targets: ["Onboarding"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "13.1.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", branch: "dbajpeyi/feature/dismiss-password-import-flow"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.2.0"),

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -83,6 +83,7 @@ public protocol AutofillLoginImportStateProvider {
     var hasImportedLogins: Bool { get }
     var credentialsImportPromptPresentationCount: Int { get }
     var isAutofillEnabled: Bool { get }
+    var isCredentialsImportPromptPermanantlyDismissed: Bool { get }
     func hasNeverPromptWebsitesFor(_ domain: String) -> Bool
 }
 
@@ -498,6 +499,9 @@ extension AutofillUserScript {
             return false
         }
         guard !loginImportStateProvider.hasNeverPromptWebsitesFor(domain) else {
+            return false
+        }
+        guard !loginImportStateProvider.isCredentialsImportPromptPermanantlyDismissed else {
             return false
         }
         return true

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -90,6 +90,7 @@ public protocol AutofillPasswordImportDelegate: AnyObject {
     func autofillUserScriptDidRequestPasswordImportFlow(_ completion: @escaping () -> Void)
     func autofillUserScriptDidFinishImportWithImportedCredentialForCurrentDomain()
     func autofillUserScriptWillDisplayOverlay(_ serializedInputContext: String)
+    func autofillUserScriptDidRequestPermanentCredentialsImportPromptDismissal()
 }
 
 extension AutofillUserScript {
@@ -788,6 +789,11 @@ extension AutofillUserScript {
                 replyHandler(nil)
             })
         }
+    }
+
+    func credentialsImportFlowPermanentlyDismissed(_ message: UserScriptMessage, replyHandler: @escaping MessageReplyHandler) {
+        passwordImportDelegate?.autofillUserScriptDidRequestPermanentCredentialsImportPromptDismissal()
+        replyHandler(nil)
     }
 
     // MARK: Pixels

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -798,6 +798,7 @@ extension AutofillUserScript {
     func credentialsImportFlowPermanentlyDismissed(_ message: UserScriptMessage, replyHandler: @escaping MessageReplyHandler) {
         passwordImportDelegate?.autofillUserScriptDidRequestPermanentCredentialsImportPromptDismissal()
         replyHandler(nil)
+        NotificationCenter.default.post(name: .passwordImportDidCloseImportDialog, object: nil)
     }
 
     // MARK: Pixels

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -483,9 +483,6 @@ extension AutofillUserScript {
         guard !isBurnerWindow else {
             return false
         }
-        guard loginImportStateProvider.credentialsImportPromptPresentationCount < 5 else {
-            return false
-        }
         guard credentials.isEmpty else {
             return false
         }

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -79,7 +79,7 @@ public protocol AutofillSecureVaultDelegate: AnyObject {
 }
 
 public protocol AutofillLoginImportStateProvider {
-    var isNewDDGUser: Bool { get }
+    var isEligibleDDGUser: Bool { get }
     var hasImportedLogins: Bool { get }
     var credentialsImportPromptPresentationCount: Int { get }
     var isAutofillEnabled: Bool { get }
@@ -493,7 +493,7 @@ extension AutofillUserScript {
         guard !loginImportStateProvider.hasImportedLogins else {
             return false
         }
-        guard loginImportStateProvider.isNewDDGUser else {
+        guard loginImportStateProvider.isEligibleDDGUser else {
             return false
         }
         guard !loginImportStateProvider.hasNeverPromptWebsitesFor(domain) else {

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -90,7 +90,7 @@ public protocol AutofillLoginImportStateProvider {
 public protocol AutofillPasswordImportDelegate: AnyObject {
     func autofillUserScriptDidRequestPasswordImportFlow(_ completion: @escaping () -> Void)
     func autofillUserScriptDidFinishImportWithImportedCredentialForCurrentDomain()
-    func autofillUserScriptWillDisplayOverlay(_ serializedInputContext: String)
+    func autofillUserScriptShouldDisplayOverlay(_ serializedInputContext: String) -> Bool
     func autofillUserScriptDidRequestPermanentCredentialsImportPromptDismissal()
 }
 

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -81,7 +81,6 @@ public class AutofillUserScript: NSObject, UserScript, UserScriptMessageEncrypti
     public weak var vaultDelegate: AutofillSecureVaultDelegate?
     public weak var passwordImportDelegate: AutofillPasswordImportDelegate?
 
-    internal let loginImportStateProvider: AutofillLoginImportStateProvider
     internal var scriptSourceProvider: AutofillUserScriptSourceProvider
 
     internal lazy var autofillDomainNameUrlMatcher: AutofillDomainNameUrlMatcher = {
@@ -180,22 +179,19 @@ public class AutofillUserScript: NSObject, UserScript, UserScriptMessageEncrypti
         return hostProvider.hostForMessage(message)
     }
 
-    public convenience init(scriptSourceProvider: AutofillUserScriptSourceProvider, loginImportStateProvider: AutofillLoginImportStateProvider) {
+    public convenience init(scriptSourceProvider: AutofillUserScriptSourceProvider) {
         self.init(scriptSourceProvider: scriptSourceProvider,
                   encrypter: AESGCMUserScriptEncrypter(),
-                  hostProvider: SecurityOriginHostProvider(),
-                  loginImportStateProvider: loginImportStateProvider)
+                  hostProvider: SecurityOriginHostProvider())
     }
 
     init(scriptSourceProvider: AutofillUserScriptSourceProvider,
          encrypter: UserScriptEncrypter = AESGCMUserScriptEncrypter(),
-         hostProvider: UserScriptHostProvider = SecurityOriginHostProvider(),
-         loginImportStateProvider: AutofillLoginImportStateProvider) {
+         hostProvider: UserScriptHostProvider = SecurityOriginHostProvider()) {
         self.scriptSourceProvider = scriptSourceProvider
         self.hostProvider = hostProvider
         self.encrypter = encrypter
         self.isTopAutofillContext = false
-        self.loginImportStateProvider = loginImportStateProvider
     }
 }
 

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -63,6 +63,7 @@ public class AutofillUserScript: NSObject, UserScript, UserScriptMessageEncrypti
         case closeEmailProtectionTab
 
         case startCredentialsImportFlow
+        case credentialsImportFlowPermanentlyDismissed
     }
 
     /// Represents if the autofill is loaded into the top autofill context.
@@ -167,6 +168,7 @@ public class AutofillUserScript: NSObject, UserScript, UserScriptMessageEncrypti
         case .startEmailProtectionSignup: return startEmailProtectionSignup
         case .closeEmailProtectionTab: return closeEmailProtectionTab
         case .startCredentialsImportFlow: return startCredentialsImportFlow
+        case .credentialsImportFlowPermanentlyDismissed
         }
     }
 

--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript.swift
@@ -168,7 +168,7 @@ public class AutofillUserScript: NSObject, UserScript, UserScriptMessageEncrypti
         case .startEmailProtectionSignup: return startEmailProtectionSignup
         case .closeEmailProtectionTab: return closeEmailProtectionTab
         case .startCredentialsImportFlow: return startCredentialsImportFlow
-        case .credentialsImportFlowPermanentlyDismissed
+        case .credentialsImportFlowPermanentlyDismissed: return credentialsImportFlowPermanentlyDismissed
         }
     }
 

--- a/Sources/BrowserServicesKit/Autofill/OverlayAutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/OverlayAutofillUserScript.swift
@@ -83,8 +83,8 @@ public class OverlayAutofillUserScript: AutofillUserScript {
     }
 
     /// Used to create a top autofill context script for injecting into a ContentOverlay
-    public convenience init(scriptSourceProvider: AutofillUserScriptSourceProvider, overlay: OverlayAutofillUserScriptPresentationDelegate, loginImportStateProvider: AutofillLoginImportStateProvider) {
-        self.init(scriptSourceProvider: scriptSourceProvider, encrypter: AESGCMUserScriptEncrypter(), hostProvider: SecurityOriginHostProvider(), loginImportStateProvider: loginImportStateProvider)
+    public convenience init(scriptSourceProvider: AutofillUserScriptSourceProvider, overlay: OverlayAutofillUserScriptPresentationDelegate) {
+        self.init(scriptSourceProvider: scriptSourceProvider, encrypter: AESGCMUserScriptEncrypter(), hostProvider: SecurityOriginHostProvider())
         self.isTopAutofillContext = true
         self.contentOverlay = overlay
     }

--- a/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
@@ -91,7 +91,10 @@ public class WebsiteAutofillUserScript: AutofillUserScript {
         }
         // Sets the last message host, so we can check when it messages back
         lastOpenHost = hostProvider.hostForMessage(message)
-        passwordImportDelegate?.autofillUserScriptWillDisplayOverlay(serializedInputContext)
+        if passwordImportDelegate?.autofillUserScriptShouldDisplayOverlay(serializedInputContext) != true {
+            replyHandler(nil)
+            return
+        }
 
         currentOverlayTab.websiteAutofillUserScript(self,
                                                     willDisplayOverlayAtClick: clickPoint,

--- a/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
+++ b/Sources/BrowserServicesKit/Autofill/WebsiteAutofillUserScript.swift
@@ -91,7 +91,7 @@ public class WebsiteAutofillUserScript: AutofillUserScript {
         }
         // Sets the last message host, so we can check when it messages back
         lastOpenHost = hostProvider.hostForMessage(message)
-        if passwordImportDelegate?.autofillUserScriptShouldDisplayOverlay(serializedInputContext) != true {
+        if passwordImportDelegate?.autofillUserScriptShouldDisplayOverlay(serializedInputContext, for: hostForMessage(message)) != true {
             replyHandler(nil)
             return
         }

--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -83,6 +83,7 @@ public enum AutofillSubfeature: String, PrivacySubfeature {
     case onByDefault
     case onForExistingUsers
     case unknownUsernameCategorization
+    case importPromptForExistingUsers
 }
 
 public enum DBPSubfeature: String, Equatable, PrivacySubfeature {

--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -83,7 +83,7 @@ public enum AutofillSubfeature: String, PrivacySubfeature {
     case onByDefault
     case onForExistingUsers
     case unknownUsernameCategorization
-    case importPromptForExistingUsers
+    case credentialsImportPromotionForExistingUsers
 }
 
 public enum DBPSubfeature: String, Equatable, PrivacySubfeature {

--- a/Tests/BrowserServicesKitTests/Autofill/AutofillEmailUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/AutofillEmailUserScriptTests.swift
@@ -42,7 +42,7 @@ class AutofillEmailUserScriptTests: XCTestCase {
                                                                            properties: properties)
             .withJSLoading()
             .build()
-        return AutofillUserScript(scriptSourceProvider: sourceProvider, encrypter: MockEncrypter(), hostProvider: SecurityOriginHostProvider(), loginImportStateProvider: MockAutofillLoginImportStateProvider())
+        return AutofillUserScript(scriptSourceProvider: sourceProvider, encrypter: MockEncrypter(), hostProvider: SecurityOriginHostProvider())
     }()
     let userContentController = WKUserContentController()
 

--- a/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
@@ -46,7 +46,7 @@ class AutofillVaultUserScriptTests: XCTestCase {
         let sourceProvider = DefaultAutofillSourceProvider(privacyConfigurationManager: privacyConfig,
                                                            properties: properties,
                                                            isDebug: false)
-        return AutofillUserScript(scriptSourceProvider: sourceProvider, hostProvider: hostProvider, loginImportStateProvider: MockAutofillLoginImportStateProvider())
+        return AutofillUserScript(scriptSourceProvider: sourceProvider, hostProvider: hostProvider)
     }()
 
     let userContentController = WKUserContentController()

--- a/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/Email/EmailManagerTests.swift
@@ -51,7 +51,7 @@ class EmailManagerTests: XCTestCase {
                                                                                               sessionKey: "1234",
                                                                                               featureToggles: ContentScopeFeatureToggles.allTogglesOn),
                                                            isDebug: false)
-        let userScript = AutofillUserScript(scriptSourceProvider: sourceProvider, loginImportStateProvider: MockAutofillLoginImportStateProvider())
+        let userScript = AutofillUserScript(scriptSourceProvider: sourceProvider)
         return userScript
     }
 

--- a/Tests/BrowserServicesKitTests/SecureVault/AutofillUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/AutofillUserScriptTests.swift
@@ -210,7 +210,7 @@ class AutofillUserScriptTests: XCTestCase {
     func testStartCredentialsImportFlow_passesDomainFromLastGetAvailableInputsCall() {
         let getAvailableInputsHost = "example.com"
         let hostProvider = MockHostProvider(host: getAvailableInputsHost)
-        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider(), hostProvider: hostProvider, loginImportStateProvider: MockAutofillLoginImportStateProvider())
+        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider(), hostProvider: hostProvider)
         let vaultDelegate = MockSecureVaultDelegate()
         let passwordImportDelegate = MockAutofillPasswordImportDelegate()
 
@@ -222,7 +222,7 @@ class AutofillUserScriptTests: XCTestCase {
     }
 
     func testStartCredentialsImportFlow_onPasswordImportFlowCompletion_firesDidCloseImportDialogNotification() {
-        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider(), loginImportStateProvider: MockAutofillLoginImportStateProvider())
+        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider())
         let passwordImportDelegate = MockAutofillPasswordImportDelegate()
         userScript.passwordImportDelegate = passwordImportDelegate
 
@@ -234,7 +234,7 @@ class AutofillUserScriptTests: XCTestCase {
     }
 
     func testStartCredentialsImportFlow_accountsForDomainIsNOTEmpty_callsDidFinishImport() {
-        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider(), loginImportStateProvider: MockAutofillLoginImportStateProvider())
+        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider())
         let vaultDelegate = MockSecureVaultDelegate()
         let passwordImportDelegate = MockAutofillPasswordImportDelegate()
 
@@ -246,7 +246,7 @@ class AutofillUserScriptTests: XCTestCase {
     }
 
     func testStartCredentialsImportFlow_credentialsForDomainIsEmpty_doesNOTCallDidFinishImport() {
-        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider(), loginImportStateProvider: MockAutofillLoginImportStateProvider())
+        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider())
         let vaultDelegate = MockSecureVaultDelegate()
         let passwordImportDelegate = MockAutofillPasswordImportDelegate()
 
@@ -270,13 +270,7 @@ class AutofillUserScriptTests: XCTestCase {
                                                 credentialsImportPresentationCount: Int = 0,
                                                 file: StaticString = #filePath,
                                                 line: UInt = #line) -> AutofillUserScript.RequestAvailableInputTypesResponse? {
-        let loginImportStateProvider = MockAutofillLoginImportStateProvider()
-        loginImportStateProvider.hasImportedLogins = hasUserImportedLogins
-        loginImportStateProvider.isEligibleDDGUser = isEligibleDDGUser
-        loginImportStateProvider.stubHasNeverPromptWebsitesForDomain = hasNeverPromptWebsites
-        loginImportStateProvider.isAutofillEnabled = isAutofillEnabled
-        loginImportStateProvider.credentialsImportPromptPresentationCount = credentialsImportPresentationCount
-        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider(), loginImportStateProvider: loginImportStateProvider)
+        let userScript = AutofillUserScript(scriptSourceProvider: MockAutofillUserScriptSourceProvider())
         let userScriptMessage = MockWKScriptMessage(name: "getAvailableInputTypes", body: "")
         let vaultDelegate = MockSecureVaultDelegate()
         userScript.vaultDelegate = vaultDelegate
@@ -321,25 +315,22 @@ class AutofillUserScriptTests: XCTestCase {
     }
 }
 
-class MockAutofillLoginImportStateProvider: AutofillLoginImportStateProvider {
-    var credentialsImportPromptPresentationCount: Int = 0
-
-    var isAutofillEnabled: Bool = false
-
-    var stubHasNeverPromptWebsitesForDomain: Bool = false
-    func hasNeverPromptWebsitesFor(_ domain: String) -> Bool {
-        stubHasNeverPromptWebsitesForDomain
-    }
-
-    var isEligibleDDGUser: Bool = false
-    var hasImportedLogins: Bool = false
-}
-
 class MockAutofillUserScriptSourceProvider: AutofillUserScriptSourceProvider {
     var source: String = ""
 }
 
 class MockAutofillPasswordImportDelegate: AutofillPasswordImportDelegate {
+    func autofillUserScriptShouldShowPasswordImportDialog(domain: String, credentials: [BrowserServicesKit.SecureVaultModels.WebsiteCredentials], credentialsProvider: BrowserServicesKit.SecureVaultModels.CredentialsProvider, totalCredentialsCount: Int) -> Bool {
+        return false
+    }
+    
+    func autofillUserScriptShouldDisplayOverlay(_ serializedInputContext: String, for domain: String) -> Bool {
+        return false
+    }
+    
+    func autofillUserScriptDidRequestPermanentCredentialsImportPromptDismissal() {
+    }
+    
     var serializedInputContext: String?
     func autofillUserScriptWillDisplayOverlay(_ serializedInputContext: String) {
         self.serializedInputContext = serializedInputContext

--- a/Tests/BrowserServicesKitTests/SecureVault/AutofillUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/AutofillUserScriptTests.swift
@@ -246,14 +246,14 @@ class MockAutofillPasswordImportDelegate: AutofillPasswordImportDelegate {
     func autofillUserScriptShouldShowPasswordImportDialog(domain: String, credentials: [BrowserServicesKit.SecureVaultModels.WebsiteCredentials], credentialsProvider: BrowserServicesKit.SecureVaultModels.CredentialsProvider, totalCredentialsCount: Int) -> Bool {
         return stubAutofillUserScriptShouldShowPasswordImportDialog
     }
-    
+
     func autofillUserScriptShouldDisplayOverlay(_ serializedInputContext: String, for domain: String) -> Bool {
         return false
     }
-    
+
     func autofillUserScriptDidRequestPermanentCredentialsImportPromptDismissal() {
     }
-    
+
     var serializedInputContext: String?
     func autofillUserScriptWillDisplayOverlay(_ serializedInputContext: String) {
         self.serializedInputContext = serializedInputContext

--- a/Tests/BrowserServicesKitTests/SecureVault/AutofillUserScriptTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/AutofillUserScriptTests.swift
@@ -156,7 +156,7 @@ class AutofillUserScriptTests: XCTestCase {
 
     func testWhenUserIsNOTNew_ThenAvailableInputTypesCredentialsImportIsFalse() {
         guard let response = getAvailableInputTypesResponse(
-            isNewDDGUser: false
+            isEligibleDDGUser: false
         ) else {
             XCTFail("No getAvailableInputTypes response")
             return
@@ -264,7 +264,7 @@ class AutofillUserScriptTests: XCTestCase {
                                                 credentialsProvider: SecureVaultModels.CredentialsProvider = .init(name: .duckduckgo, locked: false),
                                                 totalCredentialsCount: Int = 9,
                                                 hasUserImportedLogins: Bool = false,
-                                                isNewDDGUser: Bool = true,
+                                                isEligibleDDGUser: Bool = true,
                                                 hasNeverPromptWebsites: Bool = false,
                                                 isAutofillEnabled: Bool = true,
                                                 credentialsImportPresentationCount: Int = 0,
@@ -272,7 +272,7 @@ class AutofillUserScriptTests: XCTestCase {
                                                 line: UInt = #line) -> AutofillUserScript.RequestAvailableInputTypesResponse? {
         let loginImportStateProvider = MockAutofillLoginImportStateProvider()
         loginImportStateProvider.hasImportedLogins = hasUserImportedLogins
-        loginImportStateProvider.isNewDDGUser = isNewDDGUser
+        loginImportStateProvider.isEligibleDDGUser = isEligibleDDGUser
         loginImportStateProvider.stubHasNeverPromptWebsitesForDomain = hasNeverPromptWebsites
         loginImportStateProvider.isAutofillEnabled = isAutofillEnabled
         loginImportStateProvider.credentialsImportPromptPresentationCount = credentialsImportPresentationCount
@@ -331,7 +331,7 @@ class MockAutofillLoginImportStateProvider: AutofillLoginImportStateProvider {
         stubHasNeverPromptWebsitesForDomain
     }
 
-    var isNewDDGUser: Bool = false
+    var isEligibleDDGUser: Bool = false
     var hasImportedLogins: Bool = false
 }
 

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
@@ -49,7 +49,7 @@ class SecureVaultManagerTests: XCTestCase {
         let sourceProvider = DefaultAutofillSourceProvider(privacyConfigurationManager: privacyConfig,
                                                            properties: properties,
                                                            isDebug: false)
-        return AutofillUserScript(scriptSourceProvider: sourceProvider, encrypter: MockEncrypter(), hostProvider: SecurityOriginHostProvider(), loginImportStateProvider: MockAutofillLoginImportStateProvider())
+        return AutofillUserScript(scriptSourceProvider: sourceProvider, encrypter: MockEncrypter(), hostProvider: SecurityOriginHostProvider())
     }()
 
     private var testVault: (any AutofillSecureVault)!


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1202926619870900/1208282574906775/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3427
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3383
What kind of version bump will this require?: Major

**Optional**:

Task/Issue URL: https://app.asana.com/0/1202926619870900/1208282574906775/f
Tech Design URL: https://app.asana.com/0/1202926619870900/1208502988382869/f

**Description**:

- We're rolling out [✓ Promote password import in autofill menu [2w]](https://app.asana.com/0/0/1201480346793878) and the conversion rate seems pretty decent. If we expand the addressable userbase we're likely to improve the user experience of many more users.

- With [✓ Promote password import in autofill menu [2w]](https://app.asana.com/0/0/1201480346793878) we're promoting import to <7 days users with less than 10 passwords saved.
- To make this promotion even more impactful, we can expand the coverage to existing users, but to make it impactful we'll need more lax heuristics and a way for users to dismiss this promo.

**Steps to test this PR**:
[Test Instructions](https://app.asana.com/0/1202926619870900/1208543152554655)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
