### PR TITLE
Privacy Pro Free Trials - Add Offer Model and ActiveOffers Property

### DIFF
--- a/Sources/Subscription/API/Model/PrivacyProSubscription.swift
+++ b/Sources/Subscription/API/Model/PrivacyProSubscription.swift
@@ -93,6 +93,11 @@ public struct PrivacyProSubscription: Codable, Equatable, CustomDebugStringConve
         status != .expired && status != .inactive
     }
 
+    /// Returns `true` is the Subscription has an active `Offer` with a type of `trial`. False otherwise.
+    public var hasActiveTrialOffer: Bool {
+        activeOffers.contains(where: { $0.type == .trial })
+    }
+
     public var debugDescription: String {
         return """
         Subscription:

--- a/Sources/Subscription/API/Model/PrivacyProSubscription.swift
+++ b/Sources/Subscription/API/Model/PrivacyProSubscription.swift
@@ -27,7 +27,7 @@ public struct PrivacyProSubscription: Codable, Equatable, CustomDebugStringConve
     public let expiresOrRenewsAt: Date
     public let platform: Platform
     public let status: Status
-    public let activeOffers: [OfferType]
+    public let activeOffers: [Offer]
 
     /// Not parsed from 
     public var features: [SubscriptionEntitlement]?
@@ -62,6 +62,15 @@ public struct PrivacyProSubscription: Codable, Equatable, CustomDebugStringConve
         public init(from decoder: Decoder) throws {
             self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
         }
+    }
+
+    /// Represents a subscription offer.
+    ///
+    /// The `Offer` struct encapsulates information about a specific subscription offer,
+    /// including its type.
+    public struct Offer: Codable, Equatable {
+        /// The type of the offer.
+        public let type: OfferType
     }
 
     /// Represents different types of subscription offers.

--- a/Sources/Subscription/API/Model/PrivacyProSubscription.swift
+++ b/Sources/Subscription/API/Model/PrivacyProSubscription.swift
@@ -27,6 +27,7 @@ public struct PrivacyProSubscription: Codable, Equatable, CustomDebugStringConve
     public let expiresOrRenewsAt: Date
     public let platform: Platform
     public let status: Status
+    public let activeOffers: [OfferType]
 
     /// Not parsed from 
     public var features: [SubscriptionEntitlement]?
@@ -58,6 +59,22 @@ public struct PrivacyProSubscription: Codable, Equatable, CustomDebugStringConve
         case expired = "Expired"
         case unknown
 
+        public init(from decoder: Decoder) throws {
+            self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+        }
+    }
+
+    /// Represents different types of subscription offers.
+    ///
+    /// - `trial`: A trial offer.
+    /// - `unknown`: A fallback case for any unrecognized offer types, ensuring forward compatibility.
+    public enum OfferType: String, Codable {
+        case trial = "Trial"
+        case unknown
+
+        /// Decodes an `OfferType` from a JSON value.
+        ///
+        /// If the decoded value does not match any known case, it defaults to `.unknown`.
         public init(from decoder: Decoder) throws {
             self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
         }

--- a/Sources/SubscriptionTestingUtilities/APIs/SubscriptionAPIMockResponseFactory.swift
+++ b/Sources/SubscriptionTestingUtilities/APIs/SubscriptionAPIMockResponseFactory.swift
@@ -46,7 +46,7 @@ public struct SubscriptionAPIMockResponseFactory {
                                                           additionalParams: nil)!
         if success {
             let jsonString = """
-{"email":"","entitlements":[{"product":"Data Broker Protection","name":"subscriber"},{"product":"Identity Theft Restoration","name":"subscriber"},{"product":"Network Protection","name":"subscriber"}],"subscription":{"productId":"ios.subscription.1month","name":"Monthly Subscription","billingPeriod":"Monthly","startedAt":1730991734000,"expiresOrRenewsAt":1730992034000,"platform":"apple","status":"Auto-Renewable"}}
+{"email":"","entitlements":[{"product":"Data Broker Protection","name":"subscriber"},{"product":"Identity Theft Restoration","name":"subscriber"},{"product":"Network Protection","name":"subscriber"}],"subscription":{"productId":"ios.subscription.1month","name":"Monthly Subscription","billingPeriod":"Monthly","startedAt":1730991734000,"expiresOrRenewsAt":1730992034000,"platform":"apple","status":"Auto-Renewable", "activeOffers": [] }}
 """
             let httpResponse = HTTPURLResponse(url: request.apiRequest.urlRequest.url!,
                                                statusCode: HTTPStatusCode.ok.rawValue,

--- a/Sources/SubscriptionTestingUtilities/SubscriptionMockFactory.swift
+++ b/Sources/SubscriptionTestingUtilities/SubscriptionMockFactory.swift
@@ -30,7 +30,7 @@ public struct SubscriptionMockFactory {
                                                   platform: .apple,
                                                   status: .autoRenewable,
                                                   activeOffers: [])
-    public static let expiredSubscription = Subscription(productId: UUID().uuidString,
+    public static let expiredSubscription = PrivacyProSubscription(productId: UUID().uuidString,
                                                          name: "Subscription test #2",
                                                          billingPeriod: .monthly,
                                                          startedAt: Date().addingTimeInterval(TimeInterval.days(-31)),

--- a/Sources/SubscriptionTestingUtilities/SubscriptionMockFactory.swift
+++ b/Sources/SubscriptionTestingUtilities/SubscriptionMockFactory.swift
@@ -28,14 +28,16 @@ public struct SubscriptionMockFactory {
                                                   startedAt: Date(),
                                                   expiresOrRenewsAt: Date().addingTimeInterval(TimeInterval.days(+30)),
                                                   platform: .apple,
-                                                  status: .autoRenewable)
-    public static let expiredSubscription = PrivacyProSubscription(productId: UUID().uuidString,
+                                                  status: .autoRenewable,
+                                                  activeOffers: [])
+    public static let expiredSubscription = Subscription(productId: UUID().uuidString,
                                                          name: "Subscription test #2",
                                                          billingPeriod: .monthly,
                                                          startedAt: Date().addingTimeInterval(TimeInterval.days(-31)),
                                                          expiresOrRenewsAt: Date().addingTimeInterval(TimeInterval.days(-1)),
                                                          platform: .apple,
-                                                         status: .expired)
+                                                         status: .expired,
+                                                         activeOffers: [])
 
     public static let expiredStripeSubscription = PrivacyProSubscription(productId: UUID().uuidString,
                                                          name: "Subscription test #2",
@@ -43,7 +45,8 @@ public struct SubscriptionMockFactory {
                                                          startedAt: Date().addingTimeInterval(TimeInterval.days(-31)),
                                                          expiresOrRenewsAt: Date().addingTimeInterval(TimeInterval.days(-1)),
                                                          platform: .stripe,
-                                                         status: .expired)
+                                                         status: .expired,
+                                                               activeOffers: [])
 
     public static let productsItems: [GetProductsItem] = [GetProductsItem(productId: appleSubscription.productId,
                                                                           productLabel: appleSubscription.name,

--- a/Sources/SubscriptionTestingUtilities/SubscriptionMockFactory.swift
+++ b/Sources/SubscriptionTestingUtilities/SubscriptionMockFactory.swift
@@ -46,7 +46,7 @@ public struct SubscriptionMockFactory {
                                                          expiresOrRenewsAt: Date().addingTimeInterval(TimeInterval.days(-1)),
                                                          platform: .stripe,
                                                          status: .expired,
-                                                               activeOffers: [])
+                                                         activeOffers: [])
 
     public static let productsItems: [GetProductsItem] = [GetProductsItem(productId: appleSubscription.productId,
                                                                           productLabel: appleSubscription.name,

--- a/Tests/RemoteMessagingTests/Mappers/DefaultRemoteMessagingSurveyURLBuilderTests.swift
+++ b/Tests/RemoteMessagingTests/Mappers/DefaultRemoteMessagingSurveyURLBuilderTests.swift
@@ -89,13 +89,14 @@ class DefaultRemoteMessagingSurveyURLBuilderTests: XCTestCase {
             daysSinceLastActive: vpnDaysSinceLastActive
         )
 
-        let subscription = PrivacyProSubscription(productId: "product-id",
-                                                  name: "product-name",
-                                                  billingPeriod: .monthly,
-                                                  startedAt: Date(timeIntervalSince1970: 1000),
-                                                  expiresOrRenewsAt: Date(timeIntervalSince1970: 2000),
-                                                  platform: .apple,
-                                                  status: .autoRenewable)
+        let subscription = DDGSubscription(productId: "product-id",
+                                           name: "product-name",
+                                           billingPeriod: .monthly,
+                                           startedAt: Date(timeIntervalSince1970: 1000),
+                                           expiresOrRenewsAt: Date(timeIntervalSince1970: 2000),
+                                           platform: .apple,
+                                           status: .autoRenewable,
+                                           activeOffers: [])
 
         return DefaultRemoteMessagingSurveyURLBuilder(
             statisticsStore: mockStatisticsStore,

--- a/Tests/RemoteMessagingTests/Mappers/DefaultRemoteMessagingSurveyURLBuilderTests.swift
+++ b/Tests/RemoteMessagingTests/Mappers/DefaultRemoteMessagingSurveyURLBuilderTests.swift
@@ -89,7 +89,7 @@ class DefaultRemoteMessagingSurveyURLBuilderTests: XCTestCase {
             daysSinceLastActive: vpnDaysSinceLastActive
         )
 
-        let subscription = DDGSubscription(productId: "product-id",
+        let subscription = PrivacyProSubscription(productId: "product-id",
                                            name: "product-name",
                                            billingPeriod: .monthly,
                                            startedAt: Date(timeIntervalSince1970: 1000),

--- a/Tests/SubscriptionTests/API/Models/SubscriptionTests.swift
+++ b/Tests/SubscriptionTests/API/Models/SubscriptionTests.swift
@@ -204,6 +204,66 @@ final class SubscriptionTests: XCTestCase {
         let subscriptionWithUnknownOffers = try decoder.decode(PrivacyProSubscription.self, from: Data(rawSubscriptionWithUnknownOffers.utf8))
         XCTAssertEqual(subscriptionWithUnknownOffers.activeOffers, [PrivacyProSubscription.Offer(type: .unknown)])
     }
+
+    func testHasActiveTrialOffer_WithTrialOffer_ReturnsTrue() {
+        // Given
+        let subscription = PrivacyProSubscription.make(
+            withStatus: .autoRenewable,
+            activeOffers: [PrivacyProSubscription.Offer(type: .trial)]
+        )
+
+        // When
+        let hasActiveTrialOffer = subscription.hasActiveTrialOffer
+
+        // Then
+        XCTAssertTrue(hasActiveTrialOffer)
+    }
+
+    func testHasActiveTrialOffer_WithNoOffers_ReturnsFalse() {
+        // Given
+        let subscription = PrivacyProSubscription.make(
+            withStatus: .autoRenewable,
+            activeOffers: []
+        )
+
+        // When
+        let hasActiveTrialOffer = subscription.hasActiveTrialOffer
+
+        // Then
+        XCTAssertFalse(hasActiveTrialOffer)
+    }
+
+    func testHasActiveTrialOffer_WithNonTrialOffer_ReturnsFalse() {
+        // Given
+        let subscription = PrivacyProSubscription.make(
+            withStatus: .autoRenewable,
+            activeOffers: [PrivacyProSubscription.Offer(type: .unknown)]
+        )
+
+        // When
+        let hasActiveTrialOffer = subscription.hasActiveTrialOffer
+
+        // Then
+        XCTAssertFalse(hasActiveTrialOffer)
+    }
+
+    func testHasActiveTrialOffer_WithMultipleOffersIncludingTrial_ReturnsTrue() {
+        // Given
+        let subscription = PrivacyProSubscription.make(
+            withStatus: .autoRenewable,
+            activeOffers: [
+                PrivacyProSubscription.Offer(type: .unknown),
+                PrivacyProSubscription.Offer(type: .trial),
+                PrivacyProSubscription.Offer(type: .unknown)
+            ]
+        )
+
+        // When
+        let hasActiveTrialOffer = subscription.hasActiveTrialOffer
+
+        // Then
+        XCTAssertTrue(hasActiveTrialOffer)
+    }
 }
 
 extension PrivacyProSubscription {

--- a/Tests/SubscriptionTests/API/Models/SubscriptionTests.swift
+++ b/Tests/SubscriptionTests/API/Models/SubscriptionTests.swift
@@ -30,7 +30,7 @@ final class SubscriptionTests: XCTestCase {
                                 expiresOrRenewsAt: Date(timeIntervalSince1970: 2000),
                                 platform: .apple,
                                 status: .autoRenewable,
-                                activeOffers: [.trial])
+                                       activeOffers: [PrivacyProSubscription.Offer(type: .trial)])
         let b = PrivacyProSubscription(productId: "1",
                                 name: "a",
                                 billingPeriod: .monthly,
@@ -38,7 +38,7 @@ final class SubscriptionTests: XCTestCase {
                                 expiresOrRenewsAt: Date(timeIntervalSince1970: 2000),
                                 platform: .apple,
                                 status: .autoRenewable,
-                                activeOffers: [.trial])
+                                activeOffers: [PrivacyProSubscription.Offer(type: .trial)])
         let c = PrivacyProSubscription(productId: "2",
                                 name: "a",
                                 billingPeriod: .monthly,
@@ -161,7 +161,7 @@ final class SubscriptionTests: XCTestCase {
             \"expiresOrRenewsAt\": 1723375183000,
             \"platform\": \"stripe\",
             \"status\": \"Auto-Renewable\",
-            \"activeOffers\": [\"Trial\"]
+            \"activeOffers\": [{ \"type\": \"Trial\"}]
         }
         """
 
@@ -187,7 +187,7 @@ final class SubscriptionTests: XCTestCase {
             \"expiresOrRenewsAt\": 1723375183000,
             \"platform\": \"stripe\",
             \"status\": \"Auto-Renewable\",
-            \"activeOffers\": [\"SpecialOffer\"]
+            \"activeOffers\": [{ \"type\": \"SpecialOffer\"}]
         }
         """
 
@@ -196,19 +196,19 @@ final class SubscriptionTests: XCTestCase {
         decoder.dateDecodingStrategy = .millisecondsSince1970
 
         let subscriptionWithOffers = try decoder.decode(PrivacyProSubscription.self, from: Data(rawSubscriptionWithOffers.utf8))
-        XCTAssertEqual(subscriptionWithOffers.activeOffers, [.trial])
+        XCTAssertEqual(subscriptionWithOffers.activeOffers, [PrivacyProSubscription.Offer(type: .trial)])
 
         let subscriptionWithoutOffers = try decoder.decode(PrivacyProSubscription.self, from: Data(rawSubscriptionWithoutOffers.utf8))
         XCTAssertEqual(subscriptionWithoutOffers.activeOffers, [])
 
         let subscriptionWithUnknownOffers = try decoder.decode(PrivacyProSubscription.self, from: Data(rawSubscriptionWithUnknownOffers.utf8))
-        XCTAssertEqual(subscriptionWithUnknownOffers.activeOffers, [.unknown])
+        XCTAssertEqual(subscriptionWithUnknownOffers.activeOffers, [PrivacyProSubscription.Offer(type: .unknown)])
     }
 }
 
 extension PrivacyProSubscription {
 
-    static func make(withStatus status: PrivacyProSubscription.Status, activeOffers: [PrivacyProSubscription.OfferType] = []) -> PrivacyProSubscription {
+    static func make(withStatus status: PrivacyProSubscription.Status, activeOffers: [PrivacyProSubscription.Offer] = []) -> PrivacyProSubscription {
         PrivacyProSubscription(productId: UUID().uuidString,
                      name: "Subscription test #1",
                      billingPeriod: .monthly,

--- a/Tests/SubscriptionTests/API/Models/SubscriptionTests.swift
+++ b/Tests/SubscriptionTests/API/Models/SubscriptionTests.swift
@@ -30,7 +30,7 @@ final class SubscriptionTests: XCTestCase {
                                 expiresOrRenewsAt: Date(timeIntervalSince1970: 2000),
                                 platform: .apple,
                                 status: .autoRenewable,
-                                       activeOffers: [PrivacyProSubscription.Offer(type: .trial)])
+                                activeOffers: [PrivacyProSubscription.Offer(type: .trial)])
         let b = PrivacyProSubscription(productId: "1",
                                 name: "a",
                                 billingPeriod: .monthly,

--- a/Tests/SubscriptionTests/API/Models/SubscriptionTests.swift
+++ b/Tests/SubscriptionTests/API/Models/SubscriptionTests.swift
@@ -23,7 +23,7 @@ import SubscriptionTestingUtilities
 final class SubscriptionTests: XCTestCase {
 
     func testEquality() throws {
-        let a = DDGSubscription(productId: "1",
+        let a = PrivacyProSubscription(productId: "1",
                                 name: "a",
                                 billingPeriod: .monthly,
                                 startedAt: Date(timeIntervalSince1970: 1000),
@@ -31,7 +31,7 @@ final class SubscriptionTests: XCTestCase {
                                 platform: .apple,
                                 status: .autoRenewable,
                                 activeOffers: [.trial])
-        let b = DDGSubscription(productId: "1",
+        let b = PrivacyProSubscription(productId: "1",
                                 name: "a",
                                 billingPeriod: .monthly,
                                 startedAt: Date(timeIntervalSince1970: 1000),
@@ -39,7 +39,7 @@ final class SubscriptionTests: XCTestCase {
                                 platform: .apple,
                                 status: .autoRenewable,
                                 activeOffers: [.trial])
-        let c = DDGSubscription(productId: "2",
+        let c = PrivacyProSubscription(productId: "2",
                                 name: "a",
                                 billingPeriod: .monthly,
                                 startedAt: Date(timeIntervalSince1970: 1000),
@@ -144,11 +144,11 @@ final class SubscriptionTests: XCTestCase {
     }
 
     func testOfferTypeDecoding() throws {
-        let trial = try JSONDecoder().decode(Subscription.OfferType.self, from: Data("\"Trial\"".utf8))
-        XCTAssertEqual(trial, Subscription.OfferType.trial)
+        let trial = try JSONDecoder().decode(PrivacyProSubscription.OfferType.self, from: Data("\"Trial\"".utf8))
+        XCTAssertEqual(trial, PrivacyProSubscription.OfferType.trial)
 
-        let unknown = try JSONDecoder().decode(Subscription.OfferType.self, from: Data("\"something unexpected\"".utf8))
-        XCTAssertEqual(unknown, Subscription.OfferType.unknown)
+        let unknown = try JSONDecoder().decode(PrivacyProSubscription.OfferType.self, from: Data("\"something unexpected\"".utf8))
+        XCTAssertEqual(unknown, PrivacyProSubscription.OfferType.unknown)
     }
 
     func testDecodingWithActiveOffers() throws {
@@ -195,21 +195,21 @@ final class SubscriptionTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         decoder.dateDecodingStrategy = .millisecondsSince1970
 
-        let subscriptionWithOffers = try decoder.decode(Subscription.self, from: Data(rawSubscriptionWithOffers.utf8))
+        let subscriptionWithOffers = try decoder.decode(PrivacyProSubscription.self, from: Data(rawSubscriptionWithOffers.utf8))
         XCTAssertEqual(subscriptionWithOffers.activeOffers, [.trial])
 
-        let subscriptionWithoutOffers = try decoder.decode(Subscription.self, from: Data(rawSubscriptionWithoutOffers.utf8))
+        let subscriptionWithoutOffers = try decoder.decode(PrivacyProSubscription.self, from: Data(rawSubscriptionWithoutOffers.utf8))
         XCTAssertEqual(subscriptionWithoutOffers.activeOffers, [])
 
-        let subscriptionWithUnknownOffers = try decoder.decode(Subscription.self, from: Data(rawSubscriptionWithUnknownOffers.utf8))
+        let subscriptionWithUnknownOffers = try decoder.decode(PrivacyProSubscription.self, from: Data(rawSubscriptionWithUnknownOffers.utf8))
         XCTAssertEqual(subscriptionWithUnknownOffers.activeOffers, [.unknown])
     }
 }
 
 extension PrivacyProSubscription {
 
-    static func make(withStatus status: Subscription.Status, activeOffers: [Subscription.OfferType] = []) -> Subscription {
-        Subscription(productId: UUID().uuidString,
+    static func make(withStatus status: PrivacyProSubscription.Status, activeOffers: [PrivacyProSubscription.OfferType] = []) -> PrivacyProSubscription {
+        PrivacyProSubscription(productId: UUID().uuidString,
                      name: "Subscription test #1",
                      billingPeriod: .monthly,
                      startedAt: Date(),

--- a/Tests/SubscriptionTests/API/SubscriptionEndpointServiceTests.swift
+++ b/Tests/SubscriptionTests/API/SubscriptionEndpointServiceTests.swift
@@ -86,7 +86,8 @@ final class SubscriptionEndpointServiceTests: XCTestCase {
             "startedAt": \(Constants.subscription.startedAt.timeIntervalSince1970*1000),
             "expiresOrRenewsAt": \(Constants.subscription.expiresOrRenewsAt.timeIntervalSince1970*1000),
             "platform": "\(Constants.subscription.platform.rawValue)",
-            "status": "\(Constants.subscription.status.rawValue)"
+            "status": "\(Constants.subscription.status.rawValue)",
+            "activeOffers": [] 
         }
         """.data(using: .utf8)!
 
@@ -323,7 +324,8 @@ final class SubscriptionEndpointServiceTests: XCTestCase {
                 "startedAt": \(Constants.subscription.startedAt.timeIntervalSince1970*1000),
                 "expiresOrRenewsAt": \(Constants.subscription.expiresOrRenewsAt.timeIntervalSince1970*1000),
                 "platform": "\(Constants.subscription.platform.rawValue)",
-                "status": "\(Constants.subscription.status.rawValue)"
+                "status": "\(Constants.subscription.status.rawValue)",
+                "activeOffers": [] 
             }
         }
         """.data(using: .utf8)!

--- a/Tests/SubscriptionTests/API/SubscriptionEndpointServiceTests.swift
+++ b/Tests/SubscriptionTests/API/SubscriptionEndpointServiceTests.swift
@@ -87,7 +87,7 @@ final class SubscriptionEndpointServiceTests: XCTestCase {
             "expiresOrRenewsAt": \(Constants.subscription.expiresOrRenewsAt.timeIntervalSince1970*1000),
             "platform": "\(Constants.subscription.platform.rawValue)",
             "status": "\(Constants.subscription.status.rawValue)",
-            "activeOffers": [] 
+            "activeOffers": []
         }
         """.data(using: .utf8)!
 
