### PR TITLE
Add force old app delegate flag

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -65,6 +65,7 @@ public enum PrivacyFeature: String {
     case textZoom
     case adAttributionReporting
     case experimentTest
+    case forceOldAppDelegate
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1208832732122403/f
iOS PR: [n/a](https://github.com/duckduckgo/iOS/pull/3727)
macOS PR: n/a 
What kind of version bump will this require?: Major

**Description**:
Simple privacy config flag that will allow us to use old app delegate in case of any issues.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
