### PR TITLE
Validate VPN errors before re-throwing them

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -738,7 +738,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             self.knownFailureStore.lastKnownFailure = KnownFailure(error)
 
             providerEvents.fire(.tunnelStartAttempt(.failure(error)))
-            
+
             // Check that the error is valid and able to be re-thrown to the OS before shutting the tunnel down
             throw validated(error: error)
         }

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -771,8 +771,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     private func startTunnel(onDemand: Bool) async throws {
         do {
-            throw ErrorThatCrashes.crash
-
             Logger.networkProtection.log("Generating tunnel config")
             Logger.networkProtection.log("Excluded ranges are: \(String(describing: self.settings.excludedRanges), privacy: .public)")
             Logger.networkProtection.log("Server selection method: \(self.currentServerSelectionMethod.debugDescription, privacy: .public)")

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -692,9 +692,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 throw TunnelError.startingTunnelWithoutAuthToken
             }
         } catch {
-            // Check that the error is valid and able to be re-thrown to the OS before shutting the tunnel down
-            let error = validated(error: error)
-
             if startupOptions.startupMethod == .automaticOnDemand {
                 // If the VPN was started by on-demand without the basic prerequisites for
                 // it to work we skip firing pixels.  This should only be possible if the
@@ -713,7 +710,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             Logger.networkProtection.log("🔴 Stopping VPN due to no auth token")
             await attemptShutdownDueToRevokedAccess()
 
-            throw error
+            // Check that the error is valid and able to be re-thrown to the OS before shutting the tunnel down
+            throw validated(error: error)
         }
 
         do {
@@ -726,9 +724,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             providerEvents.fire(.tunnelStartAttempt(.success))
         } catch {
-            // Check that the error is valid and able to be re-thrown to the OS before shutting the tunnel down
-            let error = validated(error: error)
-
             if startupOptions.startupMethod == .automaticOnDemand {
                 // We add a delay when the VPN is started by
                 // on-demand and there's an error, to avoid frenetic ON/OFF
@@ -743,7 +738,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             self.knownFailureStore.lastKnownFailure = KnownFailure(error)
 
             providerEvents.fire(.tunnelStartAttempt(.failure(error)))
-            throw error
+            
+            // Check that the error is valid and able to be re-thrown to the OS before shutting the tunnel down
+            throw validated(error: error)
         }
     }
 

--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -42,6 +42,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         case rekeyAttempt(_ step: RekeyAttemptStep)
         case failureRecoveryAttempt(_ step: FailureRecoveryStep)
         case serverMigrationAttempt(_ step: ServerMigrationAttemptStep)
+        case malformedErrorDetected(_ error: Error)
     }
 
     public enum AttemptStep: CustomDebugStringConvertible {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1208225499545869/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3513
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3490
What kind of version bump will this require?: Major

**Description**:

This PR attempts to catch malformed errors before they get thrown to the OS. It also informs us when this happens.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

To test this, we need to make sure that existing errors still throw as expected, and that errors we're trying to filter out get successfully caught.

**For testing existing errors on iOS:**

1. Open PacketTunnelProvider.swift
2. Go to `func startTunnel(options: [String: NSObject]? = nil) async throws`, which is the function where errors from the rest of the VPN get thrown to the OS
3. Pick one of the `try` functions in `startTunnel`, for example `try await startTunnel(onDemand: startupOptions.startupMethod == .automaticOnDemand)`
4. Inside that function, throw an error such as `TunnelError.simulateTunnelFailureError`
5. Now, attempt to start the VPN, and check that it fails
6. After it has failed, go to the iOS debug menu's `Network Protection` section, and check the metadata at the very bottom to confirm that the `lastDisconnectError` value to make sure it matches the error you used in step 4

**For testing errors that we're filtering out:**

First, add the following error somewhere in PacketTunnelProvider:

```
    enum ErrorThatCrashes: CustomNSError {
        case crash

        var errorCode: Int {
            return 123
        }

        static var errorDomain: String {
            return "error-domain"
        }

        var errorUserInfo: [String: Any] {
            return [
                NSUnderlyingErrorKey: "testing"
            ]
        }
    }
```

This error uses an underlying error that isn't a valid error object, which causes a VPN extension crash. Next:

1. Throw an instance of that error from the same place that you used in the first set of instructions
2. Check the Debug menu's Network Protection section and confirm that you see a valid error object in the metadata which is of the type `InvalidDiagnosticError`
3. Also, check that it contains an underlying error that is just domain and code

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
