### PR TITLE
Allowing users to delete suggestions

### DIFF
--- a/Sources/History/HistoryCoordinator.swift
+++ b/Sources/History/HistoryCoordinator.swift
@@ -44,6 +44,7 @@ public protocol HistoryCoordinating: AnyObject {
     func burnDomains(_ baseDomains: Set<String>, tld: TLD, completion: @escaping (Set<URL>) -> Void)
     func burnVisits(_ visits: [Visit], completion: @escaping () -> Void)
 
+    func removeUrlEntry(_ url: URL, completion: ((Error?) -> Void)?)
 }
 
 /// Coordinates access to History. Uses its own queue with high qos for all operations.
@@ -189,6 +190,20 @@ final public class HistoryCoordinator: HistoryCoordinating {
         removeVisits(visits) { _ in
             completion()
         }
+    }
+
+    public enum EntryRemovalError: Error {
+        case notAvailable
+    }
+
+    public func removeUrlEntry(_ url: URL, completion: ((Error?) -> Void)? = nil) {
+        guard let historyDictionary = historyDictionary else { return }
+        guard let entry = historyDictionary[url] else {
+            completion?(EntryRemovalError.notAvailable)
+            return
+        }
+
+        removeEntries([entry], completionHandler: completion)
     }
 
     var cleaningDate: Date { .monthAgo }

--- a/Sources/Suggestions/Suggestion.swift
+++ b/Sources/Suggestions/Suggestion.swift
@@ -28,7 +28,7 @@ public enum Suggestion: Equatable {
     case openTab(title: String, url: URL)
     case unknown(value: String)
 
-    var url: URL? {
+    public var url: URL? {
         switch self {
         case .website(url: let url),
              .historyEntry(title: _, url: let url, allowedInTopHits: _),
@@ -67,20 +67,26 @@ public enum Suggestion: Equatable {
         }
     }
 
-    var isOpenTab: Bool {
+    public var isOpenTab: Bool {
         if case .openTab = self {
             return true
         }
         return false
     }
 
-    var isBookmark: Bool {
+    public var isBookmark: Bool {
         if case .bookmark = self {
             return true
         }
         return false
     }
 
+    public var isHistoryEntry: Bool {
+        if case .historyEntry = self {
+            return true
+        }
+        return false
+    }
 }
 
 extension Suggestion {

--- a/Sources/Suggestions/SuggestionResult.swift
+++ b/Sources/Suggestions/SuggestionResult.swift
@@ -24,9 +24,9 @@ public struct SuggestionResult: Equatable {
         SuggestionResult(topHits: [], duckduckgoSuggestions: [], localSuggestions: [])
     }
 
-    private(set) public var topHits: [Suggestion]
-    private(set) public var duckduckgoSuggestions: [Suggestion]
-    private(set) public var localSuggestions: [Suggestion]
+    public var topHits: [Suggestion]
+    public var duckduckgoSuggestions: [Suggestion]
+    public var localSuggestions: [Suggestion]
 
     public init(topHits: [Suggestion],
                 duckduckgoSuggestions: [Suggestion],

--- a/Sources/Suggestions/SuggestionResult.swift
+++ b/Sources/Suggestions/SuggestionResult.swift
@@ -24,9 +24,9 @@ public struct SuggestionResult: Equatable {
         SuggestionResult(topHits: [], duckduckgoSuggestions: [], localSuggestions: [])
     }
 
-    public var topHits: [Suggestion]
-    public var duckduckgoSuggestions: [Suggestion]
-    public var localSuggestions: [Suggestion]
+    public let topHits: [Suggestion]
+    public let duckduckgoSuggestions: [Suggestion]
+    public let localSuggestions: [Suggestion]
 
     public init(topHits: [Suggestion],
                 duckduckgoSuggestions: [Suggestion],


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1148564399326804/1208219569168397/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3465
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3430
What kind of version bump will this require?: Minor
**Optional**:

**Description**:
Improvements of the HistoryCoordinator to allow users to delete individual suggestions

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make sure unit tests pass
1. The UI flow is tested in  https://github.com/duckduckgo/macos-browser/pull/3430

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
