### PR TITLE
Place open tab suggestions before history and bookmark suggestions

### DIFF
--- a/Sources/Suggestions/SuggestionProcessing.swift
+++ b/Sources/Suggestions/SuggestionProcessing.swift
@@ -223,7 +223,16 @@ final class SuggestionProcessing {
             // Filter not relevant
             .filter { $0.score > 0 }
             // Sort according to the score
-            .sorted { $0.score > $1.score }
+            .sorted {
+                switch ($0.item, $1.item) {
+                // place open tab suggestions on top
+                case (.openTab, .openTab): break
+                case (.openTab, _): return true
+                case (_, .openTab): return false
+                default: break
+                }
+                return $0.score > $1.score
+            }
             // Create suggestion array
             .compactMap {
                 switch $0.item {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/0/1209138127674910/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3800
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3660
What kind of version bump will this require?: Patch

**Description**:
- Fix suggestions ranking to prefer Open Tabs over matching history records or bookmarks

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
