### PR TITLE
Malicious Site Protection - Make clientSideHit optional parameter

### DIFF
--- a/Sources/MaliciousSiteProtection/MaliciousSiteDetector.swift
+++ b/Sources/MaliciousSiteProtection/MaliciousSiteDetector.swift
@@ -113,7 +113,7 @@ public final class MaliciousSiteDetector: MaliciousSiteDetecting {
         for threatKind in hashPrefixMatchingThreatKinds {
             let matches = await checkLocalFilters(hostHash: hostHash, canonicalUrl: canonicalUrl, for: threatKind)
             if matches {
-                eventMapping.fire(.errorPageShown(category: threatKind, clientSideHit: true))
+                await fireErrorPageShown(threatKind: threatKind, clientSideHit: true)
                 return threatKind
             }
         }
@@ -123,11 +123,17 @@ public final class MaliciousSiteDetector: MaliciousSiteDetecting {
         let match = await checkApiMatches(hostHash: hostHash, canonicalUrl: canonicalUrl)
         if let match {
             let threatKind = match.category.flatMap(ThreatKind.init) ?? hashPrefixMatchingThreatKinds[0]
-            eventMapping.fire(.errorPageShown(category: threatKind, clientSideHit: false))
+            await fireErrorPageShown(threatKind: threatKind, clientSideHit: false)
             return threatKind
         }
 
         return .none
     }
 
+    private func fireErrorPageShown(threatKind: ThreatKind, clientSideHit: Bool) async {
+        let filterSet = await dataManager.dataSet(for: .filterSet(threatKind: threatKind))
+        // https://app.asana.com/0/0/1209113403594297/1209141231997704/f
+        let sanitisedClientSideHit = filterSet.filters.count < 100 ? clientSideHit : nil
+        eventMapping.fire(.errorPageShown(category: threatKind, clientSideHit: sanitisedClientSideHit))
+    }
 }

--- a/Sources/MaliciousSiteProtection/MaliciousSiteDetector.swift
+++ b/Sources/MaliciousSiteProtection/MaliciousSiteDetector.swift
@@ -132,8 +132,9 @@ public final class MaliciousSiteDetector: MaliciousSiteDetecting {
 
     private func fireErrorPageShown(threatKind: ThreatKind, clientSideHit: Bool) async {
         let filterSet = await dataManager.dataSet(for: .filterSet(threatKind: threatKind))
+        // Send Pixel clientSideHit parameter only if filterSet size is greater than 100
         // https://app.asana.com/0/0/1209113403594297/1209141231997704/f
-        let sanitisedClientSideHit = filterSet.filters.count < 100 ? clientSideHit : nil
+        let sanitisedClientSideHit = filterSet.filters.count > 100 ? clientSideHit : nil
         eventMapping.fire(.errorPageShown(category: threatKind, clientSideHit: sanitisedClientSideHit))
     }
 }

