### PR TITLE
Bug Fix: Phishing Detection Dataset Discrepancies

### DIFF
--- a/Sources/PhishingDetection/PhishingDetectionClient.swift
+++ b/Sources/PhishingDetection/PhishingDetectionClient.swift
@@ -161,6 +161,7 @@ extension PhishingDetectionAPIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.allHTTPHeaderFields = headers
+        request.cachePolicy = .reloadIgnoringLocalCacheData // Disable caching
 
         do {
             let (data, _) = try await session.data(for: request)

--- a/Sources/PhishingDetection/PhishingDetectionClient.swift
+++ b/Sources/PhishingDetection/PhishingDetectionClient.swift
@@ -161,7 +161,6 @@ extension PhishingDetectionAPIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.allHTTPHeaderFields = headers
-        request.cachePolicy = .reloadIgnoringLocalCacheData // Disable caching
 
         do {
             let (data, _) = try await session.data(for: request)

--- a/Sources/PhishingDetection/PhishingDetectionDataStore.swift
+++ b/Sources/PhishingDetection/PhishingDetectionDataStore.swift
@@ -202,18 +202,18 @@ public class PhishingDetectionDataStore: PhishingDetectionDataSaving {
 
 extension PhishingDetectionDataStore {
     public func saveFilterSet(set: Set<Filter>) {
-        writeFilterSet()
         self.filterSet = set
+        writeFilterSet()
     }
 
     public func saveHashPrefixes(set: Set<String>) {
-        writeHashPrefixes()
         self.hashPrefixes = set
+        writeHashPrefixes()
     }
 
     public func saveRevision(_ revision: Int) {
-        writeRevision()
         self.currentRevision = revision
+        writeRevision()
     }
 }
 

--- a/Tests/PhishingDetectionTests/PhishingDetectionDataStoreTests.swift
+++ b/Tests/PhishingDetectionTests/PhishingDetectionDataStoreTests.swift
@@ -87,7 +87,7 @@ class PhishingDetectionDataStoreTests: XCTestCase {
         XCTAssertEqual(actualHashPrefix, embeddedHashPrefix)
         XCTAssertEqual(actualRevision, 5)
     }
-    
+
     func testWhenEmbeddedRevisionOlderThanOnDisk_ThenDontLoadEmbedded() async {
         let encoder = JSONEncoder()
         // On Disk Data Setup
@@ -186,7 +186,7 @@ class PhishingDetectionDataStoreTests: XCTestCase {
         let decoder = JSONDecoder()
         if let storedFilterSet = try? decoder.decode(Set<Filter>.self, from: storedFilterSetData!),
            let storedHashPrefixes = try? decoder.decode(Set<String>.self, from: storedHashPrefixesData!) {
-            
+
             XCTAssertEqual(storedFilterSet, updatedFilterSet)
             XCTAssertEqual(storedHashPrefixes, updatedHashPrefixes)
         } else {

--- a/Tests/PhishingDetectionTests/PhishingDetectionDataStoreTests.swift
+++ b/Tests/PhishingDetectionTests/PhishingDetectionDataStoreTests.swift
@@ -62,19 +62,57 @@ class PhishingDetectionDataStoreTests: XCTestCase {
     }
 
     func testWhenEmbeddedRevisionNewerThanOnDisk_ThenLoadEmbedded() async {
+        let encoder = JSONEncoder()
+        // On Disk Data Setup
+        fileStorageManager.write(data: "1".utf8data, to: "revision.txt")
+        let onDiskFilterSet = Set([Filter(hashValue: "other", regex: "other")])
+        let filterSetData = try! encoder.encode(Array(onDiskFilterSet))
+        let onDiskHashPrefix = Set(["faffa"])
+        let hashPrefixData = try! encoder.encode(Array(onDiskHashPrefix))
+        fileStorageManager.write(data: filterSetData, to: "filterSet.json")
+        fileStorageManager.write(data: hashPrefixData, to: "hashPrefixes.json")
+
+        // Embedded Data Setup
         mockDataProvider.embeddedRevision = 5
-        let expectedFilerSet = Set([Filter(hashValue: "some", regex: "some")])
-        let expectedHashPrefix = Set(["sassa"])
-        mockDataProvider.shouldReturnFilterSet(set: expectedFilerSet)
-        mockDataProvider.shouldReturnHashPrefixes(set: expectedHashPrefix)
+        let embeddedFilterSet = Set([Filter(hashValue: "some", regex: "some")])
+        let embeddedHashPrefix = Set(["sassa"])
+        mockDataProvider.shouldReturnFilterSet(set: embeddedFilterSet)
+        mockDataProvider.shouldReturnHashPrefixes(set: embeddedHashPrefix)
 
         let actualRevision = dataStore.currentRevision
         let actualFilterSet = dataStore.filterSet
         let actualHashPrefix = dataStore.hashPrefixes
 
-        XCTAssertEqual(actualFilterSet, expectedFilerSet)
-        XCTAssertEqual(actualHashPrefix, expectedHashPrefix)
+        XCTAssertEqual(actualFilterSet, embeddedFilterSet)
+        XCTAssertEqual(actualHashPrefix, embeddedHashPrefix)
         XCTAssertEqual(actualRevision, 5)
+    }
+    
+    func testWhenEmbeddedRevisionOlderThanOnDisk_ThenDontLoadEmbedded() async {
+        let encoder = JSONEncoder()
+        // On Disk Data Setup
+        fileStorageManager.write(data: "6".utf8data, to: "revision.txt")
+        let onDiskFilterSet = Set([Filter(hashValue: "other", regex: "other")])
+        let filterSetData = try! encoder.encode(Array(onDiskFilterSet))
+        let onDiskHashPrefix = Set(["faffa"])
+        let hashPrefixData = try! encoder.encode(Array(onDiskHashPrefix))
+        fileStorageManager.write(data: filterSetData, to: "filterSet.json")
+        fileStorageManager.write(data: hashPrefixData, to: "hashPrefixes.json")
+
+        // Embedded Data Setup
+        mockDataProvider.embeddedRevision = 1
+        let embeddedFilterSet = Set([Filter(hashValue: "some", regex: "some")])
+        let embeddedHashPrefix = Set(["sassa"])
+        mockDataProvider.shouldReturnFilterSet(set: embeddedFilterSet)
+        mockDataProvider.shouldReturnHashPrefixes(set: embeddedHashPrefix)
+
+        let actualRevision = dataStore.currentRevision
+        let actualFilterSet = dataStore.filterSet
+        let actualHashPrefix = dataStore.hashPrefixes
+
+        XCTAssertEqual(actualFilterSet, onDiskFilterSet)
+        XCTAssertEqual(actualHashPrefix, onDiskHashPrefix)
+        XCTAssertEqual(actualRevision, 6)
     }
 
     func testWriteAndLoadData() async {

--- a/Tests/PhishingDetectionTests/PhishingDetectionDataStoreTests.swift
+++ b/Tests/PhishingDetectionTests/PhishingDetectionDataStoreTests.swift
@@ -60,14 +60,14 @@ class PhishingDetectionDataStoreTests: XCTestCase {
         XCTAssertEqual(actualFilterSet, expectedFilerSet)
         XCTAssertEqual(actualHashPrefix, expectedHashPrefix)
     }
-    
+
     func testWhenEmbeddedRevisionNewerThanOnDisk_ThenLoadEmbedded() async {
         mockDataProvider.embeddedRevision = 5
         let expectedFilerSet = Set([Filter(hashValue: "some", regex: "some")])
         let expectedHashPrefix = Set(["sassa"])
         mockDataProvider.shouldReturnFilterSet(set: expectedFilerSet)
         mockDataProvider.shouldReturnHashPrefixes(set: expectedHashPrefix)
-        
+
         let actualRevision = dataStore.currentRevision
         let actualFilterSet = dataStore.filterSet
         let actualHashPrefix = dataStore.hashPrefixes

--- a/Tests/PhishingDetectionTests/PhishingDetectionDataStoreTests.swift
+++ b/Tests/PhishingDetectionTests/PhishingDetectionDataStoreTests.swift
@@ -60,6 +60,22 @@ class PhishingDetectionDataStoreTests: XCTestCase {
         XCTAssertEqual(actualFilterSet, expectedFilerSet)
         XCTAssertEqual(actualHashPrefix, expectedHashPrefix)
     }
+    
+    func testWhenEmbeddedRevisionNewerThanOnDisk_ThenLoadEmbedded() async {
+        mockDataProvider.embeddedRevision = 5
+        let expectedFilerSet = Set([Filter(hashValue: "some", regex: "some")])
+        let expectedHashPrefix = Set(["sassa"])
+        mockDataProvider.shouldReturnFilterSet(set: expectedFilerSet)
+        mockDataProvider.shouldReturnHashPrefixes(set: expectedHashPrefix)
+        
+        let actualRevision = dataStore.currentRevision
+        let actualFilterSet = dataStore.filterSet
+        let actualHashPrefix = dataStore.hashPrefixes
+
+        XCTAssertEqual(actualFilterSet, expectedFilerSet)
+        XCTAssertEqual(actualHashPrefix, expectedHashPrefix)
+        XCTAssertEqual(actualRevision, 5)
+    }
 
     func testWriteAndLoadData() async {
         // Get and write data


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1204023833050360/1208567121137949/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3469
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3440
What kind of version bump will this require?: Patch

**Optional**:

Tech Design URL:
CC:

**Description**:
In [Implement desktop integration efficacy tests - 5-7 days](https://app.asana.com/0/1207943168535188/1207205745934704/f) it was discovered that Swift's client-side caching results in out-of-date datasets and significant dataset discrepancies between different clients. For example, it's very common for the same request to return different results from the backend, resulting in a client believing they are updating to a newer revision than they are. Over time, this compounds and results in disparate versions of the same dataset across different clients, putting users at risk of landing on newer phishing pages.

Fix: 
 - Remove Client Side Caching in PhishingDetectionClient.swift
 - Ensure embedded dataset is used to replace the on-disk dataset when the revision of the embedded dataset > on disk dataset
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check unit tests
3. Change on-disk revision:
4. `echo "1650000" > "/System/Volumes/Data/Users/<user>/Library/Application Support/com.duckduckgo.macos.browser.debug/revision.txt"`
5. Build the browser
6. Visit https://privacy-test-pages.site/security/badware/phishing.html
7. Ensure blocked
8. Check on-disk revision:
9. `cat "/System/Volumes/Data/Users/<user>/Library/Application Support/com.duckduckgo.macos.browser.debug/revision.txt"`
10. Should be > 1650000


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
