### PR TITLE
Use cookie to share subscription access token on DDG domains

### DIFF
--- a/Sources/Subscription/SubscriptionCookie/HTTPCookieStore.swift
+++ b/Sources/Subscription/SubscriptionCookie/HTTPCookieStore.swift
@@ -1,0 +1,28 @@
+//
+//  HTTPCookieStore.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+
+public protocol HTTPCookieStore {
+    func allCookies() async -> [HTTPCookie]
+    func setCookie(_ cookie: HTTPCookie) async
+    func deleteCookie(_ cookie: HTTPCookie) async
+}
+
+extension WKHTTPCookieStore: HTTPCookieStore {}

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
@@ -1,0 +1,197 @@
+//
+//  SubscriptionCookieManager.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import WebKit
+
+public protocol HTTPCookieStore {
+    func allCookies() async -> [HTTPCookie]
+    func setCookie(_ cookie: HTTPCookie) async
+    func deleteCookie(_ cookie: HTTPCookie) async
+}
+
+extension WKHTTPCookieStore: HTTPCookieStore {}
+
+public protocol SubscriptionCookieManaging {
+    init(subscriptionManager: SubscriptionManager, currentCookieStore: @MainActor @escaping () -> HTTPCookieStore) async
+    func refreshSubscriptionCookie() async
+    func testCookies() async
+}
+
+public final class SubscriptionCookieManager: SubscriptionCookieManaging {
+
+    public static let cookieDomain = "duckduckgo.com"
+    public static let cookieName = "privacy_pro_access_token"
+
+    private static let defaultRefreshTimeInterval: TimeInterval = .seconds(10) // TODO: change the default to e.g. 4h
+
+    private let subscriptionManager: SubscriptionManager
+    private let currentCookieStore: @MainActor () -> HTTPCookieStore
+
+    private var lastRefreshDate: Date?
+    private let refreshTimeInterval: TimeInterval
+
+    convenience nonisolated public required init(subscriptionManager: SubscriptionManager,
+                                                 currentCookieStore: @MainActor @escaping () -> HTTPCookieStore) {
+        self.init(subscriptionManager: subscriptionManager, 
+                  currentCookieStore: currentCookieStore,
+                  refreshTimeInterval: SubscriptionCookieManager.defaultRefreshTimeInterval)
+    }
+
+    nonisolated public required init(subscriptionManager: SubscriptionManager,
+                                     currentCookieStore: @MainActor @escaping () -> HTTPCookieStore,
+                                     refreshTimeInterval: TimeInterval) {
+        self.subscriptionManager = subscriptionManager
+        self.currentCookieStore = currentCookieStore
+        self.refreshTimeInterval = refreshTimeInterval
+
+        registerForSubscriptionAccountManagerEvents()
+    }
+
+    private func registerForSubscriptionAccountManagerEvents() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAccountDidSignIn), name: .accountDidSignIn, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAccountDidSignOut), name: .accountDidSignOut, object: nil)
+    }
+
+    @objc private func handleAccountDidSignIn() {
+        Task {
+            guard let accessToken = subscriptionManager.accountManager.accessToken else {
+                // TODO: Add error handling ".accountDidSignIn event but access token is missing"
+                return
+            }
+
+            await setSubscriptionCookie(for: accessToken)
+            print("[🍪 Cookie] Subscription sign in - setting cookie")
+        }
+    }
+
+    @objc private func handleAccountDidSignOut() {
+        Task {
+            guard let subscriptionCookie = await fetchCurrentSubscriptionCookie() else {
+                // TODO: Add error handling ".accountDidSignOut event but cookie is missing"
+                return
+            }
+
+            await currentCookieStore().deleteCookie(subscriptionCookie)
+            await deleteSubscriptionCookie()
+            print("[🍪 Cookie] Subscription sign out - removing cookie")
+        }
+    }
+
+    public func refreshSubscriptionCookie() async {
+        print("[🍪 Cookie] Refresh subscription cookie (last refresh date since now: \(lastRefreshDate?.timeIntervalSinceNow ?? 0.0)")
+        guard shouldRefreshSubscriptionCookie() else { return }
+
+//        let token = "Test(\(String(describing: Date()))"
+//        let token = "TEST2"
+        let accessToken: String? = subscriptionManager.accountManager.accessToken
+
+        print("[🍪 Cookie] Token: \(accessToken ?? "<none>")")
+
+        lastRefreshDate = Date()
+        print("[🍪 Cookie] New last refresh date")
+
+        if let accessToken {
+            if let cookie = await fetchCurrentSubscriptionCookie(), cookie.value == accessToken {
+                print("[🍪 Cookie] Current up to date")
+                // Cookie present with proper value
+                return
+            } else {
+                // Cookie not present or with different value
+                print("[🍪 Cookie] Cookie not present or with different value")
+                await setSubscriptionCookie(for: accessToken)
+
+                // TODO: Pixel that refresh actually was required - fixed by updating the token
+            }
+        } else {
+            // remove cookie
+            await deleteSubscriptionCookie()
+
+            // TODO: Pixel that refresh actually was required - fixed by deleting the token
+        }
+    }
+
+    private func shouldRefreshSubscriptionCookie() -> Bool {
+        switch lastRefreshDate {
+        case .none:
+            return true
+        case .some(let previousLastRefreshDate):
+            return previousLastRefreshDate.timeIntervalSinceNow < -refreshTimeInterval
+        }
+    }
+
+    private func fetchCurrentSubscriptionCookie() async -> HTTPCookie? {
+        let cookieStore = await currentCookieStore()
+        var currentCookie: HTTPCookie?
+
+        for cookie in await cookieStore.allCookies() {
+            if cookie.domain == Self.cookieDomain && cookie.name == Self.cookieName {
+                currentCookie = cookie
+                break
+            }
+        }
+
+        return currentCookie
+    }
+
+    private func setSubscriptionCookie(for token: String) async {
+        guard let subscriptionCookie = makeSubscriptionCookie(for: token) else {
+            // TODO: Add error handling "Failed to make a subscription cookie"
+            return
+        }
+
+        print("[🍪 Cookie] Updating cookie")
+        await currentCookieStore().setCookie(subscriptionCookie)
+    }
+
+    private func deleteSubscriptionCookie() async {
+        guard let cookie = await fetchCurrentSubscriptionCookie() else {
+            // Not really an error
+            // Add error handling "Tried to delete subscription cookie but it was not present"
+            return
+        }
+
+        await currentCookieStore().deleteCookie(cookie)
+        print("[🍪 Cookie] Deleting cookie")
+    }
+
+    private func makeSubscriptionCookie(for token: String) -> HTTPCookie? {
+        HTTPCookie(properties: [
+            .domain: Self.cookieDomain,
+            .path: "/",
+            .expires: Date().addingTimeInterval(.days(365)),
+            .name: Self.cookieName,
+            .value: token,
+            .secure: true,
+            .init(rawValue: "HttpOnly"): true
+        ])
+    }
+
+    public func testCookies() async {
+        print("[🍪 testCookie] Test cookies ================= ")
+        let cookieStore = await currentCookieStore()
+
+        for cookie in await cookieStore.allCookies() {
+            print(" [🍪 testCookie]  Cookie: \(cookie.domain) \(cookie.name)")
+            if cookie.domain == Self.cookieDomain {
+                print("  \(cookie.debugDescription.replacingOccurrences(of: "\n", with: "; "))")
+            }
+        }
+        print("[🍪 testCookie] ============================== ")
+    }
+}

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
@@ -28,7 +28,7 @@ public protocol SubscriptionCookieManaging {
 
 public final class SubscriptionCookieManager: SubscriptionCookieManaging {
 
-    public static let cookieDomain = "duckduckgo.com"
+    public static let cookieDomain = ".duckduckgo.com"
     public static let cookieName = "privacy_pro_access_token"
 
     private static let defaultRefreshTimeInterval: TimeInterval = .hours(4)

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
@@ -77,7 +77,7 @@ public final class SubscriptionCookieManager: SubscriptionCookieManaging {
                 return
             }
             Logger.subscription.info("[SubscriptionCookieManager] Handle .accountDidSignIn - setting cookie")
-           
+
             do {
                 try await cookieStore.setSubscriptionCookie(for: accessToken)
                 updateLastRefreshDateToNow()
@@ -154,7 +154,6 @@ public final class SubscriptionCookieManager: SubscriptionCookieManaging {
 enum SubscriptionCookieManagerError: Error {
     case failedToCreateSubscriptionCookie
 }
-
 
 private extension HTTPCookieStore {
 

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
@@ -80,7 +80,7 @@ public final class SubscriptionCookieManager: SubscriptionCookieManaging {
                 try await cookieStore.setSubscriptionCookie(for: accessToken)
                 updateLastRefreshDateToNow()
             } catch {
-                eventMapping.fire(.errorFailedToSetSubscriptionCookie)
+                eventMapping.fire(.failedToSetSubscriptionCookie)
             }
         }
     }
@@ -116,7 +116,7 @@ public final class SubscriptionCookieManager: SubscriptionCookieManaging {
                     try await cookieStore.setSubscriptionCookie(for: accessToken)
                     eventMapping.fire(.subscriptionCookieRefreshedWithUpdate)
                 } catch {
-                    eventMapping.fire(.errorFailedToSetSubscriptionCookie)
+                    eventMapping.fire(.failedToSetSubscriptionCookie)
                 }
             } else {
                 Logger.subscription.info("[SubscriptionCookieManager] Refresh: Cookie exists and is up to date")

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
@@ -21,7 +21,7 @@ import Common
 import os.log
 
 public protocol SubscriptionCookieManaging {
-    init(subscriptionManager: SubscriptionManager, currentCookieStore: @MainActor @escaping () -> HTTPCookieStore?, eventMapping: EventMapping<SubscriptionCookieManagerEvent>) async
+    init(subscriptionManager: SubscriptionManager, currentCookieStore: @MainActor @escaping () -> HTTPCookieStore?, eventMapping: EventMapping<SubscriptionCookieManagerEvent>)
     func refreshSubscriptionCookie() async
     func resetLastRefreshDate()
 

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
@@ -31,7 +31,7 @@ public final class SubscriptionCookieManager: SubscriptionCookieManaging {
     public static let cookieDomain = "duckduckgo.com"
     public static let cookieName = "privacy_pro_access_token"
 
-    private static let defaultRefreshTimeInterval: TimeInterval = .seconds(10) // TODO: change the default to e.g. 4h
+    private static let defaultRefreshTimeInterval: TimeInterval = .hours(4)
 
     private let subscriptionManager: SubscriptionManager
     private let currentCookieStore: @MainActor () -> HTTPCookieStore?

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
@@ -24,6 +24,8 @@ public protocol SubscriptionCookieManaging {
     init(subscriptionManager: SubscriptionManager, currentCookieStore: @MainActor @escaping () -> HTTPCookieStore?, eventMapping: EventMapping<SubscriptionCookieManagerEvent>) async
     func refreshSubscriptionCookie() async
     func resetLastRefreshDate()
+
+    var lastRefreshDate: Date? { get }
 }
 
 public final class SubscriptionCookieManager: SubscriptionCookieManaging {
@@ -37,7 +39,7 @@ public final class SubscriptionCookieManager: SubscriptionCookieManaging {
     private let currentCookieStore: @MainActor () -> HTTPCookieStore?
     private let eventMapping: EventMapping<SubscriptionCookieManagerEvent>
 
-    private var lastRefreshDate: Date?
+    public private(set) var lastRefreshDate: Date?
     private let refreshTimeInterval: TimeInterval
 
     convenience nonisolated public required init(subscriptionManager: SubscriptionManager,

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManagerEvent.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManagerEvent.swift
@@ -1,0 +1,29 @@
+//
+//  SubscriptionCookieManagerEvent.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public enum SubscriptionCookieManagerEvent {
+    case errorHandlingAccountDidSignInTokenIsMissing
+    case errorHandlingAccountDidSignOutCookieIsMissing
+
+    case subscriptionCookieRefreshedWithUpdate
+    case subscriptionCookieRefreshedWithDelete
+
+    case errorFailedToSetSubscriptionCookie
+}

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManagerEvent.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManagerEvent.swift
@@ -25,5 +25,5 @@ public enum SubscriptionCookieManagerEvent {
     case subscriptionCookieRefreshedWithUpdate
     case subscriptionCookieRefreshedWithDelete
 
-    case errorFailedToSetSubscriptionCookie
+    case failedToSetSubscriptionCookie
 }

--- a/Sources/SubscriptionTestingUtilities/SubscriptionCookie/SubscriptionCookieManagerMock.swift
+++ b/Sources/SubscriptionTestingUtilities/SubscriptionCookie/SubscriptionCookieManagerMock.swift
@@ -1,0 +1,66 @@
+//
+//  SubscriptionCookieManagerMock.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Common
+import Subscription
+
+public final class SubscriptionCookieManagerMock: SubscriptionCookieManaging {
+
+    public var lastRefreshDate: Date?
+
+    public convenience init() {
+        let accountManager = AccountManagerMock()
+        let subscriptionService = DefaultSubscriptionEndpointService(currentServiceEnvironment: .production)
+        let authService = DefaultAuthEndpointService(currentServiceEnvironment: .production)
+        let storePurchaseManager = DefaultStorePurchaseManager()
+        let subscriptionManager = SubscriptionManagerMock(accountManager: accountManager,
+                                                      subscriptionEndpointService: subscriptionService,
+                                                      authEndpointService: authService,
+                                                      storePurchaseManager: storePurchaseManager,
+                                                      currentEnvironment: SubscriptionEnvironment(serviceEnvironment: .production,
+                                                                                                  purchasePlatform: .appStore),
+                                                      canPurchase: true)
+
+        self.init(subscriptionManager: subscriptionManager,
+                  currentCookieStore: { return nil },
+                  eventMapping: MockSubscriptionCookieManagerEventPixelMapping())
+    }
+
+    public init(subscriptionManager: SubscriptionManager,
+                currentCookieStore: @MainActor @escaping () -> HTTPCookieStore?,
+                eventMapping: EventMapping<SubscriptionCookieManagerEvent>) {
+
+    }
+
+    public func refreshSubscriptionCookie() async { }
+    public func resetLastRefreshDate() { }
+}
+
+
+public final class MockSubscriptionCookieManagerEventPixelMapping: EventMapping<SubscriptionCookieManagerEvent> {
+
+    public init() {
+        super.init { _, _, _, _ in
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<SubscriptionCookieManagerEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+}

--- a/Sources/SubscriptionTestingUtilities/SubscriptionCookie/SubscriptionCookieManagerMock.swift
+++ b/Sources/SubscriptionTestingUtilities/SubscriptionCookie/SubscriptionCookieManagerMock.swift
@@ -28,7 +28,7 @@ public final class SubscriptionCookieManagerMock: SubscriptionCookieManaging {
         let accountManager = AccountManagerMock()
         let subscriptionService = DefaultSubscriptionEndpointService(currentServiceEnvironment: .production)
         let authService = DefaultAuthEndpointService(currentServiceEnvironment: .production)
-        let storePurchaseManager = DefaultStorePurchaseManager()
+        let storePurchaseManager = StorePurchaseManagerMock()
         let subscriptionManager = SubscriptionManagerMock(accountManager: accountManager,
                                                       subscriptionEndpointService: subscriptionService,
                                                       authEndpointService: authService,

--- a/Sources/SubscriptionTestingUtilities/SubscriptionCookie/SubscriptionCookieManagerMock.swift
+++ b/Sources/SubscriptionTestingUtilities/SubscriptionCookie/SubscriptionCookieManagerMock.swift
@@ -52,7 +52,6 @@ public final class SubscriptionCookieManagerMock: SubscriptionCookieManaging {
     public func resetLastRefreshDate() { }
 }
 
-
 public final class MockSubscriptionCookieManagerEventPixelMapping: EventMapping<SubscriptionCookieManagerEvent> {
 
     public init() {

--- a/Tests/SubscriptionTests/Managers/AccountManagerTests.swift
+++ b/Tests/SubscriptionTests/Managers/AccountManagerTests.swift
@@ -112,6 +112,7 @@ final class AccountManagerTests: XCTestCase {
 
     func testStoreAccount() async throws {
         // Given
+        
         let notificationExpectation = expectation(forNotification: .accountDidSignIn, object: accountManager, handler: nil)
 
         // When

--- a/Tests/SubscriptionTests/Managers/AccountManagerTests.swift
+++ b/Tests/SubscriptionTests/Managers/AccountManagerTests.swift
@@ -112,7 +112,7 @@ final class AccountManagerTests: XCTestCase {
 
     func testStoreAccount() async throws {
         // Given
-        
+
         let notificationExpectation = expectation(forNotification: .accountDidSignIn, object: accountManager, handler: nil)
 
         // When

--- a/Tests/SubscriptionTests/SubscriptionCookie/SubscriptionCookieManagerTests.swift
+++ b/Tests/SubscriptionTests/SubscriptionCookie/SubscriptionCookieManagerTests.swift
@@ -126,13 +126,12 @@ final class SubscriptionCookieManagerTests: XCTestCase {
         let firstRefreshDate: Date?
         let secondRefreshDate: Date?
 
-
         // When
         await subscriptionCookieManager.refreshSubscriptionCookie()
         firstRefreshDate = subscriptionCookieManager.lastRefreshDate
-        
+
         try await Task.sleep(seconds: 0.5)
-        
+
         await subscriptionCookieManager.refreshSubscriptionCookie()
         secondRefreshDate = subscriptionCookieManager.lastRefreshDate
 

--- a/Tests/SubscriptionTests/SubscriptionCookie/SubscriptionCookieManagerTests.swift
+++ b/Tests/SubscriptionTests/SubscriptionCookie/SubscriptionCookieManagerTests.swift
@@ -1,0 +1,237 @@
+//
+//  SubscriptionCookieManagerTests.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Common
+@testable import Subscription
+import SubscriptionTestingUtilities
+
+final class SubscriptionCookieManagerTests: XCTestCase {
+
+    private struct Constants {
+        static let authToken = UUID().uuidString
+        static let accessToken = UUID().uuidString
+    }
+
+    var accountManager: AccountManagerMock!
+    var subscriptionService: SubscriptionEndpointServiceMock!
+    var authService: AuthEndpointServiceMock!
+    var storePurchaseManager: StorePurchaseManagerMock!
+    var subscriptionEnvironment: SubscriptionEnvironment!
+    var subscriptionManager: SubscriptionManagerMock!
+
+    var cookieStore: HTTPCookieStore!
+    var subscriptionCookieManager: SubscriptionCookieManager!
+
+    override func setUp() async throws {
+        accountManager = AccountManagerMock()
+        subscriptionService = SubscriptionEndpointServiceMock()
+        authService = AuthEndpointServiceMock()
+        storePurchaseManager = StorePurchaseManagerMock()
+        subscriptionEnvironment = SubscriptionEnvironment(serviceEnvironment: .production,
+                                                           purchasePlatform: .appStore)
+
+        subscriptionManager = SubscriptionManagerMock(accountManager: accountManager,
+                                                      subscriptionEndpointService: subscriptionService,
+                                                      authEndpointService: authService,
+                                                      storePurchaseManager: storePurchaseManager,
+                                                      currentEnvironment: subscriptionEnvironment,
+                                                      canPurchase: true)
+        cookieStore = MockHTTPCookieStore()
+
+        subscriptionCookieManager = SubscriptionCookieManager(subscriptionManager: subscriptionManager,
+                                                              currentCookieStore: { self.cookieStore },
+                                                              eventMapping: MockSubscriptionCookieManageEventPixelMapping(),
+                                                              refreshTimeInterval: .seconds(1))
+    }
+
+    override func tearDown() async throws {
+        accountManager = nil
+        subscriptionService = nil
+        authService = nil
+        storePurchaseManager = nil
+        subscriptionEnvironment = nil
+
+        subscriptionManager = nil
+    }
+
+    func testSubscriptionCookieIsAddedWhenSigningInToSubscription() async throws {
+        // Given
+        await ensureNoSubscriptionCookieInTheCookieStore()
+        accountManager.accessToken = Constants.accessToken
+
+        // When
+        NotificationCenter.default.post(name: .accountDidSignIn, object: self, userInfo: nil)
+        try await Task.sleep(seconds: 0.1)
+
+        // Then
+        await checkSubscriptionCookieIsPresent()
+    }
+
+    func testSubscriptionCookieIsDeletedWhenSigningInToSubscription() async throws {
+        // Given
+        await ensureSubscriptionCookieIsInTheCookieStore()
+
+        // When
+        NotificationCenter.default.post(name: .accountDidSignOut, object: self, userInfo: nil)
+        try await Task.sleep(seconds: 0.1)
+
+        // Then
+        await checkSubscriptionCookieIsNotPresent()
+    }
+
+    func testRefreshWhenSignedInButCookieIsMissing() async throws {
+        // Given
+        accountManager.accessToken = Constants.accessToken
+        await ensureNoSubscriptionCookieInTheCookieStore()
+
+        // When
+        await subscriptionCookieManager.refreshSubscriptionCookie()
+        try await Task.sleep(seconds: 0.1)
+
+        // Then
+        await checkSubscriptionCookieIsPresent()
+    }
+
+    func testRefreshWhenSignedOutButCookieIsPresent() async throws {
+        // Given
+        accountManager.accessToken = nil
+        await ensureSubscriptionCookieIsInTheCookieStore()
+
+        // When
+        await subscriptionCookieManager.refreshSubscriptionCookie()
+        try await Task.sleep(seconds: 0.1)
+
+        // Then
+        await checkSubscriptionCookieIsNotPresent()
+    }
+
+    func testRefreshNotTriggeredTwiceWithinSetRefreshInterval() async throws {
+        // Given
+        let firstRefreshDate: Date?
+        let secondRefreshDate: Date?
+
+
+        // When
+        await subscriptionCookieManager.refreshSubscriptionCookie()
+        firstRefreshDate = subscriptionCookieManager.lastRefreshDate
+        
+        try await Task.sleep(seconds: 0.5)
+        
+        await subscriptionCookieManager.refreshSubscriptionCookie()
+        secondRefreshDate = subscriptionCookieManager.lastRefreshDate
+
+        // Then
+        XCTAssertEqual(firstRefreshDate!, secondRefreshDate!)
+    }
+
+    func testRefreshNotTriggeredSecondTimeAfterSetRefreshInterval() async throws {
+        // Given
+        let firstRefreshDate: Date?
+        let secondRefreshDate: Date?
+
+        // When
+        await subscriptionCookieManager.refreshSubscriptionCookie()
+        firstRefreshDate = subscriptionCookieManager.lastRefreshDate
+
+        try await Task.sleep(seconds: 1.1)
+
+        await subscriptionCookieManager.refreshSubscriptionCookie()
+        secondRefreshDate = subscriptionCookieManager.lastRefreshDate
+
+        // Then
+        XCTAssertTrue(firstRefreshDate! < secondRefreshDate!)
+    }
+
+    private func ensureSubscriptionCookieIsInTheCookieStore() async {
+        let subscriptionCookie = HTTPCookie(properties: [
+            .domain: SubscriptionCookieManager.cookieDomain,
+            .path: "/",
+            .expires: Date().addingTimeInterval(.days(365)),
+            .name: SubscriptionCookieManager.cookieName,
+            .value: Constants.accessToken,
+            .secure: true,
+            .init(rawValue: "HttpOnly"): true
+        ])!
+        await cookieStore.setCookie(subscriptionCookie)
+
+        let cookieStoreCookies = await cookieStore.allCookies()
+        XCTAssertEqual(cookieStoreCookies.count, 1)
+    }
+
+    private func ensureNoSubscriptionCookieInTheCookieStore() async {
+        let cookieStoreCookies = await cookieStore.allCookies()
+        XCTAssertTrue(cookieStoreCookies.isEmpty)
+    }
+
+    private func checkSubscriptionCookieIsPresent() async {
+        guard let subscriptionCookie = await cookieStore.fetchSubscriptionCookie() else {
+            XCTFail("No subscription cookie in the store")
+            return
+        }
+        XCTAssertEqual(subscriptionCookie.value, Constants.accessToken)
+    }
+
+    private func checkSubscriptionCookieIsNotPresent() async {
+        let cookie = await cookieStore.fetchSubscriptionCookie()
+        XCTAssertNil(cookie)
+    }
+
+}
+
+private extension HTTPCookieStore {
+
+    func fetchSubscriptionCookie() async -> HTTPCookie? {
+        await allCookies().first { $0.domain == SubscriptionCookieManager.cookieDomain && $0.name == SubscriptionCookieManager.cookieName }
+    }
+}
+
+class MockHTTPCookieStore: HTTPCookieStore {
+
+    var cookies: [HTTPCookie]
+
+    init(cookies: [HTTPCookie] = []) {
+        self.cookies = cookies
+    }
+
+    func allCookies() async -> [HTTPCookie] {
+        return cookies
+    }
+
+    func setCookie(_ cookie: HTTPCookie) async {
+        cookies.append(cookie)
+    }
+
+    func deleteCookie(_ cookie: HTTPCookie) async {
+        cookies.removeAll { $0.domain == cookie.domain }
+    }
+
+}
+
+class MockSubscriptionCookieManageEventPixelMapping: EventMapping<SubscriptionCookieManagerEvent> {
+
+    public init() {
+        super.init { event, _, _, _ in
+
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<SubscriptionCookieManagerEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+}


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1108686900785972/1208264562025859/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3488
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3458
What kind of version bump will this require?: Minor

**Description**:
Store and keep in sync the subscription access token for the duckduckgo.com domain cookie. For the implementation guidelines please see description of the linked task.

**Steps to test this PR**:
See platform PRs


**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