--- a/Sources/MaliciousSiteProtection/Model/Event.swift
+++ b/Sources/MaliciousSiteProtection/Model/Event.swift
@@ -29,7 +29,7 @@ public extension PixelKit {
 }
 
 public enum Event: PixelKitEventV2 {
-    case errorPageShown(category: ThreatKind, clientSideHit: Bool)
+    case errorPageShown(category: ThreatKind, clientSideHit: Bool?)
     case visitSite(category: ThreatKind)
     case iframeLoaded(category: ThreatKind)
     case settingToggled(to: Bool)
@@ -59,10 +59,17 @@ public enum Event: PixelKitEventV2 {
     public var parameters: [String: String]? {
         switch self {
         case .errorPageShown(category: let category, clientSideHit: let clientSideHit):
-            return [
-                PixelKit.Parameters.category: category.rawValue,
-                PixelKit.Parameters.clientSideHit: String(clientSideHit),
-            ]
+            let parameters = if let clientSideHit {
+                [
+                    PixelKit.Parameters.category: category.rawValue,
+                    PixelKit.Parameters.clientSideHit: String(clientSideHit),
+                ]
+            } else {
+                [
+                    PixelKit.Parameters.category: category.rawValue,
+                ]
+            }
+            return parameters
         case .visitSite(category: let category),
              .iframeLoaded(category: let category):
             return [

--- a/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
+++ b/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
@@ -172,13 +172,13 @@ class MaliciousSiteDetectorTests: XCTestCase {
         XCTAssertEqual(mockEventMapping.events.count, 1)
         switch mockEventMapping.events.last {
         case let .errorPageShown(_, clientSideHit):
-            XCTAssertTrue(clientSideHit == true)
+            XCTAssertNil(clientSideHit)
         default:
             XCTFail("Wrong event fired")
         }
     }
 
-    func testWhenLocalFilterHitAndFilterSetGreaterThanHundredThenClientSideHitParameterIsNil() async throws {
+    func testWhenLocalFilterHitAndFilterSetGreaterThanHundredThenClientSideHitParameterIsSent() async throws {
         // GIVEN
         let maliciousFilter = Filter(hash: "255a8a793097aeea1f06a19c08cde28db0eb34c660c6e4e7480c9525d034b16d", regex: ".*malicious.*")
         let filters = (1...100).map { i in
@@ -195,7 +195,7 @@ class MaliciousSiteDetectorTests: XCTestCase {
         XCTAssertEqual(mockEventMapping.events.count, 1)
         switch mockEventMapping.events.last {
         case let .errorPageShown(_, clientSideHit):
-            XCTAssertNil(clientSideHit)
+            XCTAssertNotNil(clientSideHit)
         default:
             XCTFail("Wrong event fired")
         }
@@ -207,19 +207,19 @@ class MaliciousSiteDetectorTests: XCTestCase {
         let url = URL(string: "https://example.com/mal")!
 
         // WHEN
-        let _ = await detector.evaluate(url)
+        _ = await detector.evaluate(url)
 
         // THEN
         XCTAssertEqual(mockEventMapping.events.count, 1)
         switch mockEventMapping.events.last {
         case let .errorPageShown(_, clientSideHit):
-            XCTAssertTrue(clientSideHit == false)
+            XCTAssertNil(clientSideHit)
         default:
             XCTFail("Wrong event fired")
         }
     }
 
-    func testWhenMatchesAPIAndFilterSetGreaterThanHundredThenClientSideHitParameterIsNil() async throws {
+    func testWhenMatchesAPIAndFilterSetGreaterThanHundredThenClientSideHitParameterIsSet() async throws {
         // GIVEN
         let maliciousFilter = Filter(hash: "255a8a793097aeea1f06a19c08cde28db0eb34c660c6e4e7480c9525d034b16d", regex: ".*malicious.*")
         let filters = (1...100).map { i in
@@ -230,13 +230,13 @@ class MaliciousSiteDetectorTests: XCTestCase {
         let url = URL(string: "https://example.com/mal")!
 
         // WHEN
-        let _ = await detector.evaluate(url)
+         _ = await detector.evaluate(url)
 
         // THEN
         XCTAssertEqual(mockEventMapping.events.count, 1)
         switch mockEventMapping.events.last {
         case let .errorPageShown(_, clientSideHit):
-            XCTAssertNil(clientSideHit)
+            XCTAssertNotNil(clientSideHit)
         default:
             XCTFail("Wrong event fired")
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1206329551987282/1209242004458518/f
iOS PR: https://github.com/duckduckgo/iOS/pull/3891
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3796
What kind of version bump will this require?: Minor

**Description**:

This PR makes `MaliciousSiteProtection.Event.errorPageShown` `clientSideHit` parameter optional. See dicussion in [Asana Task](https://app.asana.com/0/1206329551987282/1209242004458518/f)

**Steps to test this PR**:
1. Ensure logic is correct

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
