### PR TITLE
Do not base cache expiry on subscription expiry date

### DIFF
--- a/Sources/Subscription/API/SubscriptionEndpointService.swift
+++ b/Sources/Subscription/API/SubscriptionEndpointService.swift
@@ -100,10 +100,7 @@ public struct DefaultSubscriptionEndpointService: SubscriptionEndpointService {
 
         let cachedSubscription: Subscription? = subscriptionCache.get()
         if subscription != cachedSubscription {
-            let defaultExpiryDate = Date().addingTimeInterval(subscriptionCache.settings.defaultExpirationInterval)
-            let expiryDate = min(defaultExpiryDate, subscription.expiresOrRenewsAt)
-
-            subscriptionCache.set(subscription, expires: expiryDate)
+            subscriptionCache.set(subscription)
             NotificationCenter.default.post(name: .subscriptionDidChange, object: self, userInfo: [UserDefaultsCacheKey.subscription: subscription])
         }
     }


### PR DESCRIPTION

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1201037661562251/1209111606760738/f
iOS PR: /will follow in internal build - not impacted/
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3714
What kind of version bump will this require?: Hotfix

**Optional**:

CC: @federicocappelli 

**Description**:
In specific conditions we may cause an endless loop of remote API calls to fetch the subscription.

**Steps to test this PR**:
(macOS only)
1. Have an expired subscription in the app
2. Ensure that `isLaunchedROW` or `isLaunchedROWOverride` feature flag is enabled in privacy config.
3. Open Settings tab
4. From sidebar open "Privacy Pro"
5. Check network calls: only a single remote call should be made to GET subscription from subscriptions BE endpoint

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:
* [ ] macOS

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
