### PR TITLE
Privacy Pro Free Trials Core Implementation

### DIFF
--- a/Sources/BrowserServicesKit/FeatureFlagger/ExperimentCohortsManager.swift
+++ b/Sources/BrowserServicesKit/FeatureFlagger/ExperimentCohortsManager.swift
@@ -33,6 +33,12 @@ public struct ExperimentData: Codable, Equatable {
     public let parentID: ParentFeatureID
     public let cohortID: CohortID
     public let enrollmentDate: Date
+
+    public init(parentID: ParentFeatureID, cohortID: CohortID, enrollmentDate: Date) {
+        self.parentID = parentID
+        self.cohortID = cohortID
+        self.enrollmentDate = enrollmentDate
+    }
 }
 
 public protocol ExperimentCohortsManaging {

--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -164,7 +164,7 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case allowPurchaseStripe
     case useUnifiedFeedback
     case setAccessTokenCookieForSubscriptionDomains
-    case freeTrials
+    case privacyProFreeTrialJan25
 }
 
 public enum SslCertificatesSubfeature: String, PrivacySubfeature {

--- a/Sources/Subscription/API/SubscriptionEndpointService.swift
+++ b/Sources/Subscription/API/SubscriptionEndpointService.swift
@@ -53,7 +53,22 @@ public protocol SubscriptionEndpointService {
     func getProducts() async -> Result<[GetProductsItem], APIServiceError>
     func getSubscriptionFeatures(for subscriptionID: String) async -> Result<GetSubscriptionFeaturesResponse, APIServiceError>
     func getCustomerPortalURL(accessToken: String, externalID: String) async -> Result<GetCustomerPortalURLResponse, APIServiceError>
-    func confirmPurchase(accessToken: String, signature: String) async -> Result<ConfirmPurchaseResponse, APIServiceError>
+
+    /// Confirms a subscription purchase by validating the provided access token and signature with the backend service.
+    ///
+    /// This method sends the necessary data to the server to confirm the purchase,
+    /// and optionally includes additional parameters for customization.
+    ///
+    /// - Parameters:
+    ///   - accessToken: A string representing the user's access token, used for authentication.
+    ///   - signature: A string representing the purchase signature.
+    ///   - additionalParams: An optional dictionary of additional parameters to include in the request.
+    /// - Returns: A `Result` containing either a `ConfirmPurchaseResponse` object on success or an `APIServiceError` on failure.
+    func confirmPurchase(
+        accessToken: String,
+        signature: String,
+        additionalParams: [String: String]?
+    ) async -> Result<ConfirmPurchaseResponse, APIServiceError>
 }
 
 extension SubscriptionEndpointService {
@@ -153,11 +168,13 @@ public struct DefaultSubscriptionEndpointService: SubscriptionEndpointService {
 
     // MARK: -
 
-    public func confirmPurchase(accessToken: String, signature: String) async -> Result<ConfirmPurchaseResponse, APIServiceError> {
+    public func confirmPurchase(accessToken: String, signature: String, additionalParams: [String: String]?) async -> Result<ConfirmPurchaseResponse, APIServiceError> {
         let headers = apiService.makeAuthorizationHeader(for: accessToken)
         let bodyDict = ["signedTransactionInfo": signature]
 
-        guard let bodyData = try? JSONEncoder().encode(bodyDict) else { return .failure(.encodingError) }
+        let finalBodyDict = bodyDict.merging(additionalParams ?? [:]) { (existing, _) in existing }
+
+        guard let bodyData = try? JSONEncoder().encode(finalBodyDict) else { return .failure(.encodingError) }
         return await apiService.executeAPICall(method: "POST", endpoint: "purchase/confirm/apple", headers: headers, body: bodyData)
     }
 }

--- a/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -35,7 +35,7 @@ public enum AppStorePurchaseFlowError: Swift.Error {
 public protocol AppStorePurchaseFlow {
     typealias TransactionJWS = String
     func purchaseSubscription(with subscriptionIdentifier: String, emailAccessToken: String?) async -> Result<AppStorePurchaseFlow.TransactionJWS, AppStorePurchaseFlowError>
-    
+
     /// Completes the subscription purchase by validating the transaction.
       ///
       /// - Parameters:

--- a/Sources/Subscription/Flows/Models/SubscriptionOptions.swift
+++ b/Sources/Subscription/Flows/Models/SubscriptionOptions.swift
@@ -77,7 +77,6 @@ public struct SubscriptionOptionOffer: Encodable, Equatable {
 
     let type: OfferType
     let id: String
-    let displayPrice: String
-    let durationInDays: Int
+    let durationInDays: Int?
     let isUserEligible: Bool
 }

--- a/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
+++ b/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
@@ -356,7 +356,7 @@ private extension SubscriptionOption {
             let durationInDays = introOffer.periodInDays
             let isUserEligible = await product.isEligibleForIntroOffer
 
-            offer = .init(type: .freeTrial, id: introOffer.id ?? "", displayPrice: introOffer.displayPrice, durationInDays: durationInDays, isUserEligible: isUserEligible)
+            offer = .init(type: .freeTrial, id: introOffer.id ?? "", durationInDays: durationInDays, isUserEligible: isUserEligible)
         }
 
         self.init(id: product.id, cost: .init(displayPrice: product.displayPrice, recurrence: recurrence), offer: offer)

--- a/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
+++ b/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
@@ -117,12 +117,16 @@ public final class DefaultStorePurchaseManager: ObservableObject, StorePurchaseM
     }
 
     public func subscriptionOptions() async -> SubscriptionOptions? {
-        let nonFreeTrialProducts = availableProducts.filter { !$0.hasFreeTrialOffer }
+        let nonFreeTrialProducts = availableProducts.filter { !$0.isFreeTrialProduct }
+        let ids = nonFreeTrialProducts.map(\.self.id)
+        Logger.subscription.debug("[StorePurchaseManager] Returning SubscriptionOptions for products: \(ids)")
         return await subscriptionOptions(for: nonFreeTrialProducts)
     }
 
     public func freeTrialSubscriptionOptions() async -> SubscriptionOptions? {
-        let freeTrialProducts = availableProducts.filter { $0.hasFreeTrialOffer }
+        let freeTrialProducts = availableProducts.filter { $0.isFreeTrialProduct }
+        let ids = freeTrialProducts.map(\.self.id)
+        Logger.subscription.debug("[StorePurchaseManager] Returning Free Trial SubscriptionOptions for products: \(ids)")
         return await subscriptionOptions(for: freeTrialProducts)
     }
 

--- a/Sources/Subscription/Managers/StorePurchaseManager/SubscriptionProduct.swift
+++ b/Sources/Subscription/Managers/StorePurchaseManager/SubscriptionProduct.swift
@@ -84,10 +84,10 @@ extension Product: SubscriptionProduct {
     /// A Boolean value that indicates whether the subscription product is one which relates to a Free Trial.
     ///
     /// This property returns `true` if the subscription has an associated introductory offer marked as a free trial
-    /// or if the subscription's identifier contains the designated free trial suffix.
+    /// or if the subscription's identifier contains the designated free trial identifer.
     /// If neither condition is met, the property returns `false`.
     public var isFreeTrialProduct: Bool {
-        return subscription?.introductoryOffer?.isFreeTrial ?? false || id.contains(StoreSubscriptionConstants.freeTrialSuffix)
+        return subscription?.introductoryOffer?.isFreeTrial ?? false || id.contains(StoreSubscriptionConstants.freeTrialIdentifer)
     }
 
     /// Asynchronously checks if the user is eligible for an introductory offer.

--- a/Sources/Subscription/Managers/StorePurchaseManager/SubscriptionProduct.swift
+++ b/Sources/Subscription/Managers/StorePurchaseManager/SubscriptionProduct.swift
@@ -44,8 +44,8 @@ public protocol SubscriptionProduct: Equatable {
     /// The introductory offer associated with this subscription, if any.
     var introductoryOffer: SubscriptionProductIntroductoryOffer? { get }
 
-    /// Indicates whether this subscription has a Free Trial offer available.
-    var hasFreeTrialOffer: Bool { get }
+    /// A Boolean value that indicates whether the subscription product is one which relates to a Free Trial.
+    var isFreeTrialProduct: Bool { get }
 
     /// Asynchronously determines whether the user is eligible for an introductory offer.
     var isEligibleForIntroOffer: Bool { get async }
@@ -81,9 +81,13 @@ extension Product: SubscriptionProduct {
         subscription?.introductoryOffer
     }
 
-    /// Indicates whether this subscription has a Free Trial offer.
-    public var hasFreeTrialOffer: Bool {
-        return subscription?.introductoryOffer?.isFreeTrial ?? false
+    /// A Boolean value that indicates whether the subscription product is one which relates to a Free Trial.
+    ///
+    /// This property returns `true` if the subscription has an associated introductory offer marked as a free trial
+    /// or if the subscription's identifier contains the designated free trial suffix.
+    /// If neither condition is met, the property returns `false`.
+    public var isFreeTrialProduct: Bool {
+        return subscription?.introductoryOffer?.isFreeTrial ?? false || id.contains(StoreSubscriptionConstants.freeTrialSuffix)
     }
 
     /// Asynchronously checks if the user is eligible for an introductory offer.

--- a/Sources/Subscription/StoreSubscriptionConfiguration.swift
+++ b/Sources/Subscription/StoreSubscriptionConfiguration.swift
@@ -21,8 +21,8 @@ import Combine
 
 /// Constants relating to `StoreSubscriptionConfiguration`
 enum StoreSubscriptionConstants {
-    /// The suffix appended to subscription identifiers to indicate that the subscription includes a free trial.
-    static let freeTrialSuffix = ".freetrial"
+    /// The Free Trial identifer included as part of a Subscription identifier, used to indicate that the subscription includes a free trial.
+    static let freeTrialIdentifer = "freetrial"
 }
 
 protocol StoreSubscriptionConfiguration {
@@ -43,8 +43,8 @@ final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguratio
                   environment: .production,
                   identifiersByRegion: [.usa: ["ddg.privacy.pro.monthly.renews.us",
                                                "ddg.privacy.pro.yearly.renews.us",
-                                               "ddg.privacy.pro.monthly.renews.us\(StoreSubscriptionConstants.freeTrialSuffix)",
-                                               "ddg.privacy.pro.yearly.renews.us\(StoreSubscriptionConstants.freeTrialSuffix)"],
+                                               "ddg.privacy.pro.monthly.renews.us.\(StoreSubscriptionConstants.freeTrialIdentifer)",
+                                               "ddg.privacy.pro.yearly.renews.us.\(StoreSubscriptionConstants.freeTrialIdentifer)"],
                                         .restOfWorld: ["ddg.privacy.pro.monthly.renews.row",
                                                        "ddg.privacy.pro.yearly.renews.row"]]),
             // iOS debug Alpha build
@@ -53,8 +53,8 @@ final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguratio
                   environment: .staging,
                   identifiersByRegion: [.usa: ["ios.subscription.1month",
                                                "ios.subscription.1year",
-                                               "ios.subscription.1month\(StoreSubscriptionConstants.freeTrialSuffix).dev",
-                                               "ios.subscription.1year\(StoreSubscriptionConstants.freeTrialSuffix).dev"],
+                                               "ios.subscription.1month.\(StoreSubscriptionConstants.freeTrialIdentifer).dev",
+                                               "ios.subscription.1year.\(StoreSubscriptionConstants.freeTrialIdentifer).dev"],
                                         .restOfWorld: ["ios.subscription.1month.row",
                                                        "ios.subscription.1year.row"]]),
             // macOS debug build

--- a/Sources/Subscription/StoreSubscriptionConfiguration.swift
+++ b/Sources/Subscription/StoreSubscriptionConfiguration.swift
@@ -19,6 +19,12 @@
 import Foundation
 import Combine
 
+/// Constants relating to `StoreSubscriptionConfiguration`
+enum StoreSubscriptionConstants {
+    /// The suffix appended to subscription identifiers to indicate that the subscription includes a free trial.
+    static let freeTrialSuffix = ".freetrial"
+}
+
 protocol StoreSubscriptionConfiguration {
     var allSubscriptionIdentifiers: [String] { get }
     func subscriptionIdentifiers(for country: String) -> [String]
@@ -36,7 +42,9 @@ final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguratio
                   appIdentifier: "com.duckduckgo.mobile.ios",
                   environment: .production,
                   identifiersByRegion: [.usa: ["ddg.privacy.pro.monthly.renews.us",
-                                               "ddg.privacy.pro.yearly.renews.us"],
+                                               "ddg.privacy.pro.yearly.renews.us",
+                                               "ddg.privacy.pro.monthly.renews.us\(StoreSubscriptionConstants.freeTrialSuffix)",
+                                               "ddg.privacy.pro.yearly.renews.us\(StoreSubscriptionConstants.freeTrialSuffix)"],
                                         .restOfWorld: ["ddg.privacy.pro.monthly.renews.row",
                                                        "ddg.privacy.pro.yearly.renews.row"]]),
             // iOS debug Alpha build
@@ -45,8 +53,8 @@ final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguratio
                   environment: .staging,
                   identifiersByRegion: [.usa: ["ios.subscription.1month",
                                                "ios.subscription.1year",
-                                               "ios.subscription.1month.freetrial.dev",
-                                               "ios.subscription.1year.freetrial.dev"],
+                                               "ios.subscription.1month\(StoreSubscriptionConstants.freeTrialSuffix).dev",
+                                               "ios.subscription.1year\(StoreSubscriptionConstants.freeTrialSuffix).dev"],
                                         .restOfWorld: ["ios.subscription.1month.row",
                                                        "ios.subscription.1year.row"]]),
             // macOS debug build

--- a/Sources/SubscriptionTestingUtilities/APIs/SubscriptionEndpointServiceMock.swift
+++ b/Sources/SubscriptionTestingUtilities/APIs/SubscriptionEndpointServiceMock.swift
@@ -27,6 +27,7 @@ public final class SubscriptionEndpointServiceMock: SubscriptionEndpointService 
     public var confirmPurchaseResult: Result<ConfirmPurchaseResponse, APIServiceError>?
 
     public var onUpdateCache: ((Subscription) -> Void)?
+    public var onConfirmPurchase: ((String, String, [String: String]?) -> Void)?
     public var onGetSubscription: ((String, APICachePolicy) -> Void)?
     public var onSignOut: (() -> Void)?
 
@@ -64,7 +65,8 @@ public final class SubscriptionEndpointServiceMock: SubscriptionEndpointService 
         getCustomerPortalURLResult!
     }
 
