### PR TITLE
Update to subscription cookie

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -152,6 +152,7 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case isLaunchedOverride
     case isLaunchedOverrideStripe
     case useUnifiedFeedback
+    case setAccessTokenCookieForSubscriptionDomains
 }
 
 public enum SslCertificatesSubfeature: String, PrivacySubfeature {

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
@@ -30,7 +30,7 @@ public protocol SubscriptionCookieManaging {
 
 public final class SubscriptionCookieManager: SubscriptionCookieManaging {
 
-    public static let cookieDomain = ".duckduckgo.com"
+    public static let cookieDomain = "subscriptions.duckduckgo.com"
     public static let cookieName = "privacy_pro_access_token"
 
     private static let defaultRefreshTimeInterval: TimeInterval = .hours(4)

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManager.swift
@@ -63,19 +63,17 @@ public final class SubscriptionCookieManager: SubscriptionCookieManaging {
         self.currentCookieStore = currentCookieStore
         self.eventMapping = eventMapping
         self.refreshTimeInterval = refreshTimeInterval
-    }
 
-    public func enableSettingSubscriptionCookie() {
-        isSettingSubscriptionCookieEnabled = true
         NotificationCenter.default.addObserver(self, selector: #selector(handleAccountDidSignIn), name: .accountDidSignIn, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleAccountDidSignOut), name: .accountDidSignOut, object: nil)
     }
 
+    public func enableSettingSubscriptionCookie() {
+        isSettingSubscriptionCookieEnabled = true
+    }
+
     public func disableSettingSubscriptionCookie() async {
         isSettingSubscriptionCookieEnabled = false
-        NotificationCenter.default.removeObserver(self, name: .accountDidSignIn, object: nil)
-        NotificationCenter.default.removeObserver(self, name: .accountDidSignOut, object: nil)
-
         if let cookieStore = await currentCookieStore(),
            let cookie = await cookieStore.fetchCurrentSubscriptionCookie() {
             await cookieStore.deleteCookie(cookie)

--- a/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManagerEvent.swift
+++ b/Sources/Subscription/SubscriptionCookie/SubscriptionCookieManagerEvent.swift
@@ -20,10 +20,9 @@ import Foundation
 
 public enum SubscriptionCookieManagerEvent {
     case errorHandlingAccountDidSignInTokenIsMissing
-    case errorHandlingAccountDidSignOutCookieIsMissing
 
-    case subscriptionCookieRefreshedWithUpdate
-    case subscriptionCookieRefreshedWithDelete
+    case subscriptionCookieRefreshedWithAccessToken
+    case subscriptionCookieRefreshedWithEmptyValue
 
     case failedToSetSubscriptionCookie
 }

--- a/Sources/SubscriptionTestingUtilities/SubscriptionCookie/SubscriptionCookieManagerMock.swift
+++ b/Sources/SubscriptionTestingUtilities/SubscriptionCookie/SubscriptionCookieManagerMock.swift
@@ -48,6 +48,8 @@ public final class SubscriptionCookieManagerMock: SubscriptionCookieManaging {
 
     }
 
+    public func enableSettingSubscriptionCookie() { }
+    public func disableSettingSubscriptionCookie() async { }
     public func refreshSubscriptionCookie() async { }
     public func resetLastRefreshDate() { }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1108686900785972/1208264562025859/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3512
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3489
What kind of version bump will this require?: Patch

**Description**:
Update to how the subscription cookie operates:
- constraint the cookie to `subscriptions.duckduckgo.com`
- on sign out do not fully remove the cookie - just clear the value
- gate the feature behind the `setAccessTokenCookieForSubscriptionDomains` privacy config feature flag 

**Steps to test this PR**:
See client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
