### PR TITLE
Speculative password import prompt crash fix

### DIFF
--- a/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
+++ b/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SecureVault.swift
@@ -748,7 +748,6 @@ extension AutofillUserScript {
                 if !credentials.isEmpty {
                     self?.passwordImportDelegate?.autofillUserScriptDidFinishImportWithImportedCredentialForCurrentDomain()
                 }
-                replyHandler(nil)
             })
         }
     }


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1203822806345703/1208648341254407/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3569
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3542
What kind of version bump will this require?: Patch

**Description**:

There's a crash in moderate numbers which is occurring during the password import prompt flow. This is speculative fix for that.

The reason seemed to be that the `replyHandler` was being called too many times. However:
- The docs for `userContentController:didReceiveScriptMessage:replyHandler:` say " The replyHandler can be called at most once. If the replyHandler is deallocated before it is called, the Promise will be rejected with a JavaScript Error object
 with an appropriate message indicating the handler was never called."
- In the case of `startCredentialsImportFlow` where the crash is occurring, the JS is not awaiting. So there is no need to call the replyHandler.

**Steps to test this PR**:
Just smoke tests for the feature:
https://app.asana.com/0/1142021229838617/1208543152554655/f

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
