### PR TITLE
Fire event on matches api request failure

### DIFF
--- a/Sources/MaliciousSiteProtection/API/APIRequest.swift
+++ b/Sources/MaliciousSiteProtection/API/APIRequest.swift
@@ -101,7 +101,7 @@ public extension APIRequestType {
             .matches(self)
         }
 
-        var defaultTimeout: TimeInterval? { 10 }
+        var defaultTimeout: TimeInterval? { 5 }
     }
 }
 /// extension to call generic `load(_: some Request)` method like this: `load(.matches(…))`

--- a/Sources/MaliciousSiteProtection/MaliciousSiteDetector.swift
+++ b/Sources/MaliciousSiteProtection/MaliciousSiteDetector.swift
@@ -68,8 +68,11 @@ public final class MaliciousSiteDetector: MaliciousSiteDetecting {
         let matches: [Match]
         do {
             matches = try await apiClient.matches(forHashPrefix: hashPrefixParam).matches
+        } catch APIRequestV2.Error.urlSession(URLError.timedOut) {
+            eventMapping.fire(.matchesApiTimeout)
+            return nil
         } catch {
-            Logger.general.error("Error fetching matches from API: \(error)")
+            eventMapping.fire(.matchesApiFailure(error))
             return nil
         }
 

--- a/Sources/MaliciousSiteProtection/Model/Event.swift
+++ b/Sources/MaliciousSiteProtection/Model/Event.swift
@@ -32,6 +32,8 @@ public enum Event: PixelKitEventV2 {
     case visitSite(category: ThreatKind)
     case iframeLoaded(category: ThreatKind)
     case settingToggled(to: Bool)
+    case matchesApiTimeout
+    case matchesApiFailure(Error)
 
     public var name: String {
         switch self {
@@ -43,6 +45,10 @@ public enum Event: PixelKitEventV2 {
             return "malicious-site-protection_iframe-loaded"
         case .settingToggled:
             return "malicious-site-protection_feature-toggled"
+        case .matchesApiTimeout:
+            return "malicious-site-protection.client-timeout"
+        case .matchesApiFailure:
+            return "malicious-site-protection.matches-api-error"
         }
     }
 
@@ -62,6 +68,9 @@ public enum Event: PixelKitEventV2 {
             return [
                 PixelKit.Parameters.settingToggledTo: String(state)
             ]
+        case .matchesApiTimeout,
+             .matchesApiFailure:
+            return [:]
         }
     }
 
@@ -75,6 +84,10 @@ public enum Event: PixelKitEventV2 {
             return nil
         case .settingToggled:
             return nil
+        case .matchesApiTimeout:
+            return nil
+        case .matchesApiFailure(let error):
+            return error
         }
     }
 

--- a/Sources/Networking/v2/APIRequestErrorV2.swift
+++ b/Sources/Networking/v2/APIRequestErrorV2.swift
@@ -44,6 +44,14 @@ extension APIRequestV2 {
                 return "The response body is nil"
             }
         }
+
+        public var isTimedOut: Bool {
+            if case .urlSession(URLError.timedOut) = self {
+                true
+            } else {
+                false
+            }
+        }
     }
 
 }