-    public func confirmPurchase(accessToken: String, signature: String) async -> Result<ConfirmPurchaseResponse, APIServiceError> {
-        confirmPurchaseResult!
+    public func confirmPurchase(accessToken: String, signature: String, additionalParams: [String: String]?) async -> Result<ConfirmPurchaseResponse, APIServiceError> {
+        onConfirmPurchase?(accessToken, signature, additionalParams)
+        return confirmPurchaseResult!
     }
 }

--- a/Sources/SubscriptionTestingUtilities/Flows/AppStorePurchaseFlowMock.swift
+++ b/Sources/SubscriptionTestingUtilities/Flows/AppStorePurchaseFlowMock.swift
@@ -29,7 +29,7 @@ public final class AppStorePurchaseFlowMock: AppStorePurchaseFlow {
         purchaseSubscriptionResult!
     }
 
-    public func completeSubscriptionPurchase(with transactionJWS: TransactionJWS) async -> Result<PurchaseUpdate, AppStorePurchaseFlowError> {
+    public func completeSubscriptionPurchase(with transactionJWS: TransactionJWS, additionalParams: [String: String]?) async -> Result<PurchaseUpdate, AppStorePurchaseFlowError> {
         completeSubscriptionPurchaseResult!
     }
 }

--- a/Tests/SubscriptionTests/API/SubscriptionEndpointServiceTests.swift
+++ b/Tests/SubscriptionTests/API/SubscriptionEndpointServiceTests.swift
@@ -285,13 +285,19 @@ final class SubscriptionEndpointServiceTests: XCTestCase {
 
             if let bodyDict = try? JSONDecoder().decode([String: String].self, from: body!) {
                 XCTAssertEqual(bodyDict["signedTransactionInfo"], Constants.mostRecentTransactionJWS)
+                XCTAssertEqual(bodyDict["extraParamKey"], "extraParamValue")
             } else {
                 XCTFail("Failed to decode body")
             }
         }
 
         // When
