### PR TITLE
Add Privacy Config feature to control ad attribution reporting

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -184,8 +184,3 @@ public enum SyncPromotionSubfeature: String, PrivacySubfeature {
     case bookmarks
     case passwords
 }
-
-public enum AdAttributionReportingSubfeature: String, PrivacySubfeature {
-    public var parent: PrivacyFeature { .adAttributionReporting }
-    case includeToken
-}

--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -63,6 +63,7 @@ public enum PrivacyFeature: String {
     case networkProtection
     case aiChat
     case contextualOnboarding
+    case adAttributionReporting
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.
@@ -182,4 +183,9 @@ public enum SyncPromotionSubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature { .syncPromotion }
     case bookmarks
     case passwords
+}
+
+public enum AdAttributionReportingSubfeature: String, PrivacySubfeature {
+    public var parent: PrivacyFeature { .adAttributionReporting }
+    case includeToken
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1208638248015576/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3506
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3478
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL:
CC:

**Description**:

Adds feature to control the ad attribution reporting on iOS.

**Steps to test this PR**:
See https://github.com/duckduckgo/iOS/pull/3506

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
