### PR TITLE
Update autofill to 16.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "c992041d16ec10d790e6204dce9abf9966d1363c",
-        "version" : "15.1.0"
+        "revision" : "88982a3802ac504e2f1a118a73bfdf2d8f4a7735",
+        "version" : "16.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
         .library(name: "PrivacyStats", targets: ["PrivacyStats"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "15.1.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "16.0.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.2"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.3.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208923931185505/1208923931185505
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.0.0


## Description
Updates Autofill to version [16.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.0.0).

### Autofill 16.0.0 release notes
## What's Changed
This PR introduces breaking changes for Android/Windows causing save autofill prompt to get triggered in username only fields.
* Upgrade to shared eslint config + Adopt Prettier by @muodov in https://github.com/duckduckgo/duckduckgo-autofill/pull/695
* Ignore lint PR in git blame by @muodov in https://github.com/duckduckgo/duckduckgo-autofill/pull/699
* Update password-related json files (2024-11-18) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/706
* [Form] Always scan shadow elements when categorizing the form inputs by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/703
* Bump ts-to-zod from 3.1.3 to 3.14.0 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/710
* [FormAnalyzer] Fix paperlesspost.com login form by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/711
* [FormAnalyzer] Tweak regex to match forgot password attribute by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/712
* [Form] Trigger partialSave on username/email only form submit by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/702


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/15.1.0...16.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).