### PR TITLE
Deprecate PixelKit daily pixel suffixes

### DIFF
--- a/Sources/PixelKit/PixelKit.swift
+++ b/Sources/PixelKit/PixelKit.swift
@@ -41,10 +41,10 @@ public final class PixelKit {
         /// Sent once per day. The last timestamp for this pixel is stored and compared to the current date. Pixels of this type will have `_d` appended to their name.
         case daily
 
-        /// Sent once per day with a `_d` suffix, in addition to every time it is called with a `_c` suffix.
+        /// [Legacy] Sent once per day with a `_d` suffix, in addition to every time it is called with a `_c` suffix.
         /// This means a pixel will get sent twice the first time it is called per-day, and subsequent calls that day will only send the `_c` variant.
         /// This is useful in situations where pixels receive spikes in volume, as the daily pixel can be used to determine how many users are actually affected.
-        case dailyAndCount
+        case legacyDailyAndCount
 
         fileprivate var description: String {
             switch self {
@@ -58,8 +58,8 @@ public final class PixelKit {
                 "Legacy Daily"
             case .daily:
                 "Daily"
-            case .dailyAndCount:
-                "Daily and Count"
+            case .legacyDailyAndCount:
+                "Legacy Daily and Count"
             }
         }
     }
@@ -233,7 +233,7 @@ public final class PixelKit {
             } else {
                 printDebugInfo(pixelName: pixelName + "_d", frequency: frequency, parameters: newParams, skipped: true)
             }
-        case .dailyAndCount:
+        case .legacyDailyAndCount:
             reportErrorIf(pixel: pixelName, endsWith: "_u")
             reportErrorIf(pixel: pixelName, endsWith: "_d") // Because is added automatically
             reportErrorIf(pixel: pixelName, endsWith: "_c") // Because is added automatically

--- a/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
+++ b/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
@@ -97,7 +97,7 @@ public extension XCTestCase {
         let knownExpectedParameters = knownExpectedParameters(for: event)
         let callbackExecutedExpectation = expectation(description: "The PixelKit callback has been executed")
 
-        if frequency == .dailyAndCount {
+        if frequency == .legacyDailyAndCount {
             callbackExecutedExpectation.expectedFulfillmentCount = 2
         }
 
@@ -123,7 +123,7 @@ public extension XCTestCase {
                 firedParameters[key] == value
             }, file: file, line: line)
 
-            if frequency == .dailyAndCount {
+            if frequency == .legacyDailyAndCount {
                 XCTAssertTrue(firedPixelName.hasPrefix(expectations.pixelName))
                 XCTAssertTrue(firedPixelName.hasSuffix("_c") || firedPixelName.hasSuffix("_d"))
                 XCTAssertEqual(firedPixelName.count, expectations.pixelName.count + 2)
@@ -155,7 +155,7 @@ public extension XCTestCase {
             expectedPixelNames.append(originalName)
         case .daily:
             expectedPixelNames.append(originalName.appending("_d"))
-        case .dailyAndCount:
+        case .legacyDailyAndCount:
             expectedPixelNames.append(originalName.appending("_d"))
             expectedPixelNames.append(originalName.appending("_c"))
         }

--- a/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
+++ b/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
@@ -158,6 +158,9 @@ public extension XCTestCase {
         case .legacyDailyAndCount:
             expectedPixelNames.append(originalName.appending("_d"))
             expectedPixelNames.append(originalName.appending("_c"))
+        case .dailyAndCount:
+            expectedPixelNames.append(originalName.appending("_daily"))
+            expectedPixelNames.append(originalName.appending("_count"))
         }
         return expectedPixelNames
     }

--- a/Tests/PixelKitTests/PixelKitTests.swift
+++ b/Tests/PixelKitTests/PixelKitTests.swift
@@ -86,7 +86,7 @@ final class PixelKitTests: XCTestCase {
             case .dailyEvent, .dailyEventWithoutParameters:
                 return .daily
             case .dailyAndContinuousEvent, .dailyAndContinuousEventWithoutParameters:
-                return .dailyAndCount
+                return .legacyDailyAndCount
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1208695427490034/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3534
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3509
What kind of version bump will this require?: Major

**Description**:

This PR renames the existing `dailyAndCount` PixelKit type to `legacyDailyAndCount`.

A new `dailyAndCount` case has been added, but it uses new suffixes.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check that the enum cases are correctly tested in the unit test suite
1. Check client PRs

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
