### PR TITLE
Fix how blocked requests made inside nested 'about:blank' iFrames are counted (issue #1019)

### DIFF
--- a/Sources/BrowserServicesKit/ContentBlocking/UserScripts/contentblockerrules.js
+++ b/Sources/BrowserServicesKit/ContentBlocking/UserScripts/contentblockerrules.js
@@ -139,7 +139,7 @@
             // FROM: https://stackoverflow.com/a/7739035/73479
             // FIX: Better capturing of top level URL so that trackers in embedded documents are not considered first party
             if (window.location !== window.parent.location) {
-                return new URL(window.location.href !== 'about:blank' ? document.referrer : window.parent.location.href)
+                return new URL(window.location.href !== 'about:blank' ? document.referrer : window.parent.origin)
             } else {
                 return new URL(document.location.href)
             }


### PR DESCRIPTION
This PR fixes https://github.com/duckduckgo/BrowserServicesKit/issues/1019; we confirmed this fixes the issue on the DuckDuckGo macOS browser (version 1.102.0) on macOS 14.5