### PR TITLE
Support for Duck Player custom error settings in privacy config

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "874b27ad51d1784c934760c85493f78e609c4409",
-        "version" : "7.18.0"
+        "branch" : "pr-releases/pr-1421",
+        "revision" : "b65d1254976a711c5ef985e109b02a6a9f2ec774"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
         "branch" : "pr-releases/pr-1421",
-        "revision" : "371b1a444ac9ebcf553f708f9c759f1f5777fcdc"
+        "revision" : "493603682a81328186987796e67396e74e9679d4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
         "branch" : "pr-releases/pr-1421",
-        "revision" : "b65d1254976a711c5ef985e109b02a6a9f2ec774"
+        "revision" : "371b1a444ac9ebcf553f708f9c759f1f5777fcdc"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.4.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "7.18.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", branch: "pr-releases/pr-1421"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "8.4.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),

--- a/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -194,6 +194,7 @@ public enum DuckPlayerSubfeature: String, PrivacySubfeature {
     case pip
     case autoplay
     case openInNewTab
+    case customError
     case enableDuckPlayer // iOS DuckPlayer rollout feature
 }
 


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/0/1209151829557390
iOS PR: https://github.com/duckduckgo/iOS/pull/3970
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3872
What kind of version bump will this require?: Major/Minor/Patch

**Description**:

Adds Privacy Config support for the Duck Player custom error view 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Follow the steps here: https://app.asana.com/0/1142021229838617/1209392401656236


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] macOS 10.15
* [ ] macOS 11
* [ ] macOS 12

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
