### PR TITLE
Remove an unnecessary step when stopping the tunnel

### DIFF
--- a/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -887,6 +887,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     @MainActor
     private func stopTunnel() async throws {
         connectionStatus = .disconnecting
+
         await stopMonitors()
         try await stopAdapter()
     }
@@ -895,10 +896,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     private func stopAdapter() async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             adapter.stop { [weak self] error in
-                if let self {
-                    self.handleAdapterStopped()
-                }
-
                 if let error {
                     self?.debugEvents.fire(error.networkProtectionError)
 
@@ -1418,11 +1415,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         // and is being fixed, so we want to test the connection immediately.
         let testImmediately = startReason == .reconnected || startReason == .onDemand
         try await startMonitors(testImmediately: testImmediately)
-    }
-
-    @MainActor
-    public func handleAdapterStopped() {
-        connectionStatus = .disconnected
     }
 
     // MARK: - Monitors


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1208865941226621/f

iOS PR: https://github.com/duckduckgo/iOS/pull/3639
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3608

What kind of version bump will this require?: Patch

## Description

Removes a duplicated step from the tunnel stop logic that was causing some trouble in the logs.

## Testing

Use the macOS PR to test.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
