### PR TITLE
Add a 2 second delay before shutting down the tunnel when encountering an error

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -691,7 +691,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 // expired.  In either case it should be enough to record the manual failures
                 // for these prerequisited to avoid flooding our metrics.
                 providerEvents.fire(.tunnelStartOnDemandWithoutAccessToken)
-                try await Task.sleep(interval: .seconds(15))
+                try? await Task.sleep(interval: .seconds(15))
             } else {
                 // If the VPN was started manually without the basic prerequisites we always
                 // want to know as this should not be possible.
@@ -704,7 +704,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             // Check that the error is valid and able to be re-thrown to the OS before shutting the tunnel down
             if let wrappedError = wrapped(error: error) {
+                // Wait for the provider to complete its pixel request.
                 providerEvents.fire(.malformedErrorDetected(error))
+                try? await Task.sleep(interval: .seconds(2))
                 throw wrappedError
             } else {
                 throw error
@@ -725,7 +727,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 // We add a delay when the VPN is started by
                 // on-demand and there's an error, to avoid frenetic ON/OFF
                 // cycling.
-                try await Task.sleep(interval: .seconds(15))
+                try? await Task.sleep(interval: .seconds(15))
             }
 
             let errorDescription = (error as? LocalizedError)?.localizedDescription ?? String(describing: error)
@@ -738,9 +740,13 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
             // Check that the error is valid and able to be re-thrown to the OS before shutting the tunnel down
             if let wrappedError = wrapped(error: error) {
+                // Wait for the provider to complete its pixel request.
                 providerEvents.fire(.malformedErrorDetected(error))
+                try? await Task.sleep(interval: .seconds(2))
                 throw wrappedError
             } else {
+                // Wait for the provider to complete its pixel request.
+                try? await Task.sleep(interval: .seconds(2))
                 throw error
             }
         }


### PR DESCRIPTION
…g an error.

<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1207603085593419/1208772807738114/f
iOS PR: TODO
macOS PR: TODO
What kind of version bump will this require?: Patch

**Description**:

This PR adds a short delay when shutting down the tunnel.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. TODO

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
