### PR TITLE
Apple client send and receive support for crash report cohort IDs (CRCIDs)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -514,7 +514,8 @@ let package = Package(
         .testTarget(
             name: "CrashesTests",
             dependencies: [
-                "Crashes"
+                "Crashes",
+                "TestUtils"
             ]
         ),
         .testTarget(

--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -101,10 +101,11 @@ public final class CrashCollection {
                                     Logger.general.debug("Received matching value for CRCID: \(receivedCRCID), no update necessary")
                                 }
                             } else {
-                                Logger.general.debug("No value for CRCID header: \(Const.crcidKey), clearing local crcid value")
+                                Logger.general.debug("No value for CRCID header: \(Const.crcidKey), clearing local crcid value if present")
                                 self.crashCollectionStorage.removeObject(forKey: Const.crcidKey)
                             }
                         case .failure(let failure):
+                            // TODO: Is it worth sending a pixel for this case, so that we can monitor for missing crash reports?
                             Logger.general.debug("Crash Collection - Sending Crash Report: failed (\(failure))")
                         }
                     }

--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import MetricKit
+import Persistence
 
 public enum CrashCollectionPlatform {
     case iOS, macOS, macOSAppStore
@@ -38,9 +39,10 @@ public enum CrashCollectionPlatform {
 @available(iOS 13, macOS 12, *)
 public final class CrashCollection {
 
-    public init(platform: CrashCollectionPlatform) {
-        crashHandler = CrashHandler()
-        crashSender = CrashReportSender(platform: platform)
+    public init(crashReportSender: CrashReportSending, crashCollectionStorage: KeyValueStoring = UserDefaults()) {
+        self.crashHandler = CrashHandler()
+        self.crashSender = crashReportSender
+        self.crashCollectionStorage = crashCollectionStorage
     }
 
     public func start(didFindCrashReports: @escaping (_ pixelParameters: [[String: String]], _ payloads: [Data], _ uploadReports: @escaping () -> Void) -> Void) {
@@ -173,16 +175,17 @@ public final class CrashCollection {
 
     var isFirstCrash: Bool {
         get {
-            UserDefaults().object(forKey: Const.firstCrashKey) as? Bool ?? true
+            crashCollectionStorage.object(forKey: Const.firstCrashKey) as? Bool ?? true
         }
 
         set {
-            UserDefaults().set(newValue, forKey: Const.firstCrashKey)
+            crashCollectionStorage.set(newValue, forKey: Const.firstCrashKey)
         }
     }
 
     let crashHandler: CrashHandler
-    let crashSender: CrashReportSender
+    let crashSender: CrashReportSending
+    let crashCollectionStorage: KeyValueStoring
 
     enum Const {
         static let firstCrashKey = "CrashCollection.first"

--- a/Sources/Crashes/CrashCollection.swift
+++ b/Sources/Crashes/CrashCollection.swift
@@ -92,15 +92,20 @@ public final class CrashCollection {
 
                         switch result.result {
                         case .success:
-                            Logger.general.debug("Successfully sent crash report")
-                            if let receivedCRCID = result.response?.allHeaderFields[Const.crcidHTTPHeaderKey] as? String {
-                                self.crashCollectionStorage.set(receivedCRCID, forKey: Const.crcidKey)
+                            Logger.general.debug("Crash Collection - Sending Crash Report: succeeded")
+                            if let receivedCRCID = result.response?.allHeaderFields[CrashReportSender.httpHeaderCRCID] as? String {
+                                if crcid != receivedCRCID {
+                                    Logger.general.debug("Received new value for CRCID: \(receivedCRCID), setting local crcid value")
+                                    self.crashCollectionStorage.set(receivedCRCID, forKey: Const.crcidKey)
+                                } else {
+                                    Logger.general.debug("Received matching value for CRCID: \(receivedCRCID), no update necessary")
+                                }
                             } else {
-                                Logger.general.debug("No value found for header: \(Const.crcidKey), clearing local crcid value")
+                                Logger.general.debug("No value for CRCID header: \(Const.crcidKey), clearing local crcid value")
                                 self.crashCollectionStorage.removeObject(forKey: Const.crcidKey)
                             }
                         case .failure(let failure):
-                            Logger.general.debug("Failed to send crash report: \(failure)")
+                            Logger.general.debug("Crash Collection - Sending Crash Report: failed (\(failure))")
                         }
                     }
                     didFinishHandlingResponse()
@@ -210,6 +215,5 @@ public final class CrashCollection {
     enum Const {
         static let firstCrashKey = "CrashCollection.first"
         static let crcidKey = "CrashCollection.crcid"
-        static let crcidHTTPHeaderKey = "x-crcid"   // TODO: Settle on final value
     }
 }

--- a/Sources/Crashes/CrashReportSender.swift
+++ b/Sources/Crashes/CrashReportSender.swift
@@ -32,12 +32,8 @@ enum CrashReportSenderError: Error {
 // By conforming to a protocol, we can sub in mocks more easily
 public final class CrashReportSender: CrashReportSending {
 
-#if DEBUG
-    // TODO: Why is a breakpoint here hit twice?
-    static let reportServiceUrl = URL(string: "https://9e3c-20-75-144-152.ngrok-free.app/crash.js")!
-#else
     static let reportServiceUrl = URL(string: "https://duckduckgo.com/crash.js")!
-#endif
+
     static let httpHeaderCRCID = "crcid"
     
     public let platform: CrashCollectionPlatform

--- a/Sources/Crashes/CrashReportSender.swift
+++ b/Sources/Crashes/CrashReportSender.swift
@@ -32,7 +32,14 @@ enum CrashReportSenderError: Error {
 // By conforming to a protocol, we can sub in mocks more easily
 public final class CrashReportSender: CrashReportSending {
 
+#if DEBUG
+    // TODO: Why is a breakpoint here hit twice?
+    static let reportServiceUrl = URL(string: "https://9e3c-20-75-144-152.ngrok-free.app/crash.js")!
+#else
     static let reportServiceUrl = URL(string: "https://duckduckgo.com/crash.js")!
+#endif
+    static let httpHeaderCRCID = "crcid"
+    
     public let platform: CrashCollectionPlatform
     
     private let session = URLSession(configuration: .ephemeral)
@@ -45,6 +52,10 @@ public final class CrashReportSender: CrashReportSending {
         var request = URLRequest(url: Self.reportServiceUrl)
         request.setValue("text/plain", forHTTPHeaderField: "Content-Type")
         request.setValue(platform.userAgent, forHTTPHeaderField: "User-Agent")
+        if let crcid {
+            request.setValue(crcid, forHTTPHeaderField: CrashReportSender.httpHeaderCRCID)
+            Logger.general.debug("Configured crash report HTTP request with crcid: \(crcid)")
+        }
         request.httpMethod = "POST"
         request.httpBody = crashReportData
         

--- a/Sources/Crashes/CrashReportSender.swift
+++ b/Sources/Crashes/CrashReportSender.swift
@@ -78,7 +78,7 @@ public final class CrashReportSender: CrashReportSending {
                     completion(.failure(CrashReportSenderError.invalidResponse), response)
                 }
             } else {
-                    completion(.failure(CrashReportSenderError.invalidResponse), nil)
+                completion(.failure(CrashReportSenderError.invalidResponse), nil)
             }
         }
         task.resume()

--- a/Sources/TestUtils/MockKeyValueStore.swift
+++ b/Sources/TestUtils/MockKeyValueStore.swift
@@ -19,11 +19,11 @@
 import Foundation
 import Persistence
 
-public class MockKeyValueStore: KeyValueStoring {
+public class MockKeyValueStore: NSObject, KeyValueStoring {
 
     public var store = [String: Any?]()
 
-    public init() { }
+    public override init() { }
 
     public func object(forKey defaultName: String) -> Any? {
         return store[defaultName] as Any?

--- a/Tests/CrashesTests/CrashCollectionTests.swift
+++ b/Tests/CrashesTests/CrashCollectionTests.swift
@@ -58,8 +58,7 @@ class CrashCollectionTests: XCTestCase {
         XCTAssertFalse(crashCollection.isFirstCrash)
     }
     
-    func testCRCIDIsUpdatedWhenNoLocalValueIsPresent()
-    {
+    func testCRCIDIsStoredWhenReceived() {
         let responseCRCIDValue = "CRCID Value"
         
         let store = MockKeyValueStore()
@@ -121,13 +120,8 @@ class CrashCollectionTests: XCTestCase {
         
         XCTAssertNil(store.object(forKey: CrashCollection.Const.crcidKey), "CRCID should not be present in the store after receiving a successful response")
     }
-  
-    // TODO: Too redundant with the above to be worthwhile?
-//    func testCRCIDIsOverwrittenWhenServerProvidesNewValue() {
-//        // TODO: Implement
-//    }
     
-    func testCRCIDIsRetainedWhenErrorIsReceived() {
+    func testCRCIDIsRetainedWhenServerErrorIsReceived() {
         let store = MockKeyValueStore()
         let crashReportSender = MockCrashReportSender(platform: .iOS)
         let crashCollection = CrashCollection(crashReportSender: crashReportSender , crashCollectionStorage: store)

--- a/Tests/CrashesTests/CrashCollectionTests.swift
+++ b/Tests/CrashesTests/CrashCollectionTests.swift
@@ -159,10 +159,12 @@ class CrashCollectionTests: XCTestCase {
     }
     
     func testCRCIDIsSentToServer() {
-        // TODO: Can we inspect the HTTP request?
+        // TODO: Requires ability to inspect outbound HTTP request
     }
-        
-    // TODO: Is it possible to test multiple sends in rapid succession and ensure we complete one request to crash.js at a time?
+    
+    func testMultipleCrashReportCallsExecuteSequentialyAndUpdateCRCIDCorrectly() {
+        // TODO: Requires ability to inspect outbound HTTP request
+    }
 }
 
 class MockPayload: MXDiagnosticPayload {

--- a/Tests/CrashesTests/CrashCollectionTests.swift
+++ b/Tests/CrashesTests/CrashCollectionTests.swift
@@ -19,21 +19,13 @@
 @testable import Crashes
 import MetricKit
 import XCTest
+import Persistence
+import TestUtils
 
 class CrashCollectionTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-        clearUserDefaults()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        clearUserDefaults()
-    }
-
     func testFirstCrashFlagSent() {
-        let crashCollection = CrashCollection(platform: .iOS)
+        let crashCollection = CrashCollection(crashReportSender: CrashReportSender(platform: .iOS), crashCollectionStorage:  MockKeyValueStore())
         // 2 pixels with first = true attached
         XCTAssertTrue(crashCollection.isFirstCrash)
         crashCollection.start { pixelParameters, _, _ in
@@ -50,7 +42,7 @@ class CrashCollectionTests: XCTestCase {
     }
 
     func testSubsequentPixelsDontSendFirstFlag() {
-        let crashCollection = CrashCollection(platform: .iOS)
+        let crashCollection = CrashCollection(crashReportSender: CrashReportSender(platform: .iOS), crashCollectionStorage:  MockKeyValueStore())
         // 2 pixels with no first parameter
         crashCollection.isFirstCrash = false
         crashCollection.start { pixelParameters, _, _ in
@@ -64,10 +56,6 @@ class CrashCollectionTests: XCTestCase {
             ])
         ])
         XCTAssertFalse(crashCollection.isFirstCrash)
-    }
-
-    private func clearUserDefaults() {
-        UserDefaults().removeObject(forKey: CrashCollection.Const.firstCrashKey)
     }
 }
 

--- a/Tests/CrashesTests/CrashCollectionTests.swift
+++ b/Tests/CrashesTests/CrashCollectionTests.swift
@@ -106,6 +106,7 @@ class CrashCollectionTests: XCTestCase {
         // TODO: Can we inspect the HTTP request?
     }
         
+    // TODO: Is it possible to test multiple sends in rapid succession and ensure we complete one request to crash.js at a time?
 }
 
 class MockPayload: MXDiagnosticPayload {
@@ -140,7 +141,7 @@ class MockCrashReportSender: CrashReportSending {
         guard let response = HTTPURLResponse(url: URL(string: "fakeURL")!,
                                              statusCode: 200,
                                              httpVersion: nil,
-                                             headerFields: [CrashCollection.Const.crcidHTTPHeaderKey: responseCRCID ?? ""]) else {
+                                             headerFields: [CrashReportSender.httpHeaderCRCID: responseCRCID ?? ""]) else {
             XCTFail("Failed to create HTTPURLResponse")
             return
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1208592102886666/1208759541597499/f
iOS & macOS PRs: I’m looking for feedback on these BSK changes before posting app-level PRs
What kind of version bump will this require?: Minor (is this right? 😊).
CC: @larryturtis

**Optional**:
Tech Design URL: https://app.asana.com/0/1208592102886666/1208660326715650/f

**Description**:
DO NOT MERGE - this is a draft for input, not ready to go live yet.  Before this is ready to merge:
- I’ll have to coordinate iOS and macOS changes to match, as the API signatures for the CrashCollection class have changed
- I will be waiting past the December 9 code freeze, so these changes are not included in the last public release of 2024, and instead have an extended internal testing period

**Steps to test this PR**:
1. Relying on included automated tests is the primary testing function, but this can be tested live against @larryturtis’s dev instance.  To do this, set CrashReportSender line 35 to:
`static let reportServiceUrl = URL(string: "https://9e3c-20-75-144-152.ngrok-free.app/crash.js")!`

I have tested via the following means:
- Unit/integration tests included in this PR.
- Local changes to the iOS app to integrate with these BSK changes, seeing crashes submit to @larryturtis’s dev instance, which in turn routes crash through to [our Sentry instance (development environment)](https://errors.duckduckgo.com/organizations/ddg/issues/?environment=development&project=8&statsPeriod=90d), and ensuring that the client sends, receives, and updates, its crcid when appropriate.

Note that I have _not_ been able to test equivalent changes on macOS because I’m unable to add my computer to the DDG provisioning profile (see https://app.asana.com/0/1200194497630846/1208709596010744/f).

**OS Testing**:

* [ ] iOS 14
* [X] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
