### PR TITLE
Update RMF version matching to ignore build number

### DIFF
--- a/Sources/RemoteMessaging/Matchers/AppAttributeMatcher.swift
+++ b/Sources/RemoteMessaging/Matchers/AppAttributeMatcher.swift
@@ -81,7 +81,7 @@ public struct CommonAppAttributeMatcher: AttributeMatching {
             assertionFailure("BundleIdentifier should not be empty")
         }
         self.init(bundleId: AppVersion.shared.identifier,
-                  appVersion: AppVersion.shared.versionAndBuildNumber,
+                  appVersion: AppVersion.shared.versionNumber,
                   isInternalUser: isInternalUser,
                   statisticsStore: statisticsStore,
                   variantManager: variantManager)

--- a/Sources/RemoteMessaging/Model/MatchingAttributes.swift
+++ b/Sources/RemoteMessaging/Model/MatchingAttributes.swift
@@ -49,12 +49,27 @@ struct AppIdMatchingAttribute: SingleValueMatching {
 }
 
 struct AppVersionMatchingAttribute: StringRangeMatching {
+
     static let defaultMaxValue: String = AppVersion.shared.versionNumber
 
-    var min: String = MatchingAttributeDefaults.stringDefaultValue
-    var max: String = AppVersion.shared.versionNumber
-    var value: String = MatchingAttributeDefaults.stringDefaultValue
+    var min: String
+    var max: String
+    var value: String
     var fallback: Bool?
+
+    // Legacy versions of the app require a build number in the version string in order to match correctly.
+    // To allow message authors to include a build number for backwards compatibility, while also allowing new clients to use the simpler version
+    // string, this initializer trims the build number before storing it.
+    init(min: String = MatchingAttributeDefaults.stringDefaultValue,
+         max: String  = AppVersion.shared.versionNumber,
+         value: String = MatchingAttributeDefaults.stringDefaultValue,
+         fallback: Bool?) {
+        self.min = min.trimmingBuildNumber
+        self.max = max.trimmingBuildNumber
+        self.value = value.trimmingBuildNumber
+        self.fallback = fallback
+    }
+
 }
 
 struct AtbMatchingAttribute: SingleValueMatching {
@@ -305,4 +320,18 @@ struct RangeStringNumericMatchingAttribute: Equatable {
 
         return version + String(repeating: ".0", count: matchComponents.count - versionComponents.count)
     }
+}
+
+private extension String {
+
+    var trimmingBuildNumber: String {
+        let components = self.split(separator: ".")
+
+        if components.count == 4 {
+            return components.dropLast().joined(separator: ".")
+        } else {
+            return self
+        }
+    }
+
 }

--- a/Sources/RemoteMessaging/Model/MatchingAttributes.swift
+++ b/Sources/RemoteMessaging/Model/MatchingAttributes.swift
@@ -49,10 +49,10 @@ struct AppIdMatchingAttribute: SingleValueMatching {
 }
 
 struct AppVersionMatchingAttribute: StringRangeMatching {
-    static let defaultMaxValue: String = AppVersion.shared.versionAndBuildNumber
+    static let defaultMaxValue: String = AppVersion.shared.versionNumber
 
     var min: String = MatchingAttributeDefaults.stringDefaultValue
-    var max: String = AppVersion.shared.versionAndBuildNumber
+    var max: String = AppVersion.shared.versionNumber
     var value: String = MatchingAttributeDefaults.stringDefaultValue
     var fallback: Bool?
 }

--- a/Sources/RemoteMessaging/Model/MatchingAttributesPrototypes/StringRangeMatching.swift
+++ b/Sources/RemoteMessaging/Model/MatchingAttributesPrototypes/StringRangeMatching.swift
@@ -42,12 +42,7 @@ extension StringRangeMatching {
         let value = jsonMatchingAttribute[RuleAttributes.value] as? String ?? MatchingAttributeDefaults.stringDefaultValue
         let fallback = jsonMatchingAttribute[RuleAttributes.fallback] as? Bool
 
-        self.init(
-            min: min.trimmingBuildNumber,
-            max: max.trimmingBuildNumber,
-            value: value.trimmingBuildNumber,
-            fallback: fallback
-        )
+        self.init(min: min, max: max, value: value, fallback: fallback)
     }
 
     init(fallback: Bool?) {
@@ -65,18 +60,4 @@ extension StringRangeMatching {
         }
         return RangeStringNumericMatchingAttribute(min: min, max: max).matches(value: value)
     }
