### PR TITLE
Add 'locale' to report broken site params

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -184,11 +184,6 @@ public enum DuckPlayerSubfeature: String, PrivacySubfeature {
     case enableDuckPlayer // iOS DuckPlayer rollout feature
 }
 
-public enum MaliciousSiteProtectionSubfeature: String, PrivacySubfeature {
-    public var parent: PrivacyFeature { .maliciousSiteProtection }
-    case allowErrorPage
-}
-
 public enum SyncPromotionSubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature { .syncPromotion }
     case bookmarks

--- a/Sources/PrivacyDashboard/PrivacyDashboardUserScript.swift
+++ b/Sources/PrivacyDashboard/PrivacyDashboardUserScript.swift
@@ -363,6 +363,7 @@ final class PrivacyDashboardUserScript: NSObject, StaticUserScript {
                              {"id": "jsPerformance"},
                              {"id": "openerContext"},
                              {"id": "userRefreshCount"},
+                             {"id": "locale"},
                          ]
                      }
                      window.onGetToggleReportOptionsResponse(json);


### PR DESCRIPTION
**Required**:

Task/Issue URL:  https://app.asana.com/0/414709148257752/1208827075841585/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3717
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3661
What kind of version bump will this require?: Major

**Description**:
Add the "locale" param ID to the list of properties submitted in the Privacy Dashboard site breakage form.

**Steps to test this PR**:
See respective platform PRs.


**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
