### PR TITLE
Fixes the disappearing breakage form

### DIFF
--- a/Sources/PrivacyDashboard/PrivacyDashboardController.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardController.swift
@@ -95,6 +95,12 @@ public protocol PrivacyDashboardControllerDelegate: AnyObject {
     public func setup(for webView: WKWebView) {
         self.webView = webView
         webView.navigationDelegate = self
+        
+        if #available(iOS 16.4, macOS 13.3, *) {
+            webView.isInspectable = true
+        } else {
+            // Fallback on earlier versions
+        }
 
         setupPrivacyDashboardUserScript()
         loadStartScreen()

--- a/Sources/PrivacyDashboard/PrivacyDashboardUserScript.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardUserScript.swift
@@ -332,7 +332,7 @@ final class PrivacyDashboardUserScript: NSObject, StaticUserScript {
         atbEntry = ""
 #endif
         let js = """
-                     const json = {
+                     window.onGetToggleReportOptionsResponse({
                          "data": [
                              {
                                  "id": "siteUrl",
@@ -356,8 +356,7 @@ final class PrivacyDashboardUserScript: NSObject, StaticUserScript {
                              {"id": "openerContext"},
                              {"id": "userRefreshCount"},
                          ]
-                     }
-                     window.onGetToggleReportOptionsResponse(json);
+                     });
                      """
         evaluate(js: js, in: webView)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1206594217596623/1208729801503622/f
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Major/Minor/Patch

**Optional**:

CC: @jaceklyp 

**Description**:


When triggering `window.onGetToggleReportOptionsResponse` on the Privacy Dashboard, the native side would create a variable `json` in the global scope before sending it as a parameter to the callback. If GetToggleReportOptionsResponse was even invoked again in the same webview, the attempt to declare another variable with the same name (`json`) would result in a fatal error.

This PR removes the declaration of the `json` variable, instead passing the data directly as a parameter to the callback.

**Steps to test this PR**:
1. Check out branch `jacek/new-breakage-form` of the iOS app
2. Set BSK to point to `mgurgel/new-breakage-form`
3. Run the app
4. Click on three dots menu 
5. Select Report Broken Site
6. Choose a category and a subcategory
7. The form should be visible
8. Navigate back to category selection page
9. Choose a category again
10. The form should still be visible

<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