-        _ = await subscriptionService.confirmPurchase(accessToken: Constants.accessToken, signature: Constants.mostRecentTransactionJWS)
+        let additionalParams = ["extraParamKey": "extraParamValue"]
+        _ = await subscriptionService.confirmPurchase(
+            accessToken: Constants.accessToken,
+            signature: Constants.mostRecentTransactionJWS,
+            additionalParams: additionalParams
+        )
 
         // Then
         await fulfillment(of: [apiServiceCalledExpectation], timeout: 0.1)
@@ -323,7 +329,7 @@ final class SubscriptionEndpointServiceTests: XCTestCase {
         """.data(using: .utf8)!
 
         // When
-        let result = await subscriptionService.confirmPurchase(accessToken: Constants.accessToken, signature: Constants.mostRecentTransactionJWS)
+        let result = await subscriptionService.confirmPurchase(accessToken: Constants.accessToken, signature: Constants.mostRecentTransactionJWS, additionalParams: nil)
 
         // Then
         switch result {
@@ -345,13 +351,78 @@ final class SubscriptionEndpointServiceTests: XCTestCase {
         }
     }
 
+    func testConfirmPurchaseWithAdditionalParams() async throws {
+        // Given
+        let apiServiceCalledExpectation = expectation(description: "apiService")
+
+        apiService.mockAuthHeaders = Constants.authorizationHeader
+        apiService.onExecuteAPICall = { parameters in
+            let (_, _, _, body) = parameters
+
+            apiServiceCalledExpectation.fulfill()
+            if let bodyDict = try? JSONDecoder().decode([String: String].self, from: body!) {
+                XCTAssertEqual(bodyDict["signedTransactionInfo"], Constants.mostRecentTransactionJWS)
+                XCTAssertEqual(bodyDict["extraParamKey1"], "extraValue1")
+                XCTAssertEqual(bodyDict["extraParamKey2"], "extraValue2")
+            } else {
+                XCTFail("Failed to decode body")
+            }
+        }
+
+        // When
+        let additionalParams = [
+            "extraParamKey1": "extraValue1",
+            "extraParamKey2": "extraValue2"
+        ]
+        _ = await subscriptionService.confirmPurchase(
+            accessToken: Constants.accessToken,
+            signature: Constants.mostRecentTransactionJWS,
+            additionalParams: additionalParams
+        )
+
+        // Then
+        await fulfillment(of: [apiServiceCalledExpectation], timeout: 0.1)
+    }
+
+    func testConfirmPurchaseWithConflictingKeys() async throws {
+        // Given
+        let apiServiceCalledExpectation = expectation(description: "apiService")
+
+        apiService.mockAuthHeaders = Constants.authorizationHeader
+        apiService.onExecuteAPICall = { parameters in
+            let (_, _, _, body) = parameters
+
+            apiServiceCalledExpectation.fulfill()
+            if let bodyDict = try? JSONDecoder().decode([String: String].self, from: body!) {
+                XCTAssertEqual(bodyDict["signedTransactionInfo"], Constants.mostRecentTransactionJWS)
+                XCTAssertEqual(bodyDict["extraParamKey"], "extraValue")
+            } else {
+                XCTFail("Failed to decode body")
+            }
+        }
+
+        // When
+        let additionalParams = [
+            "signedTransactionInfo": "overriddenValue",
+            "extraParamKey": "extraValue"
+        ]
+        _ = await subscriptionService.confirmPurchase(
+            accessToken: Constants.accessToken,
+            signature: Constants.mostRecentTransactionJWS,
+            additionalParams: additionalParams
+        )
+
+        // Then
+        await fulfillment(of: [apiServiceCalledExpectation], timeout: 0.1)
+    }
+
     func testConfirmPurchaseError() async throws {
         // Given
         apiService.mockAuthHeaders = Constants.authorizationHeader
         apiService.mockAPICallError = Constants.unknownServerError
 
         // When
-        let result = await subscriptionService.confirmPurchase(accessToken: Constants.accessToken, signature: Constants.mostRecentTransactionJWS)
+        let result = await subscriptionService.confirmPurchase(accessToken: Constants.accessToken, signature: Constants.mostRecentTransactionJWS, additionalParams: nil)
 
         // Then
         switch result {

--- a/Tests/SubscriptionTests/Flows/AppStorePurchaseFlowTests.swift
+++ b/Tests/SubscriptionTests/Flows/AppStorePurchaseFlowTests.swift
@@ -241,16 +241,67 @@ final class AppStorePurchaseFlowTests: XCTestCase {
     func testCompleteSubscriptionPurchaseSuccess() async throws {
         // Given
         accountManager.accessToken = Constants.accessToken
-        subscriptionService.confirmPurchaseResult = .success(ConfirmPurchaseResponse(email: nil,
-                                                                                     entitlements: [],
-                                                                                     subscription: SubscriptionMockFactory.subscription))
+        subscriptionService.confirmPurchaseResult = .success(
+            ConfirmPurchaseResponse(
+                email: nil,
+                entitlements: [],
+                subscription: SubscriptionMockFactory.subscription
+            )
+        )
+
+        let expectedAdditionalParams = ["key1": "value1", "key2": "value2"]
+
+        subscriptionService.onConfirmPurchase = { accessToken, signature, additionalParams in
+            XCTAssertEqual(accessToken, Constants.accessToken)
+            XCTAssertEqual(signature, Constants.transactionJWS)
+            XCTAssertEqual(additionalParams, expectedAdditionalParams)
+        }
 
         subscriptionService.onUpdateCache = { subscription in
             XCTAssertEqual(subscription, SubscriptionMockFactory.subscription)
         }
 
         // When
-        switch await appStorePurchaseFlow.completeSubscriptionPurchase(with: Constants.transactionJWS) {
+        switch await appStorePurchaseFlow.completeSubscriptionPurchase(
+            with: Constants.transactionJWS,
+            additionalParams: expectedAdditionalParams
+        ) {
+        case .success(let success):
+            // Then
+            XCTAssertTrue(subscriptionService.updateCacheWithSubscriptionCalled)
+            XCTAssertTrue(accountManager.updateCacheWithEntitlementsCalled)
+            XCTAssertEqual(success.type, "completed")
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(String(reflecting: error))")
+        }
+    }
+
+    func testCompleteSubscriptionPurchaseWithNilAdditionalParams() async throws {
+        // Given
+        accountManager.accessToken = Constants.accessToken
+        subscriptionService.confirmPurchaseResult = .success(
+            ConfirmPurchaseResponse(
+                email: nil,
+                entitlements: [],
+                subscription: SubscriptionMockFactory.subscription
+            )
+        )
+
+        subscriptionService.onConfirmPurchase = { accessToken, signature, additionalParams in
+            XCTAssertEqual(accessToken, Constants.accessToken)
+            XCTAssertEqual(signature, Constants.transactionJWS)
+            XCTAssertNil(additionalParams)
+        }
+
+        subscriptionService.onUpdateCache = { subscription in
+            XCTAssertEqual(subscription, SubscriptionMockFactory.subscription)
+        }
+
+        // When
+        switch await appStorePurchaseFlow.completeSubscriptionPurchase(
+            with: Constants.transactionJWS,
+            additionalParams: nil
+        ) {
         case .success(let success):
             // Then
             XCTAssertTrue(subscriptionService.updateCacheWithSubscriptionCalled)
@@ -266,7 +317,33 @@ final class AppStorePurchaseFlowTests: XCTestCase {
         XCTAssertNil(accountManager.accessToken)
 
         // When
-        switch await appStorePurchaseFlow.completeSubscriptionPurchase(with: Constants.transactionJWS) {
+        switch await appStorePurchaseFlow.completeSubscriptionPurchase(with: Constants.transactionJWS, additionalParams: nil) {
+        case .success:
+            XCTFail("Unexpected success")
+        case .failure(let error):
+            // Then
+            XCTAssertEqual(error, .missingEntitlements)
+        }
+    }
+
+    func testCompleteSubscriptionPurchaseErrorWithAdditionalParams() async throws {
+        // Given
+        accountManager.accessToken = Constants.accessToken
+        subscriptionService.confirmPurchaseResult = .failure(Constants.unknownServerError)
+
+        let additionalParams = ["key1": "value1"]
+
+        subscriptionService.onConfirmPurchase = { accessToken, signature, additionalParams in
+            XCTAssertEqual(accessToken, Constants.accessToken)
+            XCTAssertEqual(signature, Constants.transactionJWS)
+            XCTAssertEqual(additionalParams, additionalParams)
+        }
+
+        // When
+        switch await appStorePurchaseFlow.completeSubscriptionPurchase(
+            with: Constants.transactionJWS,
+            additionalParams: additionalParams
+        ) {
         case .success:
             XCTFail("Unexpected success")
         case .failure(let error):
@@ -281,7 +358,7 @@ final class AppStorePurchaseFlowTests: XCTestCase {
         subscriptionService.confirmPurchaseResult = .failure(Constants.unknownServerError)
 
         // When
-        switch await appStorePurchaseFlow.completeSubscriptionPurchase(with: Constants.transactionJWS) {
+        switch await appStorePurchaseFlow.completeSubscriptionPurchase(with: Constants.transactionJWS, additionalParams: nil) {
         case .success:
             XCTFail("Unexpected success")
         case .failure(let error):

--- a/Tests/SubscriptionTests/Flows/Models/SubscriptionOptionsTests.swift
+++ b/Tests/SubscriptionTests/Flows/Models/SubscriptionOptionsTests.swift
@@ -23,8 +23,8 @@ import SubscriptionTestingUtilities
 final class SubscriptionOptionsTests: XCTestCase {
 
     func testEncoding() throws {
-        let monthlySubscriptionOffer = SubscriptionOptionOffer(type: .freeTrial, id: "1", displayPrice: "$0.00", durationInDays: 7, isUserEligible: true)
-        let yearlySubscriptionOffer = SubscriptionOptionOffer(type: .freeTrial, id: "2", displayPrice: "$0.00", durationInDays: 7, isUserEligible: true)
+        let monthlySubscriptionOffer = SubscriptionOptionOffer(type: .freeTrial, id: "1", durationInDays: 7, isUserEligible: true)
+        let yearlySubscriptionOffer = SubscriptionOptionOffer(type: .freeTrial, id: "2", durationInDays: 7, isUserEligible: true)
         let subscriptionOptions = SubscriptionOptions(platform: .macos,
                                                       options: [
                                                         SubscriptionOption(id: "1",
@@ -64,7 +64,6 @@ final class SubscriptionOptionsTests: XCTestCase {
       },
       "id" : "1",
       "offer" : {
-        "displayPrice" : "$0.00",
         "durationInDays" : 7,
         "id" : "1",
         "isUserEligible" : true,
@@ -78,7 +77,6 @@ final class SubscriptionOptionsTests: XCTestCase {
       },
       "id" : "2",
       "offer" : {
-        "displayPrice" : "$0.00",
         "durationInDays" : 7,
         "id" : "2",
         "isUserEligible" : true,

--- a/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
+++ b/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
@@ -44,7 +44,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Monthly Plan",
             displayPrice: "$9.99",
             isMonthly: true,
-            hasFreeTrialOffer: false
+            isFreeTrialProduct: false
         )
 
         let yearlyProduct = MockSubscriptionProduct(
@@ -52,7 +52,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Yearly Plan",
             displayPrice: "$99.99",
             isYearly: true,
-            hasFreeTrialOffer: false
+            isFreeTrialProduct: false
         )
 
         let monthlyTrialProduct = MockSubscriptionProduct(
@@ -60,7 +60,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Monthly Plan with Trial",
             displayPrice: "$9.99",
             isMonthly: true,
-            hasFreeTrialOffer: true,
+            isFreeTrialProduct: true,
             introOffer: MockIntroductoryOffer(
                 id: "trial1",
                 displayPrice: "Free",
@@ -92,7 +92,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Monthly Plan with Trial",
             displayPrice: "$9.99",
             isMonthly: true,
-            hasFreeTrialOffer: true,
+            isFreeTrialProduct: true,
             introOffer: MockIntroductoryOffer(
                 id: "trial1",
                 displayPrice: "Free",
@@ -107,7 +107,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Yearly Plan with Trial",
             displayPrice: "$99.99",
             isYearly: true,
-            hasFreeTrialOffer: true,
+            isFreeTrialProduct: true,
             introOffer: MockIntroductoryOffer(
                 id: "trial2",
                 displayPrice: "Free",
@@ -122,7 +122,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Regular Plan",
             displayPrice: "$9.99",
             isMonthly: true,
-            hasFreeTrialOffer: false
+            isFreeTrialProduct: false
         )
 
         mockProductFetcher.mockProducts = [monthlyTrialProduct, yearlyTrialProduct, regularProduct]
@@ -148,7 +148,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Monthly Plan",
             displayPrice: "$9.99",
             isMonthly: true,
-            hasFreeTrialOffer: false
+            isFreeTrialProduct: false
         )
 
         mockProductFetcher.mockProducts = [monthlyProduct]
@@ -168,7 +168,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Monthly Plan with Trial",
             displayPrice: "$9.99",
             isMonthly: true,
-            hasFreeTrialOffer: true,
+            isFreeTrialProduct: true,
             introOffer: MockIntroductoryOffer(
                 id: "trial1",
                 displayPrice: "Free",
@@ -194,7 +194,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Monthly Plan",
             displayPrice: "$9.99",
             isMonthly: true,
-            hasFreeTrialOffer: false
+            isFreeTrialProduct: false
         )
 
         let yearlyProduct = MockSubscriptionProduct(
@@ -202,7 +202,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Yearly Plan",
             displayPrice: "$99.99",
             isYearly: true,
-            hasFreeTrialOffer: false
+            isFreeTrialProduct: false
         )
 
         mockProductFetcher.mockProducts = [monthlyProduct, yearlyProduct]
@@ -235,7 +235,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Monthly Plan with Trial",
             displayPrice: "$9.99",
             isMonthly: true,
-            hasFreeTrialOffer: true,
+            isFreeTrialProduct: true,
             introOffer: MockIntroductoryOffer(
                 id: "trial1",
                 displayPrice: "$0.00",
@@ -250,7 +250,7 @@ final class StorePurchaseManagerTests: XCTestCase {
             displayName: "Yearly Plan with Trial",
             displayPrice: "$99.99",
             isYearly: true,
-            hasFreeTrialOffer: true,
+            isFreeTrialProduct: true,
             introOffer: MockIntroductoryOffer(
                 id: "trial2",
                 displayPrice: "$0.00",
@@ -413,7 +413,7 @@ private extension StorePurchaseManagerTests {
             displayName: "Monthly Plan\(withTrial ? " with Trial" : "")",
             displayPrice: "$9.99",
             isMonthly: true,
-            hasFreeTrialOffer: withTrial,
+            isFreeTrialProduct: withTrial,
             introOffer: withTrial ? MockIntroductoryOffer(
                 id: "trial1",
                 displayPrice: "Free",
@@ -430,7 +430,7 @@ private extension StorePurchaseManagerTests {
             displayName: "Yearly Plan\(withTrial ? " with Trial" : "")",
             displayPrice: "$99.99",
             isYearly: true,
-            hasFreeTrialOffer: withTrial,
+            isFreeTrialProduct: withTrial,
             introOffer: withTrial ? MockIntroductoryOffer(
                 id: "trial2",
                 displayPrice: "Free",
@@ -449,7 +449,7 @@ private class MockSubscriptionProduct: SubscriptionProduct {
     let description: String
     let isMonthly: Bool
     let isYearly: Bool
-    let hasFreeTrialOffer: Bool
+    let isFreeTrialProduct: Bool
     private let mockIntroOffer: MockIntroductoryOffer?
     private let mockIsEligibleForIntroOffer: Bool
 
@@ -459,7 +459,7 @@ private class MockSubscriptionProduct: SubscriptionProduct {
          description: String = "Mock Description",
          isMonthly: Bool = false,
          isYearly: Bool = false,
-         hasFreeTrialOffer: Bool = false,
+         isFreeTrialProduct: Bool = false,
          introOffer: MockIntroductoryOffer? = nil,
          isEligibleForIntroOffer: Bool = false) {
         self.id = id
@@ -468,7 +468,7 @@ private class MockSubscriptionProduct: SubscriptionProduct {
         self.description = description
         self.isMonthly = isMonthly
         self.isYearly = isYearly
-        self.hasFreeTrialOffer = hasFreeTrialOffer
+        self.isFreeTrialProduct = isFreeTrialProduct
         self.mockIntroOffer = introOffer
         self.mockIsEligibleForIntroOffer = isEligibleForIntroOffer
     }

--- a/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
+++ b/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
@@ -273,7 +273,6 @@ final class StorePurchaseManagerTests: XCTestCase {
         XCTAssertNotNil(monthlyOption)
         XCTAssertNotNil(monthlyOption?.offer)
         XCTAssertEqual(monthlyOption?.offer?.type, .freeTrial)
-        XCTAssertEqual(monthlyOption?.offer?.displayPrice, "$0.00")
         XCTAssertEqual(monthlyOption?.offer?.durationInDays, 7)
         XCTAssertTrue(monthlyOption?.offer?.isUserEligible ?? false)
 
@@ -281,7 +280,6 @@ final class StorePurchaseManagerTests: XCTestCase {
         XCTAssertNotNil(yearlyOption)
         XCTAssertNotNil(yearlyOption?.offer)
         XCTAssertEqual(yearlyOption?.offer?.type, .freeTrial)
-        XCTAssertEqual(yearlyOption?.offer?.displayPrice, "$0.00")
         XCTAssertEqual(yearlyOption?.offer?.durationInDays, 14)
         XCTAssertTrue(yearlyOption?.offer?.isUserEligible ?? false)
     }


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1208767141940868/f
iOS PR: [Privacy Pro Free Trials Core Implementation](https://github.com/duckduckgo/iOS/pull/3760)
macOS PR: [Privacy Pro Free Trials Core Implementation (BSK Bump Only, No macOS Impacts)](https://github.com/duckduckgo/macos-browser/pull/3693)
What kind of version bump will this require?: **Minor**
Tech Design URL: https://app.asana.com/0/1206488453854252/1208916720468103/f

**Description**: This PR adds additional changes to support Privacy Pro Free Trials on iOS, specifically:
1. Update Subscription completion/confirm API to enable passing of additional params to the `/confirm` backend API
2. Updates the Subscription offer model
3. Adds Production Free Trial products and logic to filter Free Trial products based on offer availability AND product ID (this is needed as a product might be intended for Free Trial, but might not have an offer due to it expiring, e.g outside it's availability dates)
4. Minor additional changes

**Steps to test this PR**:
1. Green CI
5. See test steps on linked iOS PR

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
