### PR TITLE
Send pixel on sync secure storage read failure

### DIFF
--- a/Sources/DDGSync/DDGSync.swift
+++ b/Sources/DDGSync/DDGSync.swift
@@ -42,7 +42,14 @@ public class DDGSync: DDGSyncing {
     }
 
     public var account: SyncAccount? {
-        try? dependencies.secureStore.account()
+        do {
+            return try dependencies.secureStore.account()
+        } catch {
+            if let syncError = error as? SyncError {
+                dependencies.errorEvents.fire(syncError, error: syncError)
+            }
+            return nil
+        }
     }
 
     public var scheduler: Scheduling {

--- a/Sources/DDGSync/SyncError.swift
+++ b/Sources/DDGSync/SyncError.swift
@@ -190,4 +190,14 @@ extension SyncError: CustomNSError {
         }
     }
 
+    public var errorUserInfo: [String: Any] {
+        switch self {
+        case .failedToReadSecureStore(let status), .failedToWriteSecureStore(let status), .failedToRemoveSecureStore(let status):
+            let underlyingError = NSError(domain: "secError", code: Int(status))
+            return [NSUnderlyingErrorKey: underlyingError]
+        default:
+            return [:]
+        }
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201493110486074/1208686320819590/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3530
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3497
What kind of version bump will this require?: Minor

**Description:**

On investigating a hard-to-reproduce issue with sync, I noticed there's a gap in error reporting when the secure storage (keychain) is not available. This adds a pixel for that case.

**Steps to test this PR:**
Just a pixel in an error case. Hard to test without altering code. But if you do want to do that:

Enable sync
Change BSK.DDGSync.SecureStorage.account() to throw every time
Go to the Settings -> Sync screen
You should see the `sync_secure_storage_read_error` Pixel in the debug console

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
