### PR TITLE
Fix toggle report not showing after user decides to send a report

### DIFF
--- a/Sources/PrivacyDashboard/ToggleReportingFlow.swift
+++ b/Sources/PrivacyDashboard/ToggleReportingFlow.swift
@@ -49,6 +49,11 @@ final class ToggleReportingFlow {
 
     let entryPoint: EntryPoint
 
+    // We need to know if the user chose to send a report. On macOS browser, the "Thank You" prompt is shown afterward.
+    // If the user dismisses that prompt, handleDismissal is triggered,
+    // but calling recordDismissal within it would be incorrect at that stage.
+    private var didSendReport = false
+
     init(entryPoint: EntryPoint,
          toggleReportingManager: ToggleReportingManaging,
          controller: PrivacyDashboardController?) {
@@ -74,7 +79,9 @@ final class ToggleReportingFlow {
     }
 
     private func handleDismissal(isUserAction: Bool = false) {
-        toggleReportingManager.recordDismissal(date: Date())
+        if !didSendReport {
+            toggleReportingManager.recordDismissal(date: Date())
+        }
         switch entryPoint {
         case .appMenuProtectionsOff(let completionHandler):
             completionHandler(false)
@@ -89,6 +96,7 @@ final class ToggleReportingFlow {
     private func handleSendReport() {
         privacyDashboardController?.didRequestSubmitToggleReport(with: entryPoint.source)
         toggleReportingManager.recordPrompt(date: Date())
+        didSendReport = true
         switch entryPoint {
         case .appMenuProtectionsOff(let completionHandler):
             completionHandler(true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1209117117981111
iOS PR: TBD
macOS PR: TBD
What kind of version bump will this require?: Patch

**Description**:
On macOS we were incorrectly recording user's choice to send a breakage report as dismissal.

**Steps to test this PR**:
1. Open any webpage
2. Tap on a protection shield and toggle off protections
3. You should see the prompt asking you to send a report, do so!
4. On macOS only, you should see thank you note! Dismiss it by tapping on it or anywhere else.
5. Open privacy dashboard again and switch protection ON.
6. Open privacy dashboard again and switch protection OFF.
7. You should see the prompt asking you to send a report. Dismiss it now.
8. Repeat steps 5 and 6.
9. You shouldn't see the prompt anymore, because you dismissed once.