### PR TITLE
Add .enable option for feature flag

### DIFF
--- a/Sources/BrowserServicesKit/FeatureFlagger/FeatureFlagger.swift
+++ b/Sources/BrowserServicesKit/FeatureFlagger/FeatureFlagger.swift
@@ -148,6 +148,9 @@ public enum FeatureFlagSource {
     /// Completely disabled in all configurations
     case disabled
 
+    /// Completely enabled in all configurations
+    case enabled
+
     /// Enabled for internal users only. Cannot be toggled remotely
     case internalOnly((any FeatureFlagCohortDescribing)? = nil)
 
@@ -333,6 +336,8 @@ public class DefaultFeatureFlagger: FeatureFlagger {
         switch featureFlag.source {
         case .disabled:
             return false
+        case .enabled:
+            return true
         case .internalOnly:
             return internalUserDecider.isInternalUser
         case .remoteDevelopment(let featureType):

--- a/Tests/BrowserServicesKitTests/FeatureFlagging/DefaultFeatureFlaggerTests.swift
+++ b/Tests/BrowserServicesKitTests/FeatureFlagging/DefaultFeatureFlaggerTests.swift
@@ -89,7 +89,7 @@ final class DefaultFeatureFlaggerTests: XCTestCase {
         XCTAssertFalse(featureFlagger.isFeatureOn(for: FeatureFlagSource.disabled))
     }
 
-    func testWhenEnabled_sourceDisabled_returnsTrue() {
+    func testWhenEnabled_sourceEnabled_returnsTrue() {
         let featureFlagger = createFeatureFlagger()
         XCTAssertTrue(featureFlagger.isFeatureOn(for: FeatureFlagSource.enabled))
     }

--- a/Tests/BrowserServicesKitTests/FeatureFlagging/DefaultFeatureFlaggerTests.swift
+++ b/Tests/BrowserServicesKitTests/FeatureFlagging/DefaultFeatureFlaggerTests.swift
@@ -89,7 +89,7 @@ final class DefaultFeatureFlaggerTests: XCTestCase {
         XCTAssertFalse(featureFlagger.isFeatureOn(for: FeatureFlagSource.disabled))
     }
 
-    func testWhenDisabled_sourceDisabled_returnsTrue() {
+    func testWhenEnabled_sourceDisabled_returnsTrue() {
         let featureFlagger = createFeatureFlagger()
         XCTAssertTrue(featureFlagger.isFeatureOn(for: FeatureFlagSource.enabled))
     }

--- a/Tests/BrowserServicesKitTests/FeatureFlagging/DefaultFeatureFlaggerTests.swift
+++ b/Tests/BrowserServicesKitTests/FeatureFlagging/DefaultFeatureFlaggerTests.swift
@@ -89,6 +89,11 @@ final class DefaultFeatureFlaggerTests: XCTestCase {
         XCTAssertFalse(featureFlagger.isFeatureOn(for: FeatureFlagSource.disabled))
     }
 
+    func testWhenDisabled_sourceDisabled_returnsTrue() {
+        let featureFlagger = createFeatureFlagger()
+        XCTAssertTrue(featureFlagger.isFeatureOn(for: FeatureFlagSource.enabled))
+    }
+
     func testWhenInternalOnly_returnsIsInternalUserValue() {
         let featureFlagger = createFeatureFlagger()
         internalUserDeciderStore.isInternalUser = false


### PR DESCRIPTION
**Required**:

Task/Issue URL:  https://app.asana.com/0/0/1209364252386095/f

iOS PR:  https://github.com/duckduckgo/iOS/pull/3952
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3854
What kind of version bump will this require?: Minor

**Optional**:

Tech Design URL:
CC:

**Description**:
Adds a new .enable option for Feature Flags which doesn’t require privacy config checks. 
Counterpart of “.disable"

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. No changes in any app, just adding functionality. If the CI is green it means it’s good since there’s a new test for it


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