--- a/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
+++ b/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
@@ -105,7 +105,7 @@ class MaliciousSiteDetectorTests: XCTestCase {
     func testWhenMatchesApiFailsThenEventIsFired() async {
         let e = expectation(description: "matchesForHashPrefix called")
         mockAPIClient.matchesForHashPrefix = { _ in
-            let error = Networking.APIRequestV2.Error.urlSession(URLError.init(.badServerResponse))
+            let error = Networking.APIRequestV2.Error.urlSession(URLError(.badServerResponse))
             XCTAssertFalse(error.isTimedOut)
             e.fulfill()
             throw error
@@ -133,7 +133,7 @@ class MaliciousSiteDetectorTests: XCTestCase {
     func testWhenMatchesApiFailsWithTimeoutThenEventIsFired() async {
         let e = expectation(description: "matchesForHashPrefix called")
         mockAPIClient.matchesForHashPrefix = { _ in
-            let error = Networking.APIRequestV2.Error.urlSession(URLError.init(.timedOut))
+            let error = Networking.APIRequestV2.Error.urlSession(URLError(.timedOut))
             XCTAssertTrue(error.isTimedOut) // should match testWhenMatchesRequestTimeouts_TimeoutErrorThrown!
             e.fulfill()
             throw error

--- a/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
+++ b/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 import Foundation
+import Networking
 import XCTest
 
 @testable import MaliciousSiteProtection
@@ -99,5 +100,61 @@ class MaliciousSiteDetectorTests: XCTestCase {
         let result = await detector.evaluate(url)
 
         XCTAssertNil(result)
+    }
+
+    func testWhenMatchesApiFailsThenEventIsFired() async {
+        let e = expectation(description: "matchesForHashPrefix called")
+        mockAPIClient.matchesForHashPrefix = { _ in
+            let error = Networking.APIRequestV2.Error.urlSession(URLError.init(.badServerResponse))
+            XCTAssertFalse(error.isTimedOut)
+            e.fulfill()
+            throw error
+        }
+
+        await mockDataManager.store(HashPrefixSet(revision: 0, items: ["255a8a79"]), for: .hashPrefixes(threatKind: .phishing))
+
+        let url = URL(string: "https://malicious.com/")!
+        let result = await detector.evaluate(url)
+        XCTAssertNil(result)
+
+        await fulfillment(of: [e], timeout: 0)
+
+        XCTAssertEqual(mockEventMapping.events.count, 1)
+        switch mockEventMapping.events.last {
+        case .matchesApiFailure(APIRequestV2.Error.urlSession(URLError.badServerResponse)):
+            break
+        case .none:
+            XCTFail( "No event fired")
+        case .some(let event):
+            XCTFail("Unexpected event \(event)")
+        }
+    }
+
+    func testWhenMatchesApiFailsWithTimeoutThenEventIsFired() async {
+        let e = expectation(description: "matchesForHashPrefix called")
+        mockAPIClient.matchesForHashPrefix = { _ in
+            let error = Networking.APIRequestV2.Error.urlSession(URLError.init(.timedOut))
+            XCTAssertTrue(error.isTimedOut) // should match testWhenMatchesRequestTimeouts_TimeoutErrorThrown!
+            e.fulfill()
+            throw error
+        }
+
+        await mockDataManager.store(HashPrefixSet(revision: 0, items: ["255a8a79"]), for: .hashPrefixes(threatKind: .phishing))
+
+        let url = URL(string: "https://malicious.com/")!
+        let result = await detector.evaluate(url)
+        XCTAssertNil(result)
+
+        await fulfillment(of: [e], timeout: 0)
+
+        XCTAssertEqual(mockEventMapping.events.count, 1)
+        switch mockEventMapping.events.last {
+        case .matchesApiTimeout:
+            break
+        case .none:
+            XCTFail( "No event fired")
+        case .some(let event):
+            XCTFail("Unexpected event \(event)")
+        }
     }
 }

--- a/Tests/MaliciousSiteProtectionTests/Mocks/MockEventMapping.swift
+++ b/Tests/MaliciousSiteProtectionTests/Mocks/MockEventMapping.swift
@@ -22,23 +22,22 @@ import MaliciousSiteProtection
 import PixelKit
 
 public class MockEventMapping: EventMapping<MaliciousSiteProtection.Event> {
-    static var events: [MaliciousSiteProtection.Event] = []
-    static var clientSideHitParam: String?
-    static var errorParam: Error?
+    var events: [MaliciousSiteProtection.Event] = []
+    var clientSideHitParam: String?
+    var errorParam: Error?
 
     public init() {
+        weak var weakSelf: MockEventMapping!
         super.init { event, error, params, _ in
-            Self.events.append(event)
+            weakSelf!.events.append(event)
             switch event {
             case .errorPageShown:
-                Self.clientSideHitParam = params?[PixelKit.Parameters.clientSideHit]
+                weakSelf!.clientSideHitParam = params?[PixelKit.Parameters.clientSideHit]
             default:
                 break
             }
         }
+        weakSelf = self
     }
 
-    override init(mapping: @escaping EventMapping<MaliciousSiteProtection.Event>.Mapping) {
-        fatalError("Use init()")
-    }
 }

--- a/Tests/MaliciousSiteProtectionTests/Mocks/MockMaliciousSiteProtectionAPIClient.swift
+++ b/Tests/MaliciousSiteProtectionTests/Mocks/MockMaliciousSiteProtectionAPIClient.swift
@@ -80,7 +80,7 @@ class MockMaliciousSiteProtectionAPIClient: MaliciousSiteProtection.APIClient.Mo
         case .filterSet(let configuration):
             return _filtersChangeSet(for: configuration.threatKind, revision: configuration.revision ?? 0) as! Request.Response
         case .matches(let configuration):
-            return _matches(forHashPrefix: configuration.hashPrefix) as! Request.Response
+            return try matchesForHashPrefix(configuration.hashPrefix) as! Request.Response
         }
     }
     func _filtersChangeSet(for threatKind: MaliciousSiteProtection.ThreatKind, revision: Int) -> MaliciousSiteProtection.APIClient.Response.FiltersChangeSet {
@@ -93,7 +93,7 @@ class MockMaliciousSiteProtectionAPIClient: MaliciousSiteProtection.APIClient.Mo
         return hashPrefixRevisions[revision] ?? .init(insert: [], delete: [], revision: revision, replace: false)
     }
 
-    func _matches(forHashPrefix hashPrefix: String) -> APIClient.Response.Matches {
+    var matchesForHashPrefix: (String) throws -> APIClient.Response.Matches = { _ in
         .init(matches: [
             Match(hostname: "example.com", url: "https://example.com/mal", regex: ".*", hash: "a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947", category: nil),
             Match(hostname: "test.com", url: "https://test.com/mal", regex: ".*test.*", hash: "aa00bb11aa00cc11bb00cc11", category: nil)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1202406491309510/1209190998168436/f
iOS PR: 
macOS PR: 
What kind of version bump will this require?: Minor

**Description**:
- Reduce Matches API default timeout to 5sec
- Fire pixel event for timeout (and error, not to be matched on the client side for now)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Connect over cellular with bad condition (or use network conditioner, or set the default timeout to a lower value)
2. Visit some website, validate the timeout pixel is fired (in the app pixels log)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
