### PR TITLE
Add Missing Enum to Freemium RMF Implementation

### DIFF
--- a/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -51,6 +51,7 @@ private enum AttributesKey: String, CaseIterable {
     case duckPlayerOnboarded
     case duckPlayerEnabled
     case messageShown
+    case isCurrentFreemiumPIRUser
 
     func matchingAttribute(jsonMatchingAttribute: AnyDecodable) -> MatchingAttribute {
         switch self {
@@ -86,6 +87,7 @@ private enum AttributesKey: String, CaseIterable {
         case .duckPlayerOnboarded: return DuckPlayerOnboardedMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .duckPlayerEnabled: return DuckPlayerEnabledMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         case .messageShown: return MessageShownMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
+        case .isCurrentFreemiumPIRUser: return FreemiumPIRCurrentUserMatchingAttribute(jsonMatchingAttribute: jsonMatchingAttribute)
         }
     }
 }


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/1206488453854252/1208904081551825/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3673
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3631
What kind of version bump will this require?: Patch

**Description**: Adding missing Freemium RMF enum

**Steps to test this PR**:
1. Green CI is fine here

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
