### PR TITLE
Use E-TLD+1 when matching domain for login saves

### DIFF
--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
@@ -211,7 +211,7 @@ class SecureVaultManagerTests: XCTestCase {
             }
         }
 
-        self.manager = SecureVaultManager(vault: self.testVault, includePartialAccountMatches: true, tld: TLD())
+        self.manager = SecureVaultManager(vault: self.testVault, tld: TLD())
         self.secureVaultManagerDelegate = SecureVaultDelegate()
         self.manager.delegate = self.secureVaultManagerDelegate
 
@@ -256,7 +256,7 @@ class SecureVaultManagerTests: XCTestCase {
             }
         }
 
-        self.manager = SecureVaultManager(vault: self.testVault, includePartialAccountMatches: true, tld: TLD())
+        self.manager = SecureVaultManager(vault: self.testVault, tld: TLD())
         self.secureVaultManagerDelegate = SecureVaultDelegate()
         self.manager.delegate = self.secureVaultManagerDelegate
 
@@ -286,13 +286,8 @@ class SecureVaultManagerTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
-    func testWhenRequestingAutofillInitDataWithDomainAndPort_withPartialMatches_ThenDataIsReturned() throws {
-        self.manager = SecureVaultManager(vault: self.testVault, includePartialAccountMatches: true, tld: TLD())
-        try assertWhenRequestingAutofillInitDataWithDomainAndPort_ThenDataIsReturned()
-    }
-
-    func testWhenRequestingAutofillInitDataWithDomainAndPort_withoutPartialMatches_ThenDataIsReturned() throws {
-        self.manager = SecureVaultManager(vault: self.testVault, includePartialAccountMatches: false, tld: TLD())
+    func testWhenRequestingAutofillInitDataWithDomainAndPort_ThenDataIsReturned() throws {
+        self.manager = SecureVaultManager(vault: self.testVault, tld: TLD())
         try assertWhenRequestingAutofillInitDataWithDomainAndPort_ThenDataIsReturned()
     }
 
@@ -347,7 +342,7 @@ class SecureVaultManagerTests: XCTestCase {
             }
         }
 
-        self.manager = SecureVaultManager(vault: self.testVault, includePartialAccountMatches: true, tld: TLD())
+        self.manager = SecureVaultManager(vault: self.testVault, tld: TLD())
         self.secureVaultManagerDelegate = SecureVaultDelegate()
         self.manager.delegate = self.secureVaultManagerDelegate
 

--- a/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
+++ b/Tests/BrowserServicesKitTests/SecureVault/SecureVaultManagerTests.swift
@@ -55,6 +55,10 @@ class SecureVaultManagerTests: XCTestCase {
     private var testVault: (any AutofillSecureVault)!
     private var secureVaultManagerDelegate: MockSecureVaultManagerDelegate!
     private var manager: SecureVaultManager!
+    static let tld = TLD()
+    var tld: TLD {
+        Self.tld
+    }
 
     override func setUp() {
         super.setUp()
@@ -66,7 +70,7 @@ class SecureVaultManagerTests: XCTestCase {
 
         self.testVault = DefaultAutofillSecureVault(providers: providers)
         self.secureVaultManagerDelegate = MockSecureVaultManagerDelegate()
-        self.manager = SecureVaultManager(vault: self.testVault, shouldAllowPartialFormSaves: true)
+        self.manager = SecureVaultManager(vault: self.testVault, shouldAllowPartialFormSaves: true, tld: tld)
         self.manager.delegate = secureVaultManagerDelegate
     }
 
@@ -211,7 +215,7 @@ class SecureVaultManagerTests: XCTestCase {
             }
         }
 
-        self.manager = SecureVaultManager(vault: self.testVault, tld: TLD())
+        self.manager = SecureVaultManager(vault: self.testVault, tld: tld)
         self.secureVaultManagerDelegate = SecureVaultDelegate()
         self.manager.delegate = self.secureVaultManagerDelegate
 
@@ -256,7 +260,7 @@ class SecureVaultManagerTests: XCTestCase {
             }
         }
 
-        self.manager = SecureVaultManager(vault: self.testVault, tld: TLD())
+        self.manager = SecureVaultManager(vault: self.testVault, tld: tld)
         self.secureVaultManagerDelegate = SecureVaultDelegate()
         self.manager.delegate = self.secureVaultManagerDelegate
 
@@ -287,7 +291,7 @@ class SecureVaultManagerTests: XCTestCase {
     }
 
     func testWhenRequestingAutofillInitDataWithDomainAndPort_ThenDataIsReturned() throws {
-        self.manager = SecureVaultManager(vault: self.testVault, tld: TLD())
+        self.manager = SecureVaultManager(vault: self.testVault, tld: tld)
         try assertWhenRequestingAutofillInitDataWithDomainAndPort_ThenDataIsReturned()
     }
 
@@ -342,7 +346,7 @@ class SecureVaultManagerTests: XCTestCase {
             }
         }
 
-        self.manager = SecureVaultManager(vault: self.testVault, tld: TLD())
+        self.manager = SecureVaultManager(vault: self.testVault, tld: tld)
         self.secureVaultManagerDelegate = SecureVaultDelegate()
         self.manager.delegate = self.secureVaultManagerDelegate
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
-->

Please review the release process for BrowserServicesKit [here](https://app.asana.com/0/1200194497630846/1200837094583426).

**Required**:

Task/Issue URL: https://app.asana.com/0/72649045549333/1209272524872735
iOS PR: https://github.com/duckduckgo/iOS/pull/3943
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3844
What kind of version bump will this require?: Major

**Description**:

Right now, we will offer to autofill into a page which is considered an E-TLD+1 match.
But we aren’t as good at comparing E-TLD+1 when it comes to considering whether to offer to save it or not.
We should detect we have a domain saved already and don’t offer to save when entering credentials for an equivalent subdomain
This should also apply to other scenarios like offering to update the saved password; we should also consider E-TLD+1 matches

**Steps to test this PR**:
https://app.asana.com/0/1203822806345703/1209279526650235

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
