### PR TITLE
Add PrivacyStatsError.failedToClearPrivacyStats

### DIFF
--- a/Sources/PrivacyStats/PrivacyStats.swift
+++ b/Sources/PrivacyStats/PrivacyStats.swift
@@ -30,6 +30,7 @@ import TrackerRadarKit
 public enum PrivacyStatsError: CustomNSError {
     case failedToFetchPrivacyStatsSummary(Error)
     case failedToStorePrivacyStats(Error)
+    case failedToClearPrivacyStats(Error)
     case failedToLoadCurrentPrivacyStats(Error)
 
     public static let errorDomain: String = "PrivacyStatsError"
@@ -42,6 +43,8 @@ public enum PrivacyStatsError: CustomNSError {
             return 2
         case .failedToLoadCurrentPrivacyStats:
             return 3
+        case .failedToClearPrivacyStats:
+            return 4
         }
     }
 
@@ -49,7 +52,8 @@ public enum PrivacyStatsError: CustomNSError {
         switch self {
         case .failedToFetchPrivacyStatsSummary(let error),
                 .failedToStorePrivacyStats(let error),
-                .failedToLoadCurrentPrivacyStats(let error):
+                .failedToLoadCurrentPrivacyStats(let error),
+                .failedToClearPrivacyStats(let error):
             return error
         }
     }
@@ -165,7 +169,7 @@ public final class PrivacyStats: PrivacyStatsCollecting {
                     Logger.privacyStats.debug("Deleted outdated entries")
                 } catch {
                     Logger.privacyStats.error("Save error: \(error)")
-                    errorEvents?.fire(.failedToFetchPrivacyStatsSummary(error))
+                    errorEvents?.fire(.failedToClearPrivacyStats(error))
                 }
                 continuation.resume()
             }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201048563534612/1208936504720914/f
iOS PR: N/A
macOS PR: N/A
What kind of version bump will this require?: Patch

**Description**:
This change fixes PrivacyStats error reporting to include a dedicated error case for indicating failure to clear stats.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Verify that CI is green.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
