### PR TITLE
Fix malsite timeout pixel name

### DIFF
--- a/Sources/MaliciousSiteProtection/API/APIRequest.swift
+++ b/Sources/MaliciousSiteProtection/API/APIRequest.swift
@@ -50,7 +50,7 @@ public extension APIRequestType {
         let threatKind: ThreatKind
         let revision: Int?
 
-        init(threatKind: ThreatKind, revision: Int?) {
+        public init(threatKind: ThreatKind, revision: Int?) {
             self.threatKind = threatKind
             self.revision = revision
         }
@@ -74,7 +74,7 @@ public extension APIRequestType {
         let threatKind: ThreatKind
         let revision: Int?
 
-        init(threatKind: ThreatKind, revision: Int?) {
+        public init(threatKind: ThreatKind, revision: Int?) {
             self.threatKind = threatKind
             self.revision = revision
         }
@@ -96,6 +96,10 @@ public extension APIRequestType {
         typealias Response = APIClient.Response.Matches
 
         let hashPrefix: String
+
+        public init(hashPrefix: String) {
+            self.hashPrefix = hashPrefix
+        }
 
         var requestType: APIRequestType {
             .matches(self)

--- a/Sources/MaliciousSiteProtection/Model/Event.swift
+++ b/Sources/MaliciousSiteProtection/Model/Event.swift
@@ -46,9 +46,9 @@ public enum Event: PixelKitEventV2 {
         case .settingToggled:
             return "malicious-site-protection_feature-toggled"
         case .matchesApiTimeout:
-            return "malicious-site-protection.client-timeout"
+            return "malicious-site-protection_client-timeout"
         case .matchesApiFailure:
-            return "malicious-site-protection.matches-api-error"
+            return "malicious-site-protection_matches-api-error"
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1202406491309510/1209190998168436/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3856
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3772
What kind of version bump will this require?: Patch

**Description**:
- Fix Malicious site protection Matches Api timeout pixel name to not contain `.`
- make API request structs publicly initializable for testing purposes

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate CI is green
2. see macOS PR for macOS testing steps

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