@@ -325,7 +325,7 @@ final class SubscriptionEndpointServiceTests: XCTestCase {
                 "expiresOrRenewsAt": \(Constants.subscription.expiresOrRenewsAt.timeIntervalSince1970*1000),
                 "platform": "\(Constants.subscription.platform.rawValue)",
                 "status": "\(Constants.subscription.status.rawValue)",
-                "activeOffers": [] 
+                "activeOffers": []
             }
         }
         """.data(using: .utf8)!

--- a/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
+++ b/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
@@ -62,7 +62,8 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
             startedAt: date,
             expiresOrRenewsAt: date.addingTimeInterval(30 * 24 * 60 * 60),
             platform: .apple,
-            status: .autoRenewable
+            status: .autoRenewable,
+            activeOffers: []
         )
         return try! encoder.encode(subscription)
     }
@@ -88,7 +89,8 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
             startedAt: date,
             expiresOrRenewsAt: date.addingTimeInterval(30 * 24 * 60 * 60),
             platform: .google,
-            status: .autoRenewable
+            status: .autoRenewable,
+            activeOffers: []
         )
         endpointService.updateCache(with: cachedSubscription)
 
@@ -196,7 +198,8 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
                 startedAt: date,
                 expiresOrRenewsAt: date.addingTimeInterval(30 * 24 * 60 * 60),
                 platform: .stripe,
-                status: .gracePeriod
+                status: .gracePeriod,
+                activeOffers: []
             )
         )
         let confirmData = try encoder.encode(confirmResponse)
@@ -221,7 +224,8 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
             startedAt: date,
             expiresOrRenewsAt: date.addingTimeInterval(30 * 24 * 60 * 60),
             platform: .google,
-            status: .autoRenewable
+            status: .autoRenewable,
+            activeOffers: []
         )
         endpointService.updateCache(with: subscription)
 
@@ -238,7 +242,8 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
             startedAt: date,
             expiresOrRenewsAt: date.addingTimeInterval(30 * 24 * 60 * 60),
             platform: .apple,
-            status: .autoRenewable
+            status: .autoRenewable,
+            activeOffers: []
         )
         endpointService.updateCache(with: subscription)
 

--- a/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
+++ b/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
@@ -82,7 +82,8 @@ class SubscriptionManagerV2Tests: XCTestCase {
             startedAt: Date(),
             expiresOrRenewsAt: Date().addingTimeInterval(30 * 24 * 60 * 60), // 30 days from now
             platform: .stripe,
-            status: .autoRenewable
+            status: .autoRenewable,
+            activeOffers: []
         )
         mockSubscriptionEndpointService.getSubscriptionResult = .success(activeSubscription)
         mockOAuthClient.getTokensResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
@@ -100,7 +101,8 @@ class SubscriptionManagerV2Tests: XCTestCase {
             startedAt: Date().addingTimeInterval(-30 * 24 * 60 * 60), // 30 days ago
             expiresOrRenewsAt: Date().addingTimeInterval(-1), // expired
             platform: .apple,
-            status: .expired
+            status: .expired,
+            activeOffers: []
         )
         mockSubscriptionEndpointService.getSubscriptionResult = .success(expiredSubscription)
 


### PR DESCRIPTION
Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/1206488453854252/1209235370800483
iOS PR: https://github.com/duckduckgo/iOS/pull/3936
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3838
What kind of version bump will this require?: Patch

**Description**: To support Free Trials in the iOS app, adding `Offer` Model and `activeOffers` Property. 

**Steps to test this PR**:
1. See client PRs

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
