### PR TITLE
Dead token recovery

### DIFF
--- a/Sources/Common/Extensions/DateExtension.swift
+++ b/Sources/Common/Extensions/DateExtension.swift
@@ -195,7 +195,7 @@ public extension Date {
     func isInThePast() -> Bool {
         return self < Date()
     }
-    
+
     func isInTheFuture() -> Bool {
         return self > Date()
     }

--- a/Sources/Common/Extensions/DateExtension.swift
+++ b/Sources/Common/Extensions/DateExtension.swift
@@ -162,27 +162,32 @@ public extension Date {
         Int(Date().timeIntervalSince(self))
     }
 
-    /// Returns the number of minutes since this date until now. Returns a negative number if the ate is in the future.
+    /// The number of minutes since this date until now.
+    /// Returns a negative number if self is in the future.
     func minutesSinceNow() -> Int {
         secondsSinceNow() / 60
     }
 
-    /// Returns the number of hours since this date until now.
+    /// The number of hours since this date until now.
+    /// Returns a negative number if self is in the future.
     func hoursSinceNow() -> Int {
         minutesSinceNow() / 60
     }
 
-    /// Returns the number of days since this date until now.
+    /// The number of days since this date until now.
+    /// Returns a negative number if self is in the future.
     func daysSinceNow() -> Int {
         hoursSinceNow() / 24
     }
 
-    /// Returns the number of months since this date until now.
+    /// The number of months since this date until now.
+    /// Returns a negative number if self is in the future.
     func monthsSinceNow() -> Int {
         Calendar.current.dateComponents([.month], from: self, to: Date()).month ?? 0
     }
 
-    /// Returns the number of years since this date until now.
+    /// The number of years since this date until now.
+    /// Returns a negative number if self is in the future.
     func yearsSinceNow() -> Int {
         Calendar.current.dateComponents([.year], from: self, to: Date()).year ?? 0
     }

--- a/Sources/Common/Extensions/DateExtension.swift
+++ b/Sources/Common/Extensions/DateExtension.swift
@@ -162,7 +162,7 @@ public extension Date {
         Int(Date().timeIntervalSince(self))
     }
 
-    /// Returns the number of minutes since this date until now.
+    /// Returns the number of minutes since this date until now. Returns a negative number if the ate is in the future.
     func minutesSinceNow() -> Int {
         secondsSinceNow() / 60
     }

--- a/Sources/Common/Extensions/DateExtension.swift
+++ b/Sources/Common/Extensions/DateExtension.swift
@@ -136,11 +136,6 @@ public extension Date {
         Int(self.timeIntervalSinceReferenceDate / TimeInterval.day)
     }
 
-    /// Adds a specific time interval to this date.
-    func adding(_ timeInterval: TimeInterval) -> Date {
-        addingTimeInterval(timeInterval)
-    }
-
     /// Checks if this date falls on the same calendar day as another date.
     func isSameDay(_ otherDate: Date?) -> Bool {
         guard let otherDate = otherDate else { return false }
@@ -162,10 +157,15 @@ public extension Date {
         Int(Date().timeIntervalSince(self))
     }
 
+    /// Returns the number of seconds since this date until now.
+    func secondsFromNow() -> Int {
+        Int(self.timeIntervalSince(Date()))
+    }
+
     /// The number of minutes since this date until now.
     /// Returns a negative number if self is in the future.
     func minutesSinceNow() -> Int {
-        secondsSinceNow() / 60
+        Int(secondsSinceNow()) / 60
     }
 
     /// The number of hours since this date until now.

--- a/Sources/Common/Extensions/DateExtension.swift
+++ b/Sources/Common/Extensions/DateExtension.swift
@@ -191,4 +191,12 @@ public extension Date {
     func yearsSinceNow() -> Int {
         Calendar.current.dateComponents([.year], from: self, to: Date()).year ?? 0
     }
+
+    func isInThePast() -> Bool {
+        return self < Date()
+    }
+    
+    func isInTheFuture() -> Bool {
+        return self > Date()
+    }
 }

--- a/Sources/NetworkingTestingUtils/OAuthTokensFactory.swift
+++ b/Sources/NetworkingTestingUtils/OAuthTokensFactory.swift
@@ -54,6 +54,21 @@ public struct OAuthTokensFactory {
         )
     }
 
+    public static func makeAccessToken(thatExpiresIn minutes: Int, scope: String, email: String = "test@example.com") -> JWTAccessToken {
+        return JWTAccessToken(
+            exp: ExpirationClaim(value: Date().addingTimeInterval(3600)), // 1 hour from now
+            iat: IssuedAtClaim(value: Date()),
+            sub: SubjectClaim(value: "test-subject"),
+            aud: AudienceClaim(value: ["test-audience"]),
+            iss: IssuerClaim(value: "test-issuer"),
+            jti: IDClaim(value: "test-id"),
+            scope: scope,
+            api: "v2",
+            email: email,
+            entitlements: []
+        )
+    }
+
     // Helper function to create a valid JWTRefreshToken with customizable scope
     public static func makeRefreshToken(scope: String) -> JWTRefreshToken {
         return JWTRefreshToken(
@@ -68,10 +83,30 @@ public struct OAuthTokensFactory {
         )
     }
 
+    public static func makeExpiredRefreshToken(scope: String) -> JWTRefreshToken {
+        return JWTRefreshToken(
+            exp: ExpirationClaim(value: Date().daysAgo(40)),
+            iat: IssuedAtClaim(value: Date().daysAgo(70)),
+            sub: SubjectClaim(value: "test-subject"),
+            aud: AudienceClaim(value: ["test-audience"]),
+            iss: IssuerClaim(value: "test-issuer"),
+            jti: IDClaim(value: "test-id"),
+            scope: scope,
+            api: "v2"
+        )
+    }
+
     public static func makeValidTokenContainer() -> TokenContainer {
         return TokenContainer(accessToken: "accessToken",
                                refreshToken: "refreshToken",
                                decodedAccessToken: OAuthTokensFactory.makeAccessToken(scope: "privacypro"),
+                               decodedRefreshToken: OAuthTokensFactory.makeRefreshToken(scope: "refresh"))
+    }
+
+    public static func makeTokenContainer(thatExpiresIn minutes: Int) -> TokenContainer {
+        return TokenContainer(accessToken: "AccessTokenExpiringIn\(minutes)Minutes",
+                               refreshToken: "refreshToken",
+                              decodedAccessToken: OAuthTokensFactory.makeAccessToken(thatExpiresIn: minutes, scope: "privacypro"),
                                decodedRefreshToken: OAuthTokensFactory.makeRefreshToken(scope: "refresh"))
     }
 
@@ -96,6 +131,13 @@ public struct OAuthTokensFactory {
 
     public static func makeValidOAuthTokenResponse() -> OAuthTokenResponse {
         return OAuthTokenResponse(accessToken: "**validaccesstoken**", refreshToken: "**validrefreshtoken**")
+    }
+
+    public static func makeDeadTokenContainer() -> TokenContainer {
+        return TokenContainer(accessToken: "expiredAccessToken",
+                               refreshToken: "expiredRefreshToken",
+                               decodedAccessToken: OAuthTokensFactory.makeExpiredAccessToken(),
+                              decodedRefreshToken: OAuthTokensFactory.makeExpiredRefreshToken(scope: "refresh"))
     }
 }
 

--- a/Sources/Subscription/DeadTokenRecoverer.swift
+++ b/Sources/Subscription/DeadTokenRecoverer.swift
@@ -1,0 +1,50 @@
+//
+//  DeadTokenRecoverer.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Networking
+import os.log
+
+@available(macOS 12.0, *)
+public struct DeadTokenRecoverer {
+
+    private static var recoveryAttempted: Int = 0
+
+    public static func recoverDeadToken(endpointService: any SubscriptionEndpointServiceV2,
+                                 restoreFlow: any AppStoreRestoreFlowV2) async throws {
+
+        if recoveryAttempted != 0 {
+            recoveryAttempted -= 1
+            throw SubscriptionManagerError.tokenUnRefreshable
+        }
+        recoveryAttempted += 1
+
+        let subscription = try await endpointService.getSubscription(accessToken: "",
+                                                                     cachePolicy: .returnCacheDataDontLoad)
+        guard subscription.platform == .apple else {
+            throw SubscriptionManagerError.tokenUnRefreshable
+        }
+
+        switch await restoreFlow.restoreAccountFromPastPurchase() {
+        case .success:
+            break
+        case .failure:
+            throw SubscriptionManagerError.tokenUnRefreshable
+        }
+    }
+}

--- a/Sources/Subscription/DeadTokenRecoverer.swift
+++ b/Sources/Subscription/DeadTokenRecoverer.swift
@@ -25,7 +25,7 @@ public struct DeadTokenRecoverer {
 
     private static var recoveryAttemptCount: Int = 0
 
-    public static func recoverDeadToken(endpointService: any SubscriptionEndpointServiceV2,
+    public static func attemptRecoveryFromPastPurchase(endpointService: any SubscriptionEndpointServiceV2,
                                         restoreFlow: any AppStoreRestoreFlowV2) async throws {
         if recoveryAttemptCount != 0 {
             recoveryAttemptCount -= 1

--- a/Sources/Subscription/DeadTokenRecoverer.swift
+++ b/Sources/Subscription/DeadTokenRecoverer.swift
@@ -26,8 +26,7 @@ public struct DeadTokenRecoverer {
     private static var recoveryAttempted: Int = 0
 
     public static func recoverDeadToken(endpointService: any SubscriptionEndpointServiceV2,
-                                 restoreFlow: any AppStoreRestoreFlowV2) async throws {
-
+                                        restoreFlow: any AppStoreRestoreFlowV2) async throws {
         if recoveryAttempted != 0 {
             recoveryAttempted -= 1
             throw SubscriptionManagerError.tokenUnRefreshable

--- a/Sources/Subscription/DeadTokenRecoverer.swift
+++ b/Sources/Subscription/DeadTokenRecoverer.swift
@@ -25,16 +25,14 @@ public struct DeadTokenRecoverer {
 
     private static var recoveryAttemptCount: Int = 0
 
-    public static func attemptRecoveryFromPastPurchase(endpointService: any SubscriptionEndpointServiceV2,
-                                        restoreFlow: any AppStoreRestoreFlowV2) async throws {
+    public static func attemptRecoveryFromPastPurchase(endpointService: any SubscriptionEndpointServiceV2, restoreFlow: any AppStoreRestoreFlowV2) async throws {
         if recoveryAttemptCount != 0 {
             recoveryAttemptCount -= 1
             throw SubscriptionManagerError.tokenUnRefreshable
         }
         recoveryAttemptCount += 1
 
-        let subscription = try await endpointService.getSubscription(accessToken: "",
-                                                                     cachePolicy: .returnCacheDataDontLoad)
+        let subscription = try await endpointService.getSubscription(accessToken: "", cachePolicy: .returnCacheDataDontLoad)
         guard subscription.platform == .apple else {
             throw SubscriptionManagerError.tokenUnRefreshable
         }

--- a/Sources/Subscription/DeadTokenRecoverer.swift
+++ b/Sources/Subscription/DeadTokenRecoverer.swift
@@ -23,15 +23,15 @@ import os.log
 @available(macOS 12.0, *)
 public struct DeadTokenRecoverer {
 
-    private static var recoveryAttempted: Int = 0
+    private static var recoveryAttemptCount: Int = 0
 
     public static func recoverDeadToken(endpointService: any SubscriptionEndpointServiceV2,
                                         restoreFlow: any AppStoreRestoreFlowV2) async throws {
-        if recoveryAttempted != 0 {
-            recoveryAttempted -= 1
+        if recoveryAttemptCount != 0 {
+            recoveryAttemptCount -= 1
             throw SubscriptionManagerError.tokenUnRefreshable
         }
-        recoveryAttempted += 1
+        recoveryAttemptCount += 1
 
         let subscription = try await endpointService.getSubscription(accessToken: "",
                                                                      cachePolicy: .returnCacheDataDontLoad)

--- a/Sources/SubscriptionTestingUtilities/SubscriptionMockFactory.swift
+++ b/Sources/SubscriptionTestingUtilities/SubscriptionMockFactory.swift
@@ -22,7 +22,7 @@ import Foundation
 /// Provides all mocks needed for testing subscription initialised with positive outcomes and basic configurations. All mocks can be partially reconfigured with failures or incorrect data
 public struct SubscriptionMockFactory {
 
-    public static let subscription = PrivacyProSubscription(productId: UUID().uuidString,
+    public static let appleSubscription = PrivacyProSubscription(productId: UUID().uuidString,
                                                   name: "Subscription test #1",
                                                   billingPeriod: .monthly,
                                                   startedAt: Date(),
@@ -45,9 +45,9 @@ public struct SubscriptionMockFactory {
                                                          platform: .stripe,
                                                          status: .expired)
 
-    public static let productsItems: [GetProductsItem] = [GetProductsItem(productId: subscription.productId,
-                                                                          productLabel: subscription.name,
-                                                                          billingPeriod: subscription.billingPeriod.rawValue,
+    public static let productsItems: [GetProductsItem] = [GetProductsItem(productId: appleSubscription.productId,
+                                                                          productLabel: appleSubscription.name,
+                                                                          billingPeriod: appleSubscription.billingPeriod.rawValue,
                                                                           price: "0.99",
                                                                           currency: "USD")]
 }

--- a/Tests/CommonTests/Extensions/DateExtensionTest.swift
+++ b/Tests/CommonTests/Extensions/DateExtensionTest.swift
@@ -148,13 +148,6 @@ final class DateExtensionTests: XCTestCase {
         XCTAssertEqual(date.daySinceReferenceDate, daysSinceReference)
     }
 
-    func testAdding() {
-        let date = Date()
-        let addedDate = date.adding(60)
-
-        XCTAssertEqual(addedDate.timeIntervalSince(date), 60)
-    }
-
     func testIsSameDayInstanceMethod() {
         let today = Date()
         let sameDay = today
@@ -218,8 +211,7 @@ final class DateExtensionTests: XCTestCase {
         let futureDate = Date(timeIntervalSinceNow: 100) // 100 seconds in the future
         XCTAssertFalse(futureDate.isInThePast())
 
-        let now = Date()
-        XCTAssertFalse(now.isInThePast()) // Edge case: exact current time
+        XCTAssertFalse(Date().isInThePast()) // Edge case: exact current time
     }
 
     func testIsInTheFuture() {
@@ -229,7 +221,6 @@ final class DateExtensionTests: XCTestCase {
         let pastDate = Date(timeIntervalSinceNow: -100) // 100 seconds ago
         XCTAssertFalse(pastDate.isInTheFuture())
 
-        let now = Date()
-        XCTAssertFalse(now.isInTheFuture()) // Edge case: exact current time
+        XCTAssertFalse(Date().isInTheFuture()) // Edge case: exact current time
     }
 }

--- a/Tests/CommonTests/Extensions/DateExtensionTest.swift
+++ b/Tests/CommonTests/Extensions/DateExtensionTest.swift
@@ -210,4 +210,26 @@ final class DateExtensionTests: XCTestCase {
         let date = Calendar.current.date(byAdding: .year, value: -2, to: Date())!
         XCTAssertEqual(date.yearsSinceNow(), 2)
     }
+
+    func testIsInThePast() {
+        let pastDate = Date(timeIntervalSinceNow: -100) // 100 seconds ago
+        XCTAssertTrue(pastDate.isInThePast())
+
+        let futureDate = Date(timeIntervalSinceNow: 100) // 100 seconds in the future
+        XCTAssertFalse(futureDate.isInThePast())
+
+        let now = Date()
+        XCTAssertFalse(now.isInThePast()) // Edge case: exact current time
+    }
+
+    func testIsInTheFuture() {
+        let futureDate = Date(timeIntervalSinceNow: 100) // 100 seconds in the future
+        XCTAssertTrue(futureDate.isInTheFuture())
+
+        let pastDate = Date(timeIntervalSinceNow: -100) // 100 seconds ago
+        XCTAssertFalse(pastDate.isInTheFuture())
+
+        let now = Date()
+        XCTAssertFalse(now.isInTheFuture()) // Edge case: exact current time
+    }
 }

--- a/Tests/SubscriptionTests/API/SubscriptionEndpointServiceTests.swift
+++ b/Tests/SubscriptionTests/API/SubscriptionEndpointServiceTests.swift
@@ -30,7 +30,7 @@ final class SubscriptionEndpointServiceTests: XCTestCase {
 
         static let mostRecentTransactionJWS = "dGhpcyBpcyBub3QgYSByZWFsIEFw(...)cCBTdG9yZSB0cmFuc2FjdGlvbiBKV1M="
 
-        static let subscription = SubscriptionMockFactory.subscription
+        static let subscription = SubscriptionMockFactory.appleSubscription
 
         static let customerPortalURL = "https://billing.stripe.com/p/session/test_ABC"
 

--- a/Tests/SubscriptionTests/Flows/AppStorePurchaseFlowTests.swift
+++ b/Tests/SubscriptionTests/Flows/AppStorePurchaseFlowTests.swift
@@ -255,7 +255,7 @@ final class AppStorePurchaseFlowTests: XCTestCase {
             ConfirmPurchaseResponse(
                 email: nil,
                 entitlements: [],
-                subscription: SubscriptionMockFactory.subscription
+                subscription: SubscriptionMockFactory.appleSubscription
             )
         )
 
@@ -268,7 +268,7 @@ final class AppStorePurchaseFlowTests: XCTestCase {
         }
 
         subscriptionService.onUpdateCache = { subscription in
-            XCTAssertEqual(subscription, SubscriptionMockFactory.subscription)
+            XCTAssertEqual(subscription, SubscriptionMockFactory.appleSubscription)
         }
 
         // When
@@ -293,7 +293,7 @@ final class AppStorePurchaseFlowTests: XCTestCase {
             ConfirmPurchaseResponse(
                 email: nil,
                 entitlements: [],
-                subscription: SubscriptionMockFactory.subscription
+                subscription: SubscriptionMockFactory.appleSubscription
             )
         )
 
@@ -304,7 +304,7 @@ final class AppStorePurchaseFlowTests: XCTestCase {
         }
 
         subscriptionService.onUpdateCache = { subscription in
-            XCTAssertEqual(subscription, SubscriptionMockFactory.subscription)
+            XCTAssertEqual(subscription, SubscriptionMockFactory.appleSubscription)
         }
 
         // When

--- a/Tests/SubscriptionTests/Flows/AppStorePurchaseFlowV2Tests.swift
+++ b/Tests/SubscriptionTests/Flows/AppStorePurchaseFlowV2Tests.swift
@@ -95,7 +95,7 @@ final class AppStorePurchaseFlowV2Tests: XCTestCase {
         appStoreRestoreFlowMock.restoreAccountFromPastPurchaseResult = .failure(AppStoreRestoreFlowErrorV2.missingAccountOrTransactions)
         storePurchaseManagerMock.purchaseSubscriptionResult = .failure(StorePurchaseManagerError.purchaseCancelledByUser)
         subscriptionManagerMock.resultCreateAccountTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
-        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.subscription
+        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.appleSubscription
 
         let result = await sut.purchaseSubscription(with: "testSubscriptionID")
 
@@ -106,7 +106,7 @@ final class AppStorePurchaseFlowV2Tests: XCTestCase {
         appStoreRestoreFlowMock.restoreAccountFromPastPurchaseResult = .failure(AppStoreRestoreFlowErrorV2.missingAccountOrTransactions)
         storePurchaseManagerMock.purchaseSubscriptionResult = .failure(StorePurchaseManagerError.purchaseFailed)
         subscriptionManagerMock.resultCreateAccountTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
-        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.subscription
+        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.appleSubscription
 
         let result = await sut.purchaseSubscription(with: "testSubscriptionID")
 
@@ -117,7 +117,7 @@ final class AppStorePurchaseFlowV2Tests: XCTestCase {
 
     func test_completeSubscriptionPurchase_withActiveSubscription_returnsSuccess() async {
         subscriptionManagerMock.resultTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
-        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.subscription
+        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.appleSubscription
         subscriptionManagerMock.confirmPurchaseResponse = .success(subscriptionManagerMock.resultSubscription!)
 
         let result = await sut.completeSubscriptionPurchase(with: "transactionJWS", additionalParams: nil)
@@ -127,7 +127,7 @@ final class AppStorePurchaseFlowV2Tests: XCTestCase {
 
     func test_completeSubscriptionPurchase_withMissingEntitlements_returnsMissingEntitlementsError() async {
         subscriptionManagerMock.resultTokenContainer = OAuthTokensFactory.makeValidTokenContainer()
-        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.subscription
+        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.appleSubscription
         subscriptionManagerMock.confirmPurchaseResponse = .success(subscriptionManagerMock.resultSubscription!)
 
         let result = await sut.completeSubscriptionPurchase(with: "transactionJWS", additionalParams: nil)
@@ -146,7 +146,7 @@ final class AppStorePurchaseFlowV2Tests: XCTestCase {
     }
 
     func test_completeSubscriptionPurchase_withConfirmPurchaseError_returnsPurchaseFailedError() async {
-        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.subscription
+        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.appleSubscription
         subscriptionManagerMock.resultTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
         subscriptionManagerMock.confirmPurchaseResponse = .failure(OAuthServiceError.invalidResponseCode(HTTPStatusCode.badRequest))
 

--- a/Tests/SubscriptionTests/Flows/AppStoreRestoreFlowTests.swift
+++ b/Tests/SubscriptionTests/Flows/AppStoreRestoreFlowTests.swift
@@ -84,7 +84,7 @@ final class AppStoreRestoreFlowTests: XCTestCase {
             XCTAssertEqual(accessToken, Constants.accessToken)
         }
 
-        let subscription = SubscriptionMockFactory.subscription
+        let subscription = SubscriptionMockFactory.appleSubscription
         subscriptionService.getSubscriptionResult = .success(subscription)
 
         XCTAssertTrue(subscription.isActive)

--- a/Tests/SubscriptionTests/Flows/AppStoreRestoreFlowV2Tests.swift
+++ b/Tests/SubscriptionTests/Flows/AppStoreRestoreFlowV2Tests.swift
@@ -94,7 +94,7 @@ final class AppStoreRestoreFlowV2Tests: XCTestCase {
 
     func test_restoreAccountFromPastPurchase_withActiveSubscription_returnsSuccess() async {
         storePurchaseManagerMock.mostRecentTransactionResult = "lastTransactionJWS"
-        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.subscription
+        subscriptionManagerMock.resultSubscription = SubscriptionMockFactory.appleSubscription
 
         let result = await sut.restoreAccountFromPastPurchase()
 

--- a/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
+++ b/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
@@ -113,7 +113,7 @@ final class SubscriptionManagerTests: XCTestCase {
         subscriptionService.onGetSubscription = { _, cachePolicy in
             XCTAssertEqual(cachePolicy, .reloadIgnoringLocalCacheData)
         }
-        subscriptionService.getSubscriptionResult = .success(SubscriptionMockFactory.subscription)
+        subscriptionService.getSubscriptionResult = .success(SubscriptionMockFactory.appleSubscription)
 
         accountManager.onFetchEntitlements = { cachePolicy in
             XCTAssertEqual(cachePolicy, .reloadIgnoringLocalCacheData)
@@ -146,7 +146,7 @@ final class SubscriptionManagerTests: XCTestCase {
 
     func testForRefreshCachedSubscriptionAndEntitlements() async throws {
         // Given
-        let subscription = SubscriptionMockFactory.subscription
+        let subscription = SubscriptionMockFactory.appleSubscription
 
         accountManager.accessToken = Constants.accessToken
 

--- a/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
+++ b/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
@@ -29,7 +29,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
     var mockSubscriptionEndpointService: SubscriptionEndpointServiceMockV2!
     var mockStorePurchaseManager: StorePurchaseManagerMockV2!
     var mockAppStoreRestoreFlowV2: AppStoreRestoreFlowMockV2!
-    var overrideTokenResponse: Result<Networking.TokenContainer, Error>? = nil
+    var overrideTokenResponse: Result<Networking.TokenContainer, Error>?
 
     override func setUp() {
         super.setUp()
@@ -72,15 +72,15 @@ class SubscriptionManagerV2Tests: XCTestCase {
         XCTAssertEqual(result, expectedTokenContainer)
     }
 
-//    func testGetTokenContainer_ExpiresInLessThen10Minutes() async throws {
-//        mockOAuthClient.getTokensResponse = .success(OAuthTokensFactory.makeTokenContainer(thatExpiresIn: 5))
-//        mockOAuthClient.refreshTokensResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
-//
-//        let result = try await subscriptionManager.getTokenContainer(policy: .localValid)
-//        XCTAssertFalse(result.decodedAccessToken.isExpired())
-//        let expiryDate = result.decodedAccessToken.exp.value
-//        XCTAssertTrue(expiryDate.minutesSinceNow() > 20)
-//    }
+    func testGetTokenContainer_ExpiresInLessThen10Minutes() async throws {
+        mockOAuthClient.getTokensResponse = .success(OAuthTokensFactory.makeTokenContainer(thatExpiresIn: 5))
+        mockOAuthClient.refreshTokensResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
+
+        let result = try await subscriptionManager.getTokenContainer(policy: .localValid)
+        XCTAssertFalse(result.decodedAccessToken.isExpired())
+        let expiryDate = result.decodedAccessToken.exp.value
+        XCTAssertTrue(abs(expiryDate.minutesSinceNow()) > 20)
+    }
 
     // MARK: - Subscription Status Tests
 

--- a/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
+++ b/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
@@ -28,6 +28,8 @@ class SubscriptionManagerV2Tests: XCTestCase {
     var mockOAuthClient: MockOAuthClient!
     var mockSubscriptionEndpointService: SubscriptionEndpointServiceMockV2!
     var mockStorePurchaseManager: StorePurchaseManagerMockV2!
+    var mockAppStoreRestoreFlowV2: AppStoreRestoreFlowMockV2!
+    var overrideTokenResponse: Result<Networking.TokenContainer, Error>? = nil
 
     override func setUp() {
         super.setUp()
@@ -35,13 +37,20 @@ class SubscriptionManagerV2Tests: XCTestCase {
         mockOAuthClient = MockOAuthClient()
         mockSubscriptionEndpointService = SubscriptionEndpointServiceMockV2()
         mockStorePurchaseManager = StorePurchaseManagerMockV2()
+        mockAppStoreRestoreFlowV2 = AppStoreRestoreFlowMockV2()
 
         subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: SubscriptionEnvironment(serviceEnvironment: .staging, purchasePlatform: .stripe),
-            pixelHandler: { _ in }
+            pixelHandler: { _ in },
+            autoRecoveryHandler: {
+                if let overrideTokenResponse = self.overrideTokenResponse {
+                    self.mockOAuthClient.getTokensResponse = overrideTokenResponse
+                }
+                try await DeadTokenRecoverer.recoverDeadToken(endpointService: self.mockSubscriptionEndpointService, restoreFlow: self.mockAppStoreRestoreFlowV2)
+            }
         )
     }
 
@@ -63,43 +72,15 @@ class SubscriptionManagerV2Tests: XCTestCase {
         XCTAssertEqual(result, expectedTokenContainer)
     }
 
-    func testGetTokenContainer_ErrorHandlingDeadToken() async throws {
-        // Set up dead token error to trigger recovery attempt
-        mockOAuthClient.getTokensResponse = .failure(OAuthClientError.refreshTokenExpired)
-        let date = Date()
-        let expiredSubscription = PrivacyProSubscription(
-            productId: "testProduct",
-            name: "Test Subscription",
-            billingPeriod: .monthly,
-            startedAt: date.addingTimeInterval(-30 * 24 * 60 * 60), // 30 days ago
-            expiresOrRenewsAt: date.addingTimeInterval(-1), // expired
-            platform: .apple,
-            status: .expired
-        )
-        mockSubscriptionEndpointService.getSubscriptionResult = .success(expiredSubscription)
-        let expectation = self.expectation(description: "Dead token pixel called")
-        subscriptionManager = DefaultSubscriptionManagerV2(
-            storePurchaseManager: mockStorePurchaseManager,
-            oAuthClient: mockOAuthClient,
-            subscriptionEndpointService: mockSubscriptionEndpointService,
-            subscriptionEnvironment: SubscriptionEnvironment(serviceEnvironment: .staging, purchasePlatform: .stripe),
-            pixelHandler: { type in
-                XCTAssertEqual(type, .deadToken)
-                expectation.fulfill()
-            }
-        )
-
-        do {
-            _ = try await subscriptionManager.getTokenContainer(policy: .localValid)
-            XCTFail("Error expected")
-        } catch SubscriptionManagerError.tokenUnavailable {
-            // Expected error
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
-
-        await fulfillment(of: [expectation], timeout: 0.1)
-    }
+//    func testGetTokenContainer_ExpiresInLessThen10Minutes() async throws {
+//        mockOAuthClient.getTokensResponse = .success(OAuthTokensFactory.makeTokenContainer(thatExpiresIn: 5))
+//        mockOAuthClient.refreshTokensResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
+//
+//        let result = try await subscriptionManager.getTokenContainer(policy: .localValid)
+//        XCTAssertFalse(result.decodedAccessToken.isExpired())
+//        let expiryDate = result.decodedAccessToken.exp.value
+//        XCTAssertTrue(expiryDate.minutesSinceNow() > 20)
+//    }
 
     // MARK: - Subscription Status Tests
 
@@ -159,7 +140,8 @@ class SubscriptionManagerV2Tests: XCTestCase {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: environment,
-            pixelHandler: { _ in }
+            pixelHandler: { _ in },
+            autoRecoveryHandler: {}
         )
 
         let helpURL = subscriptionManager.url(for: .purchase)
@@ -216,7 +198,8 @@ class SubscriptionManagerV2Tests: XCTestCase {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: productionEnvironment,
-            pixelHandler: { _ in }
+            pixelHandler: { _ in },
+            autoRecoveryHandler: {}
         )
 
         // When
@@ -235,7 +218,8 @@ class SubscriptionManagerV2Tests: XCTestCase {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: stagingEnvironment,
-            pixelHandler: { _ in }
+            pixelHandler: { _ in },
+            autoRecoveryHandler: {}
         )
 
         // When
@@ -243,5 +227,49 @@ class SubscriptionManagerV2Tests: XCTestCase {
 
         // Then
         XCTAssertEqual(stagingPurchaseURL, SubscriptionURL.purchase.subscriptionURL(environment: .staging))
+    }
+
+    // MARK: - Dead token recovery
+
+    func testDeadTokenRecoverySuccess() async throws {
+        mockOAuthClient.getTokensResponse = .failure(OAuthClientError.refreshTokenExpired)
+        overrideTokenResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
+        mockSubscriptionEndpointService.getSubscriptionResult = .success(SubscriptionMockFactory.appleSubscription)
+        mockAppStoreRestoreFlowV2.restoreAccountFromPastPurchaseResult = .success("some")
+        let tokenContainer = try await subscriptionManager.getTokenContainer(policy: .localValid)
+        XCTAssertFalse(tokenContainer.decodedAccessToken.isExpired())
+    }
+
+    func testDeadTokenRecoveryFailure() async throws {
+        mockOAuthClient.getTokensResponse = .failure(OAuthClientError.refreshTokenExpired)
+        overrideTokenResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
+        mockSubscriptionEndpointService.getSubscriptionResult = .success(SubscriptionMockFactory.appleSubscription)
+        mockAppStoreRestoreFlowV2.restoreAccountFromPastPurchaseResult = .failure(AppStoreRestoreFlowErrorV2.subscriptionExpired)
+
+        do {
+            try await subscriptionManager.getTokenContainer(policy: .localValid)
+            XCTFail("This should fail with error: SubscriptionManagerError.tokenUnRefreshable")
+        } catch {
+            XCTAssertEqual(error as! SubscriptionManagerError, SubscriptionManagerError.tokenUnRefreshable)
+        }
+    }
+
+    /// Dead token error loop detector: this case shouldn't be possible, but if the BE starts to send back expired tokens we risk to enter in an infinite loop.
+    func testDeadTokenRecoveryLoop() async throws {
+        mockOAuthClient.getTokensResponse = .failure(OAuthClientError.refreshTokenExpired)
+        mockSubscriptionEndpointService.getSubscriptionResult = .success(SubscriptionMockFactory.appleSubscription)
+        mockAppStoreRestoreFlowV2.restoreAccountFromPastPurchaseResult = .success("some")
+        do {
+            try await subscriptionManager.getTokenContainer(policy: .localValid)
+            XCTFail("This should fail with error: SubscriptionManagerError.tokenUnRefreshable")
+        } catch {
+            XCTAssertEqual(error as! SubscriptionManagerError, SubscriptionManagerError.tokenUnRefreshable)
+        }
+        do {
+            try await subscriptionManager.getTokenContainer(policy: .localValid)
+            XCTFail("This should fail with error: SubscriptionManagerError.tokenUnRefreshable")
+        } catch {
+            XCTAssertEqual(error as! SubscriptionManagerError, SubscriptionManagerError.tokenUnRefreshable)
+        }
     }
 }

--- a/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
+++ b/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
@@ -49,7 +49,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
                 if let overrideTokenResponse = self.overrideTokenResponse {
                     self.mockOAuthClient.getTokensResponse = overrideTokenResponse
                 }
-                try await DeadTokenRecoverer.recoverDeadToken(endpointService: self.mockSubscriptionEndpointService, restoreFlow: self.mockAppStoreRestoreFlowV2)
+                try await DeadTokenRecoverer.attemptRecoveryFromPastPurchase(endpointService: self.mockSubscriptionEndpointService, restoreFlow: self.mockAppStoreRestoreFlowV2)
             }
         )
     }

--- a/Tests/SubscriptionTests/PrivacyProSubscriptionV2IntegrationTests.swift
+++ b/Tests/SubscriptionTests/PrivacyProSubscriptionV2IntegrationTests.swift
@@ -24,7 +24,7 @@ import SubscriptionTestingUtilities
 import JWTKit
 
 final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
-
+    
     var apiService: MockAPIService!
     var tokenStorage: MockTokenStorage!
     var legacyAccountStorage: MockLegacyTokenStorage!
@@ -34,9 +34,9 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
     var stripePurchaseFlow: DefaultStripePurchaseFlowV2!
     var storePurchaseManager: StorePurchaseManagerMockV2!
     var subscriptionFeatureFlagger: FeatureFlaggerMapping<SubscriptionFeatureFlags>!
-
+    
     let subscriptionSelectionID = "ios.subscription.1month"
-
+    
     override func setUpWithError() throws {
         apiService = MockAPIService()
         apiService.authorizationRefresherCallback = { _ in
@@ -47,32 +47,33 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
         // keychain storage
         tokenStorage = MockTokenStorage()
         legacyAccountStorage = MockLegacyTokenStorage()
-
+        
         let authClient = DefaultOAuthClient(tokensStorage: tokenStorage,
                                             legacyTokenStorage: legacyAccountStorage,
                                             authService: authService)
         storePurchaseManager = StorePurchaseManagerMockV2()
         let subscriptionEndpointService = DefaultSubscriptionEndpointServiceV2(apiService: apiService,
-                                                                             baseURL: subscriptionEnvironment.serviceEnvironment.url)
+                                                                               baseURL: subscriptionEnvironment.serviceEnvironment.url)
         let pixelHandler: SubscriptionManagerV2.PixelHandler = { type in
             print("Pixel fired: \(type)")
         }
         subscriptionFeatureFlagger = FeatureFlaggerMapping<SubscriptionFeatureFlags>(mapping: { $0.defaultState })
-
+        
         subscriptionManager = DefaultSubscriptionManagerV2(storePurchaseManager: storePurchaseManager,
-                                                         oAuthClient: authClient,
-                                                         subscriptionEndpointService: subscriptionEndpointService,
-                                                         subscriptionEnvironment: subscriptionEnvironment,
-                                                         pixelHandler: pixelHandler)
-
+                                                           oAuthClient: authClient,
+                                                           subscriptionEndpointService: subscriptionEndpointService,
+                                                           subscriptionEnvironment: subscriptionEnvironment,
+                                                           pixelHandler: pixelHandler,
+                                                           autoRecoveryHandler: {})
+        
         appStoreRestoreFlow = DefaultAppStoreRestoreFlowV2(subscriptionManager: subscriptionManager,
-                                                         storePurchaseManager: storePurchaseManager)
+                                                           storePurchaseManager: storePurchaseManager)
         appStorePurchaseFlow = DefaultAppStorePurchaseFlowV2(subscriptionManager: subscriptionManager,
-                                                           storePurchaseManager: storePurchaseManager,
-                                                           appStoreRestoreFlow: appStoreRestoreFlow)
+                                                             storePurchaseManager: storePurchaseManager,
+                                                             appStoreRestoreFlow: appStoreRestoreFlow)
         stripePurchaseFlow = DefaultStripePurchaseFlowV2(subscriptionManager: subscriptionManager)
     }
-
+    
     override func tearDownWithError() throws {
         apiService = nil
         tokenStorage = nil
@@ -82,11 +83,11 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
         appStoreRestoreFlow = nil
         stripePurchaseFlow = nil
     }
-
+    
     // MARK: - Apple store
-
+    
     func testAppStorePurchaseSuccess() async throws {
-
+        
         // configure mock API responses
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockCreateAccountResponse(destinationMockAPIService: apiService, success: true)
@@ -96,14 +97,14 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
         SubscriptionAPIMockResponseFactory.mockConfirmPurchase(destinationMockAPIService: apiService, success: true)
         SubscriptionAPIMockResponseFactory.mockGetProducts(destinationMockAPIService: apiService, success: true)
         SubscriptionAPIMockResponseFactory.mockGetFeatures(destinationMockAPIService: apiService, success: true, subscriptionID: "ios.subscription.1month")
-
+        
         (subscriptionManager.oAuthClient as! DefaultOAuthClient).testingDecodedTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
-
+        
         // configure mock store purchase manager responses
         storePurchaseManager.purchaseSubscriptionResult = .success("purchaseTransactionJWS")
-
+        
         // Buy subscription
-
+        
         var purchaseTransactionJWS: String?
         switch await appStorePurchaseFlow.purchaseSubscription(with: subscriptionSelectionID) {
         case .success(let transactionJWS):
@@ -112,7 +113,7 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             XCTFail("Purchase failed with error: \(error)")
         }
         XCTAssertNotNil(purchaseTransactionJWS)
-
+        
         switch await appStorePurchaseFlow.completeSubscriptionPurchase(with: purchaseTransactionJWS!, additionalParams: nil) {
         case .success:
             break
@@ -120,10 +121,10 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             XCTFail("Purchase failed with error: \(error)")
         }
     }
-
+    
     func testAppStorePurchaseFailure_authorise() async throws {
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: false)
-
+        
         switch await appStorePurchaseFlow.purchaseSubscription(with: subscriptionSelectionID) {
         case .success:
             XCTFail("Unexpected success")
@@ -136,12 +137,12 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             }
         }
     }
-
+    
     func testAppStorePurchaseFailure_create_account() async throws {
         // configure mock API responses
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockCreateAccountResponse(destinationMockAPIService: apiService, success: false)
-
+        
         switch await appStorePurchaseFlow.purchaseSubscription(with: subscriptionSelectionID) {
         case .success:
             XCTFail("Unexpected success")
@@ -154,13 +155,13 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             }
         }
     }
-
+    
     func testAppStorePurchaseFailure_get_token() async throws {
         // configure mock API responses
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockCreateAccountResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockGetAccessTokenResponse(destinationMockAPIService: apiService, success: false)
-
+        
         switch await appStorePurchaseFlow.purchaseSubscription(with: subscriptionSelectionID) {
         case .success:
             XCTFail("Unexpected success")
@@ -173,14 +174,14 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             }
         }
     }
-
+    
     func testAppStorePurchaseFailure_get_JWKS() async throws {
         // configure mock API responses
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockCreateAccountResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockGetAccessTokenResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockGetJWKS(destinationMockAPIService: apiService, success: false)
-
+        
         switch await appStorePurchaseFlow.purchaseSubscription(with: subscriptionSelectionID) {
         case .success:
             XCTFail("Unexpected success")
@@ -193,19 +194,19 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             }
         }
     }
-
+    
     func testAppStorePurchaseFailure_confirm_purchase() async throws {
         // configure mock API responses
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockCreateAccountResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockGetAccessTokenResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockGetJWKS(destinationMockAPIService: apiService, success: true)
-
+        
         (subscriptionManager.oAuthClient as! DefaultOAuthClient).testingDecodedTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
         storePurchaseManager.purchaseSubscriptionResult = .success("purchaseTransactionJWS")
-
+        
         SubscriptionAPIMockResponseFactory.mockConfirmPurchase(destinationMockAPIService: apiService, success: false)
-
+        
         var purchaseTransactionJWS: String?
         switch await appStorePurchaseFlow.purchaseSubscription(with: subscriptionSelectionID) {
         case .success(let transactionJWS):
@@ -214,7 +215,7 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             XCTFail("Purchase failed with error: \(error)")
         }
         XCTAssertNotNil(purchaseTransactionJWS)
-
+        
         switch await appStorePurchaseFlow.completeSubscriptionPurchase(with: purchaseTransactionJWS!, additionalParams: nil) {
         case .success:
             XCTFail("Unexpected success")
@@ -222,21 +223,21 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             XCTAssertEqual(error, .purchaseFailed(SubscriptionEndpointServiceError.invalidResponseCode(.badRequest)))
         }
     }
-
+    
     func testAppStorePurchaseFailure_get_features() async throws {
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockCreateAccountResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockGetAccessTokenResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockGetJWKS(destinationMockAPIService: apiService, success: true)
-
+        
         (subscriptionManager.oAuthClient as! DefaultOAuthClient).testingDecodedTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
         storePurchaseManager.purchaseSubscriptionResult = .success("purchaseTransactionJWS")
-
+        
         SubscriptionAPIMockResponseFactory.mockConfirmPurchase(destinationMockAPIService: apiService, success: true)
         SubscriptionAPIMockResponseFactory.mockGetFeatures(destinationMockAPIService: apiService, success: false, subscriptionID: "ios.subscription.1month")
-
+        
         (subscriptionManager.oAuthClient as! DefaultOAuthClient).testingDecodedTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
-
+        
         var purchaseTransactionJWS: String?
         switch await appStorePurchaseFlow.purchaseSubscription(with: subscriptionSelectionID) {
         case .success(let transactionJWS):
@@ -245,7 +246,7 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             XCTFail("Purchase failed with error: \(error)")
         }
         XCTAssertNotNil(purchaseTransactionJWS)
-
+        
         switch await appStorePurchaseFlow.completeSubscriptionPurchase(with: purchaseTransactionJWS!, additionalParams: nil) {
         case .success:
             XCTFail("Unexpected success")
@@ -253,17 +254,17 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             XCTAssertEqual(error, .purchaseFailed(SubscriptionEndpointServiceError.invalidResponseCode(.badRequest)))
         }
     }
-
+    
     // MARK: - Stripe
-
+    
     func testStripePurchaseSuccess() async throws {
         // configure mock API responses
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockCreateAccountResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockGetAccessTokenResponse(destinationMockAPIService: apiService, success: true)
-
+        
         (subscriptionManager.oAuthClient as! DefaultOAuthClient).testingDecodedTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
-
+        
         // Buy subscription
         let email = "test@duck.com"
         let result = await stripePurchaseFlow.prepareSubscriptionPurchase(emailAccessToken: email)
@@ -275,12 +276,12 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             XCTFail("Purchase failed with error: \(error)")
         }
     }
-
+    
     func testStripePurchaseFailure_authorise() async throws {
         // configure mock API responses
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: false)
         (subscriptionManager.oAuthClient as! DefaultOAuthClient).testingDecodedTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
-
+        
         // Buy subscription
         let email = "test@duck.com"
         let result = await stripePurchaseFlow.prepareSubscriptionPurchase(emailAccessToken: email)
@@ -291,14 +292,14 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             XCTAssertEqual(error, StripePurchaseFlowError.accountCreationFailed)
         }
     }
-
+    
     func testStripePurchaseFailure_create_account() async throws {
         // configure mock API responses
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockCreateAccountResponse(destinationMockAPIService: apiService, success: false)
-
+        
         (subscriptionManager.oAuthClient as! DefaultOAuthClient).testingDecodedTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
-
+        
         // Buy subscription
         let email = "test@duck.com"
         let result = await stripePurchaseFlow.prepareSubscriptionPurchase(emailAccessToken: email)
@@ -309,15 +310,15 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
             XCTAssertEqual(error, StripePurchaseFlowError.accountCreationFailed)
         }
     }
-
+    
     func testStripePurchaseFailure_get_token() async throws {
         // configure mock API responses
         APIMockResponseFactory.mockAuthoriseResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockCreateAccountResponse(destinationMockAPIService: apiService, success: true)
         APIMockResponseFactory.mockGetAccessTokenResponse(destinationMockAPIService: apiService, success: false)
-
+        
         (subscriptionManager.oAuthClient as! DefaultOAuthClient).testingDecodedTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
-
+        
         // Buy subscription
         let email = "test@duck.com"
         let result = await stripePurchaseFlow.prepareSubscriptionPurchase(emailAccessToken: email)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205842942115003/1209252725803000
iOS PR: no
macOS PR: no
What kind of version bump will this require?: none

**Description**:

This PR introduces improvements in the "dead token" detection and recovery for Auth V2.
A deat token happens when the refresh has expired.
The only thing we can do is log out the user and try to recover the subscription, if it was purchased via the Apple store, or show an error to the user for Stripe.

**Steps to test this PR**:
The code is not used yet, check the unit tests

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
