### PR TITLE
fix breakByRaisingSigInt mistakenly called when run w/o debugger

### DIFF
--- a/Sources/Common/Debug.swift
+++ b/Sources/Common/Debug.swift
@@ -40,13 +40,11 @@ public func breakByRaisingSigInt(_ description: String, file: StaticString = #fi
 #if DEBUG
 
 // get symbol from stack trace for a caller of a calling method
-public func callingSymbol() -> String {
+public func callingSymbol(after lastSymbolName: String? = nil) -> String {
     let stackTrace = Thread.callStackSymbols
     // find `callingSymbol` itself or dispatch_once_callout
-    var callingSymbolIdx = stackTrace.firstIndex(where: { $0.contains("_dispatch_once_callout") })
-    ?? stackTrace.firstIndex(where: { $0.contains("callingSymbol") })!
-    // procedure calling `callingSymbol`
-    callingSymbolIdx += 1
+    var callingSymbolIdx = lastSymbolName.flatMap { lastSymbolName in stackTrace.lastIndex(where: { $0.contains(lastSymbolName) }) }
+    ?? stackTrace.firstIndex(where: { $0.contains("callingSymbol") })! + 1 // procedure calling `callingSymbol`
 
     var symbolName: String
     repeat {

--- a/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
+++ b/Sources/Navigation/Extensions/WKFrameInfoExtension.swift
@@ -57,7 +57,8 @@ public extension WKFrameInfo {
         method_exchangeImplementations(originalRequestMethod, swizzledRequestMethod)
 
         // ignore `request` selector calls from `safeRequest` itself
-        ignoredRequestUsageSymbols.insert(callingSymbol())
+        let callingSymbol = callingSymbol(after: "addSafetyCheckForSafeRequestUsageOnce")
+        ignoredRequestUsageSymbols.insert(callingSymbol)
         // ignore `-[WKFrameInfo description]`
         ignoredRequestUsageSymbols.insert("-[WKFrameInfo description]")
     }()

--- a/Sources/Navigation/Extensions/WKNavigationActionExtension.swift
+++ b/Sources/Navigation/Extensions/WKNavigationActionExtension.swift
@@ -60,8 +60,9 @@ extension WKNavigationAction: WebViewNavigationAction {
         let swizzledSourceFrameMethod = class_getInstanceMethod(WKNavigationAction.self, #selector(WKNavigationAction.swizzledSourceFrame))!
         method_exchangeImplementations(originalSourceFrameMethod, swizzledSourceFrameMethod)
 
+        let callingSymbol = callingSymbol(after: "addSafetyCheckForSafeSourceFrameUsageOnce")
         // ignore `sourceFrame` selector calls from `safeSourceFrame` itself
-        ignoredSourceFrameUsageSymbols.insert(callingSymbol())
+        ignoredSourceFrameUsageSymbols.insert(callingSymbol)
         // ignore `-[WKNavigationAction description]`
         ignoredSourceFrameUsageSymbols.insert("-[WKNavigationAction description]")
     }()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL:  https://app.asana.com/0/414709148257752/1208592357309749/f
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
Fixes debug helper raising `breakByRaisingSigInt` when run w/o debugger attached
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
