### PR TITLE
Defaults internal Privacy Pro links to /subscriptions

### DIFF
--- a/Sources/Subscription/SubscriptionURL.swift
+++ b/Sources/Subscription/SubscriptionURL.swift
@@ -43,7 +43,7 @@ public enum SubscriptionURL {
                 URL(string: "https://duckduckgo.com/subscriptions?environment=staging")!
             }
         case .purchase:
-            SubscriptionURL.baseURL.subscriptionURL(environment: environment).appendingPathComponent("welcome")
+            SubscriptionURL.baseURL.subscriptionURL(environment: environment)
         case .faq:
             URL(string: "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/")!
         case .activateViaEmail:


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/72649045549333/1209009315184468/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3812
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3741
What kind of version bump will this require?: Patch

**Description**:
Previously, default Privacy Pro links were sent to `/subscriptions/welcome`, and the frontend redirected to `/subscriptions`.

Currently, this will still result in a redirect to `/subscriptions/welcome` for subscribed users—effectively a no-op. After an upcoming frontend release, this will show `/subscriptions` with a link to `/subscriptions/welcome`.

**Steps to test this PR**:
1. See Client PRs

**OS Testing**:

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