-}
-
-private extension String {
-
-    var trimmingBuildNumber: String {
-        let components = self.split(separator: ".")
-
-        if components.count == 4 {
-            return components.dropLast().joined(separator: ".")
-        } else {
-            return self
-        }
-    }
-
 }

--- a/Sources/RemoteMessaging/Model/MatchingAttributesPrototypes/StringRangeMatching.swift
+++ b/Sources/RemoteMessaging/Model/MatchingAttributesPrototypes/StringRangeMatching.swift
@@ -42,7 +42,12 @@ extension StringRangeMatching {
         let value = jsonMatchingAttribute[RuleAttributes.value] as? String ?? MatchingAttributeDefaults.stringDefaultValue
         let fallback = jsonMatchingAttribute[RuleAttributes.fallback] as? Bool
 
-        self.init(min: min, max: max, value: value, fallback: fallback)
+        self.init(
+            min: min.trimmingBuildNumber,
+            max: max.trimmingBuildNumber,
+            value: value.trimmingBuildNumber,
+            fallback: fallback
+        )
     }
 
     init(fallback: Bool?) {
@@ -60,4 +65,18 @@ extension StringRangeMatching {
         }
         return RangeStringNumericMatchingAttribute(min: min, max: max).matches(value: value)
     }
+}
+
+private extension String {
+
+    var trimmingBuildNumber: String {
+        let components = self.split(separator: ".")
+
+        if components.count == 4 {
+            return components.dropLast().joined(separator: ".")
+        } else {
+            return self
+        }
+    }
+
 }

--- a/Tests/RemoteMessagingTests/Matchers/CommonAppAttributeMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/Matchers/CommonAppAttributeMatcherTests.swift
@@ -144,10 +144,6 @@ class CommonAppAttributeMatcherTests: XCTestCase {
                        .fail)
     }
 
