### PR TITLE
Update AutofillCredentialIdentityStoreManager to allow vault to be initialised lazily

### DIFF
--- a/Tests/BrowserServicesKitTests/SecureVault/AutofillCredentialIdentityStoreManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/AutofillCredentialIdentityStoreManagerTests.swift
@@ -44,7 +44,7 @@ final class AutofillCredentialIdentityStoreManagerTests: XCTestCase {
         mockVault = DefaultAutofillSecureVault(providers: providers)
 
         tld = TLD()
-        manager = AutofillCredentialIdentityStoreManager(credentialStore: mockStore, vault: mockVault, tld: tld)
+        manager = AutofillCredentialIdentityStoreManager(credentialStore: mockStore, vault: mockVault, reporter: MockSecureVaultReporting(), tld: tld)
     }
 
     override func tearDown() {
@@ -204,4 +204,8 @@ final class AutofillCredentialIdentityStoreManagerTests: XCTestCase {
         return SecureVaultModels.WebsiteAccount(id: id, username: username, domain: domain, signature: signature, created: created, lastUpdated: lastUpdated, lastUsed: lastUsed)
     }
 
+}
+
+private class MockSecureVaultReporting: SecureVaultReporting {
+    func secureVaultError(_ error: SecureStorage.SecureStorageError) {}
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/414709148257752/1209045090157949/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3763
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3702
What kind of version bump will this require?: Minor

**Description**:
Update to vault initialization in AutofillCredentialIdentityStoreManager to only init on demand

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. See client PRs

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
