### PR TITLE
add new privacy feature and sub feature for tab multi-selection

### DIFF
--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -67,6 +67,7 @@ public enum PrivacyFeature: String {
     case experimentTest
     case forceOldAppDelegate
     case htmlNewTabPage
+    case tabManager
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.
@@ -77,6 +78,14 @@ public protocol PrivacySubfeature: RawRepresentable where RawValue == String {
 }
 
 // MARK: Subfeature definitions
+
+public enum TabManagerSubfeature: String, PrivacySubfeature {
+    public var parent: PrivacyFeature {
+        .tabManager
+    }
+
+    case multiSelection
+}
 
 public enum AutofillSubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature {


### PR DESCRIPTION
**Required**:

Task/Issue URL: https://app.asana.com/0/392891325557410/1209149612843161/f
iOS PR:  n/a
macOS PR: n/a
What kind of version bump will this require?: minor

**Description**:
Adds feature and sub feature flag. 

Note: There will be no iOS/macOS update as it does not break the app. 

**Steps to test this PR**:
1. Drag into iOS and run the app
1. Drag into macOS and run the app