-    func testWhenAppVersionDoesNotIncludeBuildNumberButVersionMatchesThenReturnMatch() {
-
-    }
-
     func testWhenAtbMatchesThenReturnMatch() throws {
         XCTAssertEqual(matcher.evaluate(matchingAttribute: AtbMatchingAttribute(value: "v105-2", fallback: nil)),
                        .match)

--- a/Tests/RemoteMessagingTests/Matchers/CommonAppAttributeMatcherTests.swift
+++ b/Tests/RemoteMessagingTests/Matchers/CommonAppAttributeMatcherTests.swift
@@ -26,6 +26,7 @@ import XCTest
 class CommonAppAttributeMatcherTests: XCTestCase {
 
     private var matcher: CommonAppAttributeMatcher!
+    private let versionNumber = "3.2.1"
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -36,7 +37,13 @@ class CommonAppAttributeMatcherTests: XCTestCase {
         mockStatisticsStore.searchRetentionAtb = "v105-88"
 
         let manager = MockVariantManager(isSupportedReturns: true, currentVariant: MockVariant(name: "zo", weight: 44, isIncluded: { return true }, features: [.dummy]))
-        matcher = CommonAppAttributeMatcher(statisticsStore: mockStatisticsStore, variantManager: manager)
+        matcher = CommonAppAttributeMatcher(
+            bundleId: AppVersion.shared.identifier,
+            appVersion: versionNumber,
+            isInternalUser: true,
+            statisticsStore: mockStatisticsStore,
+            variantManager: manager
+        )
     }
 
     override func tearDownWithError() throws {
@@ -66,7 +73,7 @@ class CommonAppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionEqualOrLowerThanMaxThenReturnMatch() throws {
-        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = versionNumber.components(separatedBy: ".").map { $0 }
         let appMajorVersion = appVersionComponents[0]
         let appMinorVersion = appVersionComponents.suffix(from: 1).joined(separator: ".")
 
@@ -82,7 +89,7 @@ class CommonAppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionGreaterThanMaxThenReturnFail() throws {
-        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = versionNumber.components(separatedBy: ".").map { $0 }
         let appMajorVersion = appVersionComponents[0]
         let lessThanMax = String(Int(appMajorVersion)! - 1)
 
@@ -91,12 +98,12 @@ class CommonAppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionEqualOrGreaterThanMinThenReturnMatch() throws {
-        XCTAssertEqual(matcher.evaluate(matchingAttribute: AppVersionMatchingAttribute(min: AppVersion.shared.versionAndBuildNumber, fallback: nil)),
+        XCTAssertEqual(matcher.evaluate(matchingAttribute: AppVersionMatchingAttribute(min: versionNumber, fallback: nil)),
                        .match)
     }
 
     func testWhenAppVersionLowerThanMinThenReturnFail() throws {
-        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = versionNumber.components(separatedBy: ".").map { $0 }
         let (major, minor, patch) = (appVersionComponents[0], appVersionComponents[1], appVersionComponents[2])
         let majorBumped = String(Int(major)! + 1)
         let patchBumped = [major, minor, String(Int(patch)! + 1)].joined(separator: ".")
@@ -105,7 +112,7 @@ class CommonAppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionInRangeThenReturnMatch() throws {
-        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = versionNumber.components(separatedBy: ".").map { $0 }
         let (major, minor, patch) = (appVersionComponents[0], appVersionComponents[1], appVersionComponents[2])
         let majorBumped = String(Int(major)! + 1)
         let patchDecremented = [major, minor, String(Int(patch)! - 1)].joined(separator: ".")
@@ -115,7 +122,7 @@ class CommonAppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionNotInRangeThenReturnFail() throws {
-        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = versionNumber.components(separatedBy: ".").map { $0 }
         let appMajorVersion = appVersionComponents[0]
         let greaterThanMax = String(Int(appMajorVersion)! + 1)
 
@@ -124,17 +131,21 @@ class CommonAppAttributeMatcherTests: XCTestCase {
     }
 
     func testWhenAppVersionSameAsDeviceThenReturnMatch() throws {
-        XCTAssertEqual(matcher.evaluate(matchingAttribute: AppVersionMatchingAttribute(min: AppVersion.shared.versionAndBuildNumber, max: AppVersion.shared.versionAndBuildNumber, fallback: nil)),
+        XCTAssertEqual(matcher.evaluate(matchingAttribute: AppVersionMatchingAttribute(min: versionNumber, max: versionNumber, fallback: nil)),
                        .match)
     }
 
     func testWhenAppVersionDifferentToDeviceThenReturnFail() throws {
-        let appVersionComponents = AppVersion.shared.versionAndBuildNumber.components(separatedBy: ".").map { $0 }
+        let appVersionComponents = versionNumber.components(separatedBy: ".").map { $0 }
         let (major, minor, patch) = (appVersionComponents[0], appVersionComponents[1], appVersionComponents[2])
         let patchDecremented = [major, minor, String(Int(patch)! - 1)].joined(separator: ".")
 
         XCTAssertEqual(matcher.evaluate(matchingAttribute: AppVersionMatchingAttribute(value: patchDecremented, fallback: nil)),
                        .fail)
+    }
+
+    func testWhenAppVersionDoesNotIncludeBuildNumberButVersionMatchesThenReturnMatch() {
+
     }
 
     func testWhenAtbMatchesThenReturnMatch() throws {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1207619243206445/1208908529122506/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3686
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3635
What kind of version bump will this require?: Patch

**Description**:

This PR updates the RMF version matching logic to ignore build number. Previously, when you tried to match a version like `1.110.0`, it would fail because you needed to know the build number.

To fix this, this PR makes the following changes:
1. Update the version number fetching logic to use `versionNumber`, not `versionAndBuildNumber`
2. To avoid breaking messages that are using build number, the attributes that match version number ranges have been updated to trim the build number at init time (let's discuss that one in the comments though)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check that the test suite is green and correctly covers this new case
1. Launch one of the clients and verify that existing messages are parsed correctly - many of the existing production messages contain version checks so these can be used for testing as-is, but please ping me if you'd prefer a custom message written to facilitate easier testing

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
